### PR TITLE
Remove timestamps from spans and events

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -22,7 +22,7 @@
 extern crate tokio_trace;
 extern crate log;
 
-use std::{io, time::Instant};
+use std::io;
 use tokio_trace::{span, Subscriber, Event, SpanData, Meta};
 
 /// Format a log record as a trace event in the current span.
@@ -180,7 +180,7 @@ impl Subscriber for LogSubscriber {
         }
     }
 
-    fn enter(&self, span: &SpanData, _at: Instant) {
+    fn enter(&self, span: &SpanData) {
         let logger = log::logger();
         logger.log(&log::Record::builder()
             .args(format_args!("-> {:?}", span.name()))
@@ -188,7 +188,7 @@ impl Subscriber for LogSubscriber {
         )
     }
 
-    fn exit(&self, span: &SpanData, _at: Instant) {
+    fn exit(&self, span: &SpanData) {
         let logger = log::logger();
         logger.log(&log::Record::builder().args(format_args!("<- {:?}", span.name())).build())
     }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -29,7 +29,6 @@ use tokio_trace::{span, Subscriber, Event, SpanData, Meta};
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let meta: tokio_trace::Meta = record.as_trace();
     let event = Event {
-        timestamp: Instant::now(),
         parent: tokio_trace::SpanData::current(),
         follows_from: &[],
         meta: &meta,

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,9 +1,6 @@
 use {span, subscriber::Subscriber, Event, SpanData, Meta};
 
-use std::{
-    sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
-    time::Instant,
-};
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 static STATE: AtomicUsize = ATOMIC_USIZE_INIT;
 
@@ -82,16 +79,16 @@ impl Subscriber for Builder {
     }
 
     #[inline]
-    fn enter(&self, span: &SpanData, at: Instant) {
+    fn enter(&self, span: &SpanData) {
         for subscriber in &self.subscribers {
-            subscriber.enter(span, at)
+            subscriber.enter(span)
         }
     }
 
     #[inline]
-    fn exit(&self, span: &SpanData, at: Instant) {
+    fn exit(&self, span: &SpanData) {
         for subscriber in &self.subscribers {
-            subscriber.exit(span, at)
+            subscriber.exit(span)
         }
     }
 }
@@ -125,13 +122,13 @@ impl Subscriber for Dispatcher {
     }
 
     #[inline]
-    fn enter(&self, span: &SpanData, at: Instant) {
-        self.0.enter(span, at)
+    fn enter(&self, span: &SpanData) {
+        self.0.enter(span)
     }
 
     #[inline]
-    fn exit(&self, span: &SpanData, at: Instant) {
-        self.0.exit(span, at)
+    fn exit(&self, span: &SpanData) {
+        self.0.exit(span)
     }
 }
 
@@ -153,7 +150,7 @@ impl Subscriber for NoDispatcher {
         // Do nothing.
     }
 
-    fn enter(&self, _span: &SpanData, _at: Instant) {}
+    fn enter(&self, _span: &SpanData) {}
 
-    fn exit(&self, _span: &SpanData, _at: Instant) {}
+    fn exit(&self, _span: &SpanData) {}
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -113,7 +113,7 @@
 
 extern crate futures;
 
-use std::{fmt, slice, time::Instant};
+use std::{fmt, slice};
 
 use self::dedup::IteratorDedup;
 
@@ -219,7 +219,6 @@ macro_rules! event {
             if dispatcher.enabled(&META) {
                 let field_values: &[& dyn Value] = &[ $( & $val),* ];
                 dispatcher.observe_event(&Event {
-                    timestamp: ::std::time::Instant::now(),
                     parent: SpanData::current(),
                     follows_from: &[],
                     meta: &META,
@@ -284,8 +283,6 @@ impl<T> Value for T where T: fmt::Debug + Send + Sync {}
 /// macro). Consumers of `Event` probably do not need to actually care about
 /// these lifetimes, however.
 pub struct Event<'event, 'meta> {
-    pub timestamp: Instant,
-
     pub parent: Option<SpanData>,
     pub follows_from: &'event [SpanData],
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -8,7 +8,6 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    time::Instant,
 };
 
 thread_local! {
@@ -595,12 +594,11 @@ impl Active {
                 let result = CURRENT_SPAN.with(|current_span| {
                     self.inner.transition_on_enter(prior_state);
                     current_span.replace(Some(self.clone()));
-                    Dispatcher::current().enter(self.data(), Instant::now());
+                    Dispatcher::current().enter(self.data());
                     f()
                 });
 
                 CURRENT_SPAN.with(|current_span| {
-                    let timestamp = Instant::now();
                     current_span.replace(self.inner.enter_parent.as_ref().cloned());
                     // If we are the only remaining enter handle to this
                     // span, it can now transition to Done. Otherwise, it
@@ -613,7 +611,7 @@ impl Active {
                         State::Idle
                     };
                     self.inner.transition_on_exit(next_state);
-                    Dispatcher::current().exit(self.data(), timestamp);
+                    Dispatcher::current().exit(self.data());
                 });
                 result
             }


### PR DESCRIPTION
Fixes #24.
Requires #34.

Currently, spans and events both have `std::time::Instant` fields that
record a timestamp of when the span or event was created. Furthermore,
the `Subscriber::enter` and `Subscriber::exit` trait methods take an
`Instant` argument representing a timestamp of when the span was entered
or exited. As described in #24, this is a potential performance issue,
as `Instant::now` may result in an expensive syscall. Since some
subscriber implementations may not need timestamps, or may not need to
record them for _all_ possible events, we should not perform these
syscalls by default.

This branch removes the timestamps from spans and events, and from the
`Subscriber` API. If subscribers require timestamps for events or spans,
they can call `Instant::now` or `SystemTime::now`. This has the side
benefit of allowing subscriber implementations to choose what timestamp
type is appropriate for their use case. 

Since event and span entry/exit notifications are broadcast to
subscribers synchronously as they occur, if a subscriber records a
timestamp itself, it should still be sufficiently accurate.

This branch requires PR #34 to be merged first, so that span 
identifiers may be used for testing span equality, rather than the 
timestamps.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>