### PR TITLE
Turn `new_span_id` into `new_span`

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -155,7 +155,7 @@ impl Subscriber for LogSubscriber {
         log::logger().enabled(&metadata.as_log())
     }
 
-    fn new_span_id(&self, metadata: &Meta) -> span::Id {
+    fn new_span(&self, _new_span: &span::NewSpan) -> span::Id {
         span::Id::from_u64(0)
     }
 

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -119,7 +119,7 @@ impl tokio_trace::Subscriber for SloggishSubscriber {
         true
     }
 
-    fn new_span_id(&self, _: &tokio_trace::Meta) -> tokio_trace::span::Id {
+    fn new_span(&self, _: &tokio_trace::span::NewSpan) -> tokio_trace::span::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         tokio_trace::span::Id::from_u64(next)
     }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -195,12 +195,12 @@ macro_rules! span {
             static META: Meta<'static> = static_meta!($name, $($k),* );
             let dispatcher = Dispatcher::current();
             if dispatcher.enabled(&META) {
-                span::Span::new(
-                    dispatcher.new_span_id(&META),
-                    ::std::time::Instant::now(),
+                let new_span = span::NewSpan::new(
                     &META,
                     vec![ $(Box::new($val)),* ], // todo: wish this wasn't double-boxed...
-                )
+                );
+                let id = dispatcher.new_span(&new_span);
+                new_span.finish(id)
             } else {
                 span::Span::new_disabled()
             }


### PR DESCRIPTION
This branch changes the semantics of that function to be "notifying the
subscriber of the creation of a new span", rather than simply
"requesting a new ID".

This introduces some new guarantees to the `new_span` API (as discussed
in
https://github.com/hawkw/tokio-trace-prototype/commit/f7bc34651e980e0a08dd599b25737df7656c7a18#r30777026),
but I think they can reasonably addressed as part of future changes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>