### PR TITLE
Remove implicit root span

### DIFF
--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 [dependencies]
 futures = "0.1"
 log = "0.4"
-lazy_static = "1"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -113,8 +113,6 @@
 
 extern crate futures;
 extern crate log;
-#[macro_use]
-extern crate lazy_static;
 pub use log::Level;
 
 use std::{fmt, slice, time::Instant};
@@ -264,7 +262,7 @@ impl<T> Value for T where T: fmt::Debug + Send + Sync {}
 pub struct Event<'event, 'meta> {
     pub timestamp: Instant,
 
-    pub parent: SpanData,
+    pub parent: Option<SpanData>,
     pub follows_from: &'event [SpanData],
 
     pub meta: &'meta Meta<'meta>,
@@ -336,7 +334,7 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
     /// event's immediate parent to the root span of the trace.
     pub fn parents<'a>(&'a self) -> Parents<'a> {
         Parents {
-            next: Some(&self.parent),
+            next: self.parent.as_ref(),
         }
     }
 


### PR DESCRIPTION
Fixes #10. Also required for #20.

Currently, any span created at the top level is implicitly a child of
the "root span" that is created when the program starts and lasts for
its entire lifespan. Removing the implicit root span would allow
subscribers to more easily distinguish between "separate" traces, such
as per-request traces in a server application. 

See also:
+ https://github.com/hawkw/tokio-trace-prototype/issues/4#issuecomment-424165691  
+ https://github.com/hawkw/tokio-trace-prototype/issues/4#issuecomment-424167537

Also, the implicit root span is an artifact of prior implementation 
constraints and it is no longer required.

This branch removes the implicit root span. It also removes the
dependency on the `lazy_static` crate.

Note that this also changes the `event.parent` field to an
`Option<SpanData>` rather than just a `SpanData`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>