### PR TITLE
Move `log` compatibility code to its own crate

### DIFF
--- a/tokio-trace-log/Cargo.toml
+++ b/tokio-trace-log/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 [dependencies]
 tokio-trace = { path = "../tokio-trace" }
 log = "0.4"
+
+[dev-dependencies]
+env_logger = "0.5"

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -54,7 +54,7 @@ impl<'a> AsLog for Meta<'a> {
     type Log = log::Metadata<'a>;
     fn as_log(&self) -> Self::Log {
         log::Metadata::builder()
-            .level(&self.level.as_trace())
+            .level(self.level.as_log())
             .target(self.target.unwrap_or(""))
             .build()
     }
@@ -74,6 +74,32 @@ impl<'a> AsTrace for log::Record<'a> {
             line: self.line().unwrap_or(0),
             file: self.file().unwrap_or("???"),
             field_names: &[],
+        }
+    }
+}
+
+impl AsLog for tokio_trace::Level {
+    type Log = log::Level;
+    fn as_log(&self) -> log::Level {
+        match self {
+            tokio_trace::Level::Error => log::Level::Error,
+            tokio_trace::Level::Warn => log::Level::Warn,
+            tokio_trace::Level::Info => log::Level::Info,
+            tokio_trace::Level::Debug => log::Level::Debug,
+            tokio_trace::Level::Trace => log::Level::Trace,
+        }
+    }
+}
+
+impl AsTrace for log::Level {
+    type Trace = tokio_trace::Level;
+    fn as_trace(&self) -> tokio_trace::Level {
+        match self {
+            log::Level::Error => tokio_trace::Level::Error,
+            log::Level::Warn => tokio_trace::Level::Warn,
+            log::Level::Info => tokio_trace::Level::Info,
+            log::Level::Debug => tokio_trace::Level::Debug,
+            log::Level::Trace => tokio_trace::Level::Trace,
         }
     }
 }

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
 futures = "0.1"
-log = "0.4"
 
 [dev-dependencies]
 ansi_term = "0.11"

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -8,6 +8,7 @@ futures = "0.1"
 log = "0.4"
 
 [dev-dependencies]
-env_logger = "0.5"
 ansi_term = "0.11"
 humantime = "1.1.1"
+env_logger = "0.5"
+tokio-trace-log = { path = "../tokio-trace-log" }

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -1,12 +1,13 @@
 #[macro_use]
 extern crate tokio_trace;
+extern crate tokio_trace_log;
 extern crate env_logger;
 
 use tokio_trace::Level;
 
 fn main() {
     tokio_trace::Dispatcher::builder()
-        .add_subscriber(tokio_trace::subscriber::LogSubscriber::new())
+        .add_subscriber(tokio_trace_log::LogSubscriber::new())
         .init();
     env_logger::Builder::new().parse("info").init();
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -112,12 +112,35 @@
 //! [`Dispatcher::builder`]: struct.Dispatcher.html#method.builder
 
 extern crate futures;
-extern crate log;
-pub use log::Level;
 
 use std::{fmt, slice, time::Instant};
 
 use self::dedup::IteratorDedup;
+
+#[repr(usize)]
+#[derive(Copy, Eq, Debug, Hash)]
+pub enum Level {
+    /// The "error" level.
+    ///
+    /// Designates very serious errors.
+    Error = 1, // This way these line up with the discriminants for LevelFilter below
+    /// The "warn" level.
+    ///
+    /// Designates hazardous situations.
+    Warn,
+    /// The "info" level.
+    ///
+    /// Designates useful information.
+    Info,
+    /// The "debug" level.
+    ///
+    /// Designates lower priority information.
+    Debug,
+    /// The "trace" level.
+    ///
+    /// Designates very low priority, often extremely verbose, information.
+    Trace,
+}
 
 #[doc(hidden)]
 #[macro_export]
@@ -275,7 +298,7 @@ pub struct Event<'event, 'meta> {
 pub struct Meta<'a> {
     pub name: Option<&'a str>,
     pub target: Option<&'a str>,
-    pub level: log::Level,
+    pub level: Level,
 
     pub module_path: &'a str,
     pub file: &'a str,
@@ -395,5 +418,22 @@ impl<'a> Iterator for Parents<'a> {
         let next = self.next;
         self.next = self.next.and_then(SpanData::parent);
         next
+    }
+}
+
+
+// ===== impl Level =====
+
+impl Clone for Level {
+    #[inline]
+    fn clone(&self) -> Level {
+        *self
+    }
+}
+
+impl PartialEq for Level {
+    #[inline]
+    fn eq(&self, other: &Level) -> bool {
+        *self as usize == *other as usize
     }
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -397,20 +397,3 @@ impl<'a> Iterator for Parents<'a> {
         next
     }
 }
-
-impl<'a, 'meta> From<&'a log::Record<'meta>> for Meta<'meta> {
-    fn from(record: &'a log::Record<'meta>) -> Self {
-        Meta {
-            name: None,
-            target: Some(record.target()),
-            level: record.level(),
-            module_path: record
-                .module_path()
-                // TODO: make symmetric
-                .unwrap_or_else(|| record.target()),
-            line: record.line().unwrap_or(0),
-            file: record.file().unwrap_or("???"),
-            field_names: &[],
-        }
-    }
-}


### PR DESCRIPTION
This means that the core `tokio_trace` crate no longer has to depend on `log`; see #20.