### PR TITLE
Move futures compatibility code to a new `tokio-trace-futures` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "tokio-trace",
+    "tokio-trace-futures",
     "tokio-trace-tower",
     "tokio-trace-tower-http",
     "tokio-trace-log",

--- a/tokio-trace-env-logger/Cargo.toml
+++ b/tokio-trace-env-logger/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4"
 
 [dev-dependencies]
 tokio-trace = { path = "../tokio-trace" }
+tokio-trace-futures = { path = "../tokio-trace-futures" }
 hyper = "0.12"
 futures = "0.1"
 ansi_term = "0.11"

--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -2,6 +2,7 @@ extern crate futures;
 extern crate hyper;
 #[macro_use]
 extern crate tokio_trace;
+extern crate tokio_trace_futures;
 extern crate tokio_trace_env_logger;
 extern crate tokio;
 
@@ -17,10 +18,8 @@ use std::str;
 mod sloggish;
 use self::sloggish::SloggishSubscriber;
 
-use tokio_trace::{
-    Level,
-    instrument::{Instrument, Instrumented},
-};
+use tokio_trace::Level;
+use tokio_trace_futures::{Instrument, Instrumented};
 
 type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 

--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tokio-trace-futures"
+version = "0.0.1"
+authors = ["Eliza Weisman <eliza@buoyant.io>"]
+
+[dependencies]
+futures = "0.1"
+tokio-trace = { path = "../tokio-trace" }
+
+[dev-dependencies]
+tokio-trace = { path = "../tokio-trace", features = ["test-support"] }

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,4 +1,8 @@
-use super::Span;
+#![macro_use]
+extern crate tokio_trace;
+extern crate futures;
+
+use tokio_trace::Span;
 use futures::{Async, Future, Sink, Stream, Poll, StartSend};
 
 // TODO: seal?
@@ -92,7 +96,7 @@ impl<T: Sink> Sink for Instrumented<T> {
 #[cfg(test)]
 mod tests {
     use futures::{prelude::*, task, future, stream};
-    use ::{span, subscriber};
+    use tokio_trace::{span, subscriber};
     use super::*;
 
     #[test]
@@ -131,7 +135,7 @@ mod tests {
             )
             .run();
         MyFuture { polls: 0 }
-            .instrument(span!("foo",))
+            .instrument(span!("foo"))
             .wait().unwrap();
     }
 
@@ -166,7 +170,7 @@ mod tests {
                     .with_state(span::State::Idle)
             )
             .run();
-        let foo = span!("foo",);
+        let foo = span!("foo");
         MyFuture { polls: 0 }
             .instrument(foo.clone())
             .wait().unwrap();
@@ -204,7 +208,7 @@ mod tests {
             )
             .run();
         MyFuture { polls: 0 }
-            .instrument(span!("foo",))
+            .instrument(span!("foo"))
             .wait().unwrap_err();
     }
 
@@ -233,7 +237,7 @@ mod tests {
             )
             .run();
         stream::iter_ok::<_, ()>(&[1, 2, 3])
-            .instrument(span!("foo",))
+            .instrument(span!("foo"))
             .for_each(|_| { future::ok(()) })
             .wait().unwrap();
     }

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,4 +1,4 @@
-#![macro_use]
+#[macro_use]
 extern crate tokio_trace;
 extern crate futures;
 

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,4 +1,4 @@
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate tokio_trace;
 extern crate futures;
 

--- a/tokio-trace-log/Cargo.toml
+++ b/tokio-trace-log/Cargo.toml
@@ -6,6 +6,3 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 [dependencies]
 tokio-trace = { path = "../tokio-trace" }
 log = "0.4"
-
-[dev-dependencies]
-env_logger = "0.5"

--- a/tokio-trace-tower-http/Cargo.toml
+++ b/tokio-trace-tower-http/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
 tokio-trace = { path = "../tokio-trace" }
+tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = { git = "https://github.com/tower-rs/tower.git" }
 http = "0.1"
-
 
 [dev-dependencies]
 bytes = "0.4"

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -5,6 +5,7 @@ extern crate http;
 extern crate tokio;
 #[macro_use]
 extern crate tokio_trace;
+extern crate tokio_trace_futures;
 extern crate tokio_trace_tower_http;
 extern crate tower_h2;
 extern crate tower_service;
@@ -16,10 +17,8 @@ use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tower_h2::{Body, Server, RecvBody};
 use tower_service::{NewService, Service};
-use tokio_trace::{
-    Level,
-    instrument::Instrument,
-};
+use tokio_trace::Level;
+use tokio_trace_futures::Instrument;
 
 #[path = "../../tokio-trace/examples/sloggish/sloggish_subscriber.rs"]
 mod sloggish;

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -2,10 +2,11 @@ extern crate tower_service;
 extern crate http;
 #[macro_use]
 extern crate tokio_trace;
+extern crate tokio_trace_futures;
 extern crate futures;
 
 use futures::{Future, Poll};
-use tokio_trace::instrument::{Instrumented, Instrument};
+use tokio_trace_futures::{Instrumented, Instrument};
 use tower_service::{Service, NewService};
 
 #[derive(Clone, Debug)]

--- a/tokio-trace-tower/Cargo.toml
+++ b/tokio-trace-tower/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
 tokio-trace = { path = "../tokio-trace" }
+tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = { git = "https://github.com/tower-rs/tower.git" }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -1,9 +1,10 @@
 extern crate tower_service;
 #[macro_use]
 extern crate tokio_trace;
+extern crate tokio_trace_futures;
 extern crate futures;
 
-use tokio_trace::instrument::{Instrumented, Instrument};
+use tokio_trace_futures::{Instrumented, Instrument};
 use tower_service::Service;
 use std::fmt;
 

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -3,6 +3,10 @@ name = "tokio-trace"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
+[features]
+default = []
+test-support =  []
+
 [dependencies]
 futures = "0.1"
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -117,11 +117,8 @@ use std::{fmt, slice, time::Instant};
 
 use self::dedup::IteratorDedup;
 
-// TODO: remove this and let the span/event macros generate the
-// metadata directly. this macro causes weird issues when using the
-// test-support code from other crates...
-#[macro_export]
 #[doc(hidden)]
+#[macro_export]
 macro_rules! static_meta {
     ($($k:ident),*) => (
         static_meta!(@ None, None, $crate::Level::Trace, $($k),* )
@@ -193,21 +190,9 @@ macro_rules! static_meta {
 macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident = $val:expr),*) => {
-        span!(@ Some($name), None, $crate::Level::Trace, $($k = $val),*)
-    };
-    // TODO: add support for spans with levels and targets.
-    (@ $name:expr, $target:expr, $lvl:expr, $($k:ident = $val:expr),*) => {
         {
             use $crate::{span, Subscriber, Dispatcher, Meta};
-            static META: Meta<'static> = Meta {
-                name: $name,
-                target: $target,
-                level: $lvl,
-                module_path: module_path!(),
-                file: file!(),
-                line: line!(),
-                field_names: &[ $(stringify!($k)),* ],
-            };
+            static META: Meta<'static> = static_meta!($name, $($k),* );
             if Dispatcher::current().enabled(&META) {
                 span::Span::new(
                     ::std::time::Instant::now(),

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -542,9 +542,10 @@ impl cmp::PartialEq for DataInner {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::*;
-#[cfg(test)]
+
+#[cfg(any(test, feature = "test-support"))]
 mod test_support {
     use ::{ Value, span::State };
     use std::collections::HashMap;

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -98,9 +98,10 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::*;
-#[cfg(test)]
+
+#[cfg(any(test, feature = "test-support"))]
 mod test_support {
     use super::Subscriber;
     use ::{Event, SpanData, Meta};


### PR DESCRIPTION
Closes #20. Also needed for #23.

This PR moves the instrumented future types to their own separate crate.