### PR TITLE
Implement span filtering

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -30,7 +30,7 @@ pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let meta: tokio_trace::Meta = record.into();
     let event = Event {
         timestamp: Instant::now(),
-        parent: tokio_trace::Span::current().into(),
+        parent: tokio_trace::SpanData::current(),
         follows_from: &[],
         meta: &meta,
         field_values: &[],

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -113,6 +113,10 @@ impl SloggishSubscriber {
 }
 
 impl tokio_trace::Subscriber for SloggishSubscriber {
+    fn enabled(&self, _metadata: &tokio_trace::Meta) -> bool {
+        true
+    }
+
     #[inline]
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event tokio_trace::Event<'event, 'meta>) {
         let mut stderr = self.stderr.lock();

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -89,19 +89,35 @@ use self::dedup::IteratorDedup;
 #[macro_export]
 macro_rules! static_meta {
     ($($k:ident),*) => (
-        static_meta!(@ None, $crate::Level::Trace, $($k),* )
+        static_meta!(@ None, None, $crate::Level::Trace, $($k),* )
     );
     (level: $lvl:expr, $($k:ident),*) => (
-        static_meta!(@ None, $lvl, $($k),* )
+        static_meta!(@ None, None, $lvl, $($k),* )
     );
     (target: $target:expr, level: $lvl:expr, $($k:ident),*) => (
-        static_meta!(@ Some($target), $lvl, $($k),* )
+        static_meta!(@ None, Some($target), $lvl, $($k),* )
     );
     (target: $target:expr, $($k:ident),*) => (
-        static_meta!(@ Some($target), $crate::Level::Trace, $($k),* )
+        static_meta!(@ None, Some($target), $crate::Level::Trace, $($k),* )
     );
-    (@ $target:expr, $lvl:expr, $($k:ident),*) => (
+    ($name:expr) => (
+        static_meta!(@ Some($name), None, $crate::Level::Trace, )
+    );
+    ($name:expr, $($k:ident),*) => (
+        static_meta!(@ Some($name), None, $crate::Level::Trace, $($k),* )
+    );
+    ($name:expr, level: $lvl:expr, $($k:ident),*) => (
+        static_meta!(@ Some($name),None, $lvl, $($k),* )
+    );
+    ($name:expr, target: $target:expr, level: $lvl:expr, $($k:ident),*) => (
+        static_meta!(@ Some($name), Some($target), $lvl, $($k),* )
+    );
+    ($name:expr, target: $target:expr, $($k:ident),*) => (
+        static_meta!(@ Some($name), Some($target), $crate::Level::Trace, $($k),* )
+    );
+    (@ $name:expr, $target:expr, $lvl:expr, $($k:ident),*) => (
         $crate::Meta {
+            name: $name,
             target: $target,
             level: $lvl,
             module_path: module_path!(),
@@ -142,31 +158,34 @@ macro_rules! static_meta {
 macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident = $val:expr),*) => {
-        $crate::Span::new(
-            Some($name),
-            ::std::time::Instant::now(),
-            Some($crate::Span::current()),
-            &static_meta!( $($k),* ),
-            vec![ $(Box::new($val)),* ], // todo: wish this wasn't double-boxed...
-        )
+        {
+            static META: $crate::Meta<'static> = static_meta!($name, $($k),* );
+            $crate::Span::new(
+                ::std::time::Instant::now(),
+                Some($crate::Span::current()),
+                &META,
+                vec![ $(Box::new($val)),* ], // todo: wish this wasn't double-boxed...
+            )
+        }
     }
 }
 
 #[macro_export]
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
-    {       let field_values: &[& dyn $crate::Value] = &[ $( & $val),* ];
-            use $crate::Subscriber;
-            $crate::Dispatcher::current().observe_event(&$crate::Event {
-                timestamp: ::std::time::Instant::now(),
-                parent: $crate::Span::current().into(),
-                follows_from: &[],
-                meta: &static_meta!(@ $target, $lvl, $($k),* ),
-                field_values: &field_values[..],
-                message: format_args!( $($arg)+ ),
-            });
-        }
-
+    {
+        static META: $crate::Meta<'static> = static_meta!(@ None, $target, $lvl, $($k),* );
+        let field_values: &[& dyn $crate::Value] = &[ $( & $val),* ];
+        use $crate::Subscriber;
+        $crate::Dispatcher::current().observe_event(&$crate::Event {
+            timestamp: ::std::time::Instant::now(),
+            parent: $crate::Span::current().into(),
+            follows_from: &[],
+            meta: &META,
+            field_values: &field_values[..],
+            message: format_args!( $($arg)+ ),
+        });
+    }
     });
     ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (event!(target: None, $lvl, { $($k = $val),* }, $($arg)+))
 }
@@ -212,6 +231,7 @@ pub struct Event<'event, 'meta> {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Meta<'a> {
+    pub name: Option<&'a str>,
     pub target: Option<&'a str>,
     pub level: log::Level,
 
@@ -339,6 +359,7 @@ impl<'a> Iterator for Parents<'a> {
 impl<'a, 'meta> From<&'a log::Record<'meta>> for Meta<'meta> {
     fn from(record: &'a log::Record<'meta>) -> Self {
         Meta {
+            name: None,
             target: Some(record.target()),
             level: record.level(),
             module_path: record

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -1,12 +1,12 @@
 //!
 //! # Core Concepts
 //!
-//! The core of `tokio-trace`'s API is composed of `Events`, `Spans`, and
-//! `Subscribers`. We'll cover these in turn.
+//! The core of `tokio-trace`'s API is composed of `Event`s, `Span`s, and
+//! `Subscriber`s. We'll cover these in turn.
 //!
-//! # Spans
+//! # `Span`s
 //!
-//! A `Span` represents a _period of time_ during which a program was executing
+//! A [`Span`] represents a _period of time_ during which a program was executing
 //! in some context. A thread of execution is said to _enter_ a span when it
 //! begins executing in that context and _exit_s the span when switching to
 //! another context. The span in which a thread is currently executing is
@@ -59,7 +59,7 @@
 //!
 //! # Events
 //!
-//! An `Event` represents a _point_ in time. It signifies something that
+//! An [`Event`] represents a _point_ in time. It signifies something that
 //! happened while the trace was executing. `Event`s are comparable to the log
 //! records emitted by unstructured logging code, but unlike a typical log line,
 //! an `Event` always occurs within the context of a `Span`. Like a `Span`, it
@@ -73,8 +73,44 @@
 //! may be recorded at a number of levels, and can have unstructured,
 //! human-readable messages; however, they also carry key-value data and exist
 //! within the context of the tree of spans that comprise a trase. Thus,
-//! individual log record-like events can be pinpointed not only in time, but in
-//! the logical execution flow of the system.
+//! individual log record-like events can be pinpointed not only in time, but
+//! in the logical execution flow of the system.
+//!
+//! # `Subscriber`s
+//!
+//! As `Span`s and `Event`s occur, they are recorded or aggregated by
+//! implementations of the [`Subscriber`] trait. `Subscriber`s are notified
+//! when an `Event` takes place and when a `Span` is entered or exited. These
+//! notifications are represented by the following `Subscriber` trait methods:
+//! + [`observe_event`], called when an `Event` takes place,
+//! + [`enter`], called when execution enters a `Span`,
+//! + [`exit`], called when execution exits a `Span`
+//!
+//! In addition, subscribers may implement the [`enabled`] function to _filter_
+//! the notifications they receive based on [metadata] describing each `Span`
+//! or `Event`. If a call to `Subscriber::enabled` returns `false` for a given
+//! set of metadata, that `Subscriber` will *not* be notified about the
+//! corresponding `Span` or `Event`. For performance reasons, if no currently
+//! active subscribers express  interest in a given set of metadata by returning
+//! `true`, then the corresponding `Span` or `Event` will never be constructed.
+//!
+//! `Event`s and `Span`s are broadcast to `Subscriber`s by the [`Dispatcher`], a
+//! special `Subscriber` implementation which broadcasts the notifications it
+//! receives to a list of attached `Subscriber`s. The [`Dispatcher::builder`]
+//! function returns a builder that can be used to attach `Subscriber`s to a
+//! `Dispatcher` and initialize it.
+//!
+//! [`Span`]: span/struct.Span
+//! [`Event`]: struct.Event.html
+//! [`Subscriber`]: subscriber/trait.Subscriber.html
+//! [`observe_event`]: subscriber/trait.Subscriber.html#tymethod.observe_event
+//! [`enter`]: subscriber/trait.Subscriber.html#tymethod.enter
+//! [`exit`]: subscriber/trait.Subscriber.html#tymethod.exit
+//! [`enabled`]: subscriber/trait.Subscriber.html#tymethod.enabled
+//! [metadata]: struct.Meta.html
+//! [`Dispatcher`]: struct.Dispatcher.html
+//! [`Dispatcher::builder`]: struct.Dispatcher.html#method.builder
+
 extern crate futures;
 extern crate log;
 #[macro_use]

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -164,12 +164,11 @@ macro_rules! span {
             if Dispatcher::current().enabled(&META) {
                 span::Span::new(
                     ::std::time::Instant::now(),
-                    Some(span::ActiveInner::current()),
                     &META,
                     vec![ $(Box::new($val)),* ], // todo: wish this wasn't double-boxed...
                 )
             } else {
-                span::Span::disabled()
+                span::Span::new_disabled()
             }
         }
     }

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -11,6 +11,8 @@ pub trait Subscriber {
 
     /// Note that this function is generic over a pair of lifetimes because the
     /// `Event` type is. See the documentation for [`Event`] for details.
+    ///
+    /// [`Event`]: ../struct.Event.html
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
     fn enter(&self, span: &SpanData, at: Instant);
     fn exit(&self, span: &SpanData, at: Instant);
@@ -52,7 +54,7 @@ pub trait Subscriber {
     /// # }
     /// ```
     ///
-    /// [`enabled`]: #fn.enabled
+    /// [`enabled`]: #tymethod.enabled
     fn with_filter<F>(self, filter: F) -> WithFilter<Self, F>
     where
         F: Fn(&Meta) -> bool,


### PR DESCRIPTION
Fixes #14, #15.

Since span creation is relatively expensive (it causes multiple
allocations, for the span itself and for any associated values), spans
which no subscribers will record should never be created. 

This branch implements this feature by adding an `enabled` method to the
`Subscriber` trait, similar to the method of the same name on the `log`
crate's `Log` trait. This method is called to determine whether a
`Subscriber` is interested in a particular span or event, based on its
metadata. If no `Subscriber`s return true, the span or event is never
constructed. Metadata construction is significantly less expensive than
`Span` construction (especially since for `Span`s, it can always be
constructed statically), so the filtering is based on metadata only. To
allow spans to be filtered by name (as span names are also always
`'static`), the name field was moved to the `Meta` type as well.

In addition, a `with_filter` method was added to `Subscriber`, to allow
composing subscribers from external crates with a user-defined filtering
predicate.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>