### PR TITLE
Remove global dispatcher

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -35,7 +35,7 @@ pub fn format_trace(record: &log::Record) -> io::Result<()> {
         field_values: &[],
         message: record.args().clone()
     };
-    tokio_trace::Dispatcher::current().observe_event(&event);
+    tokio_trace::Dispatch::current().observe_event(&event);
     Ok(())
 }
 

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -6,16 +6,16 @@ extern crate env_logger;
 use tokio_trace::Level;
 
 fn main() {
-    tokio_trace::Dispatcher::builder()
-        .add_subscriber(tokio_trace_log::LogSubscriber::new())
-        .init();
     env_logger::Builder::new().parse("info").init();
+    let subscriber = tokio_trace_log::LogSubscriber::new();
 
-    let foo = 3;
-    event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
+    tokio_trace::Dispatch::to(subscriber).with(|| {
+        let foo = 3;
+        event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 
-    let span = span!("my_great_span", foo = 4, baz = 5);
-    span.enter(|| {
-        event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
+        let span = span!("my_great_span", foo = 4, baz = 5);
+        span.enter(|| {
+            event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
+        });
     });
 }

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -19,35 +19,35 @@ mod sloggish_subscriber;
 use self::sloggish_subscriber::SloggishSubscriber;
 
 fn main() {
-    tokio_trace::Dispatcher::builder()
-        .add_subscriber(SloggishSubscriber::new(2))
-        .init();
+    let subscriber = SloggishSubscriber::new(2);
 
-    span!("", version = 5.0).enter(|| {
-        span!("server", host = "localhost", port = 8080).enter(|| {
-            event!(Level::Info, {}, "starting");
-            event!(Level::Info, {}, "listening");
-            let peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381);
-            peer1.clone().enter(|| {
-                event!(Level::Debug, {}, "connected");
-                event!(Level::Debug, { length = 2 }, "message received");
-            });
-            let peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230);
-            peer2.clone().enter(|| {
-                event!(Level::Debug, {}, "connected");
-            });
-            peer1.enter(|| {
-                event!(Level::Warn, { algo = "xor" }, "weak encryption requested");
-                event!(Level::Debug, { length = 8 }, "response sent");
-                event!(Level::Debug, {}, "disconnected");
-            });
-            peer2.enter(|| {
-                event!(Level::Debug, { length = 5 }, "message received");
-                event!(Level::Debug, { length = 8 }, "response sent");
-                event!(Level::Debug, {}, "disconnected");
-            });
-            event!(Level::Error, {}, "internal error");
-            event!(Level::Info, {}, "exit");
-        })
+    tokio_trace::Dispatch::to(subscriber).with(|| {
+        span!("", version = 5.0).enter(|| {
+            span!("server", host = "localhost", port = 8080).enter(|| {
+                event!(Level::Info, {}, "starting");
+                event!(Level::Info, {}, "listening");
+                let peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381);
+                peer1.clone().enter(|| {
+                    event!(Level::Debug, {}, "connected");
+                    event!(Level::Debug, { length = 2 }, "message received");
+                });
+                let peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230);
+                peer2.clone().enter(|| {
+                    event!(Level::Debug, {}, "connected");
+                });
+                peer1.enter(|| {
+                    event!(Level::Warn, { algo = "xor" }, "weak encryption requested");
+                    event!(Level::Debug, { length = 8 }, "response sent");
+                    event!(Level::Debug, {}, "disconnected");
+                });
+                peer2.enter(|| {
+                    event!(Level::Debug, { length = 5 }, "message received");
+                    event!(Level::Debug, { length = 8 }, "response sent");
+                    event!(Level::Debug, {}, "disconnected");
+                });
+                event!(Level::Error, {}, "internal error");
+                event!(Level::Info, {}, "exit");
+            })
+        });
     });
 }

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -32,7 +32,7 @@ impl Dispatch {
         Dispatch(Arc::new(subscriber))
     }
 
-    pub fn with<T>(&self, f: impl Fn() -> T) -> T {
+    pub fn with<T>(&self, f: impl FnOnce() -> T) -> T {
         let (prior, result) = CURRENT_DISPATCH.with(|current| {
             let prior = current.replace(self.clone());
             (prior, (f)())

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -77,12 +77,9 @@ impl Subscriber for Dispatch {
     }
 }
 
-struct NoDispatcher;
+struct NoSubscriber;
 
-#[derive(Debug)]
-pub struct InitError;
-
-impl Subscriber for NoDispatcher {
+impl Subscriber for NoSubscriber {
     fn enabled(&self, _metadata: &Meta) -> bool {
         false
     }

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -2,110 +2,41 @@ use {span, subscriber::Subscriber, Event, SpanData, Meta};
 
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
-static STATE: AtomicUsize = ATOMIC_USIZE_INIT;
-
-// There are three different states that we care about: the logger's
-// uninitialized, the logger's initializing (set_logger's been called but
-// LOGGER hasn't actually been set yet), or the logger's active.
-const UNINITIALIZED: usize = 0;
-const INITIALIZING: usize = 1;
-const INITIALIZED: usize = 2;
-static mut DISPATCHER: &'static Subscriber = &NoDispatcher;
-
-#[derive(Default)]
-pub struct Builder {
-    subscribers: Vec<Box<dyn Subscriber>>,
+thread_local! {
+    static CURRENT_DISPATCH: RefCell<Dispatch> = RefCell::new(Dispatch::none());
 }
 
-impl Builder {
-    pub fn new() -> Self {
-        Self::default()
+#[derive(Clone)]
+pub struct Dispatch(Arc<dyn Subscriber>);
+
+impl Dispatch {
+    pub fn none() -> Self {
+        Dispatch(Arc::new(NoSubscriber))
     }
 
-    pub fn add_subscriber<T: Subscriber + 'static>(mut self, subscriber: T) -> Self {
-        self.subscribers.push(Box::new(subscriber));
-        self
+    pub fn current() -> Dispatch {
+        CURRENT_DISPATCH.with(|current| {
+            current.borrow().clone()
+        })
     }
 
-    pub fn try_init(self) -> Result<(), InitError> {
-        unsafe {
-            match STATE.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) {
-                UNINITIALIZED => {
-                    DISPATCHER = &*Box::into_raw(Box::new(self));
-                    STATE.store(INITIALIZED, Ordering::SeqCst);
-                    Ok(())
-                }
-                INITIALIZING => {
-                    while STATE.load(Ordering::SeqCst) == INITIALIZING {}
-                    Err(InitError)
-                }
-                _ => Err(InitError),
-            }
-        }
+    pub fn to<S: Subscriber + 'static>(subscriber: S) -> Self {
+        Dispatch(Arc::new(subscriber))
     }
 
-    pub fn init(self) {
-        self.try_init().unwrap()
+    pub fn with<T>(&self, f: impl Fn() -> T) -> T {
+        let (prior, result) = CURRENT_DISPATCH.with(|current| {
+            let prior = current.replace(self.clone());
+            (prior, (f)())
+        });
+        CURRENT_DISPATCH.with(move |current| {
+            *current.borrow_mut() = prior;
+        });
+        result
     }
 }
 
-impl Subscriber for Builder {
-    fn enabled(&self, metadata: &Meta) -> bool {
-        self.subscribers.iter()
-            .any(|subscriber| subscriber.enabled(metadata))
-    }
-
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
-        for subscriber in &self.subscribers {
-            subscriber.observe_event(event)
-        }
-    }
-
-    fn new_span(&self, new_span: &span::NewSpan) -> span::Id {
-        // TODO: this shouldn't let the first attached subscriber always be in
-        // control of the span ID, but the dispatcher type is going away soon
-        // anyway, so for now, it just needs to compile.
-        let id = self.subscribers.get(0)
-            .map(|subscriber| subscriber.new_span(&new_span))
-            .unwrap_or_else(|| span::Id::from_u64(0));
-        // Show the new span to all the attached subscribers anyway, so they can
-        // register its creation.
-        // TODO: this means their IDs will silently be ignored. Figure out a
-        // better way to handle this!
-        for subscriber in &self.subscribers[1..] {
-            subscriber.new_span(&new_span);
-        }
-        id
-    }
-
-    #[inline]
-    fn enter(&self, span: &SpanData) {
-        for subscriber in &self.subscribers {
-            subscriber.enter(span)
-        }
-    }
-
-    #[inline]
-    fn exit(&self, span: &SpanData) {
-        for subscriber in &self.subscribers {
-            subscriber.exit(span)
-        }
-    }
-}
-
-pub struct Dispatcher(&'static Subscriber);
-
-impl Dispatcher {
-    pub fn current() -> Dispatcher {
-        Dispatcher(unsafe { DISPATCHER })
-    }
-
-    pub fn builder() -> Builder {
-        Builder::new()
-    }
-}
-
-impl Subscriber for Dispatcher {
+impl Subscriber for Dispatch {
     #[inline]
     fn enabled(&self, metadata: &Meta) -> bool {
         self.0.enabled(metadata)

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -237,12 +237,10 @@ macro_rules! span {
             static META: Meta<'static> = static_meta!($name, $($k),* );
             let dispatcher = Dispatch::current();
             if cached_filter!(&META, dispatcher) {
-                let new_span = span::NewSpan::new(
+                span::NewSpan::new(
                     &META,
                     vec![ $(Box::new($val)),* ], // todo: wish this wasn't double-boxed...
-                );
-                let id = dispatcher.new_span(&new_span);
-                new_span.finish(id)
+                ).finish(dispatcher)
             } else {
                 span::Span::new_disabled()
             }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -233,9 +233,9 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident = $val:expr),*) => {
         {
-            use $crate::{span, Subscriber, Dispatcher, Meta};
+            use $crate::{span, Subscriber, Dispatch, Meta};
             static META: Meta<'static> = static_meta!($name, $($k),* );
-            let dispatcher = Dispatcher::current();
+            let dispatcher = Dispatch::current();
             if cached_filter!(&META, dispatcher) {
                 let new_span = span::NewSpan::new(
                     &META,
@@ -255,9 +255,9 @@ macro_rules! event {
 
     (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{Subscriber, Dispatcher, Meta, SpanData, Event, Value};
+            use $crate::{Subscriber, Dispatch, Meta, SpanData, Event, Value};
             static META: Meta<'static> = static_meta!(@ None, $target, $lvl, $($k),* );
-            let dispatcher = Dispatcher::current();
+            let dispatcher = Dispatch::current();
             if cached_filter!(&META, dispatcher) {
                 let field_values: &[& dyn Value] = &[ $( & $val),* ];
                 dispatcher.observe_event(&Event {
@@ -304,7 +304,7 @@ pub mod span;
 pub mod subscriber;
 
 pub use self::{
-    dispatcher::{Builder as DispatcherBuilder, Dispatcher},
+    dispatcher::Dispatch,
     span::{Data as SpanData, Span},
     subscriber::Subscriber,
 };

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -419,7 +419,7 @@ impl fmt::Debug for Data {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Span")
             .field("name", &self.name())
-            .field("parent", &self.parent().unwrap_or(self).name())
+            .field("parent", &self.parent())
             .field("fields", &self.debug_fields())
             .field("meta", &self.meta())
             .finish()


### PR DESCRIPTION
Fixes #30. Fixes #29.

Currently, the `tokio_trace` crate provides a global dispatcher through
which all trace events are set. This was based primarily on the design
of the `log` crate. 

As described in #30, this is not an ideal design. Instead, there should
be no global subscriber state. The Tokio runtime will handle setting up
the subscriber at the root of the task. When operating outside of a
Tokio runtime, the user will be responsible for setting up the necessary
subscriber. There should be a way to get a handle to the current
subscriber and probably easy ways to get into new execution while
carrying over the subscriber.

This branch removes the global dispatcher, and replaces it with an
explicit contextual dispatcher. In doing so, it also removes the fanout
functionality from the dispatcher. We will be able to implement fanout
subscribers in other crates, using the new API.

Also, this branch changes span enter and exit behavior, so that when a
span is entered or exited, that event is broadcast to the subscriber
_that provided that span with its ID_, rather than to the _current_
subscriber. The need for this change was described in
https://github.com/hawkw/tokio-trace-prototype/pull/37#commitcomment-30777184

Signed-off-by: Eliza Weisman <eliza@buoyant.io>