### PR TITLE
Miscellaneous cleanup & docs work

### DIFF
--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -209,6 +209,18 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
         self.meta.field_names.iter()
     }
 
+
+    pub fn field<Q>(&'event self, key: Q) -> Option<&'event dyn Value>
+    where
+        &'event str: PartialEq<Q>,
+    {
+        self.field_names()
+            .position(|&field_name| field_name == key)
+            .and_then(|i| self.field_values
+                .get(i)
+                .map(|&val| val))
+    }
+
     pub fn fields(&'event self) -> impl Iterator<Item = (&'event str, &'event dyn Value)> {
         self.field_names()
             .enumerate()

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -238,8 +238,11 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
         DebugFields(self)
     }
 
-    /// Returns an iterator over all the [`Span`]s that are parents of this
-    /// `Event`.
+    /// Returns an iterator over [`SpanData`] references to all the [`Span`]s
+    /// that are parents of this `Event`.
+    ///
+    /// The iterator will traverse the trace tree in ascending order from this
+    ///  event's immediate parent to the root span of the trace.
     pub fn parents<'a>(&'a self) -> Parents<'a> {
         Parents {
             next: Some(&self.parent),

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -255,11 +255,13 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
     /// # #[macro_use]
     /// # extern crate tokio_trace;
     /// # use tokio_trace::Level;
+    /// # fn main() {
     /// span!("parent 1", foo = 1, bar = 1).enter(|| {
     ///     span!("parent 2", foo = 2, bar = 1).enter(|| {
     ///         event!(Level::Info, { bar = 2 }, "my event");
     ///     })
-    /// })
+    /// });
+    /// # }
     /// ```
     /// If a `Subscriber` were to call `all_fields` on this event, it will
     /// receive an iterator with the values `("foo", 2)` and `("bar", 2)`.

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -1,5 +1,6 @@
 use super::{DebugFields, Dispatcher, StaticMeta, Subscriber, Value};
 use std::{
+    borrow::Borrow,
     cell::RefCell,
     cmp, fmt,
     hash::{Hash, Hasher},
@@ -341,6 +342,18 @@ impl Data {
 
     pub fn opened_at(&self) -> Instant {
         self.inner.opened_at
+    }
+
+    pub fn field<Q>(&self, key: Q) -> Option<&dyn Value>
+    where
+        &'static str: PartialEq<Q>,
+    {
+        self.field_names()
+            .position(|&field_name| field_name == key)
+            .and_then(|i| self.inner
+                .field_values
+                .get(i)
+                .map(AsRef::as_ref))
     }
 
     pub fn fields<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a dyn Value)> {


### PR DESCRIPTION
This branch makes the following minor changes: 
+ Add `field` methods to `Event` and `SpanData` allowing optional 
  access to an individual field value by name 
+ Add `SpanData::parents` and `SpanData::all_fields` methods, by
  analogy to the methods of the same names on `Event`
+ Add RustDoc to `SpanData` and `Event` public API methods

Signed-off-by: Eliza Weisman <eliza@buoyant.io>