### PR TITLE
Introduce a `tokio-trace-subscriber` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "tokio-trace-tower-http",
     "tokio-trace-log",
     "tokio-trace-env-logger",
-    "tokio-trace-slog"
+    "tokio-trace-slog",
+    "tokio-trace-subscriber"
 ]

--- a/tokio-trace-log/Cargo.toml
+++ b/tokio-trace-log/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "tokio-trace-log"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
 tokio-trace = { path = "../tokio-trace" }
+tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }
 log = "0.4"

--- a/tokio-trace-subscriber/Cargo.toml
+++ b/tokio-trace-subscriber/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
 tokio-trace = { path = "../tokio-trace" }
+
+[dev-dependencies]
+tokio-trace-log = { path = "../tokio-trace-log" }

--- a/tokio-trace-subscriber/Cargo.toml
+++ b/tokio-trace-subscriber/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-trace-subscriber"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
-edition = "2018"
 
 [dependencies]
+tokio-trace = { path = "../tokio-trace" }

--- a/tokio-trace-subscriber/Cargo.toml
+++ b/tokio-trace-subscriber/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tokio-trace-subscriber"
+version = "0.1.0"
+authors = ["Eliza Weisman <eliza@buoyant.io>"]
+edition = "2018"
+
+[dependencies]

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use super::{Observe, RegisterSpan, Filter};
+use ::{filter::NoFilter, observe::NoObserver, Observe, RegisterSpan, Filter};
 use tokio_trace::{span, Subscriber, Meta, Event, SpanData};
 
 #[derive(Debug, Clone)]
@@ -8,19 +8,19 @@ pub struct Composed<F, O, R> {
     registry: R,
 }
 
-impl Composed<(), (), ()> {
+impl Composed<NoFilter, NoObserver, ()> {
     /// Returns a new instance of `Composed` which can be built using the
     /// [`with_filter`], [`with_observer`], and [`with_registry`] methods.
     pub fn builder() -> Self {
         Composed {
-            filter: (),
-            observer: (),
+            filter: NoFilter,
+            observer: NoObserver,
             registry: (),
         }
     }
 }
 
-impl<O, R> Composed<(), O, R> {
+impl<O, R> Composed<NoFilter, O, R> {
     /// Sets the [filter] to be used by the composed `Subscriber`.
     ///
     /// [filter]: ../trait.Filter.html
@@ -37,7 +37,7 @@ impl<O, R> Composed<(), O, R> {
 }
 
 
-impl<F, R> Composed<F, (), R> {
+impl<F, R> Composed<F, NoObserver, R> {
     /// Sets the [observer] to be used by the composed `Subscriber`.
     ///
     /// [observer]: ../trait.Observe.html

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -92,15 +92,15 @@ where
     R: RegisterSpan,
 {
     fn enabled(&self, metadata: &Meta) -> bool {
-        self.filter.enabled(metadata)
+        self.filter.enabled(metadata) && self.observer.enabled(metadata)
+    }
+
+    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+        self.filter.should_invalidate_filter(metadata) || self.observer.should_invalidate_filter(metadata)
     }
 
     fn new_span(&self, new_span: &span::NewSpan) -> span::Id {
         self.registry.new_span(new_span)
-    }
-
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
-        self.filter.should_invalidate_filter(metadata)
     }
 
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use super::{Notify, RegisterSpan, Filter};
+use super::{Observe, RegisterSpan, Filter};
 use tokio_trace::{span, Subscriber, Meta, Event, SpanData};
 
 #[derive(Debug, Clone)]
@@ -24,13 +24,14 @@ impl<O, R> Composed<(), O, R> {
     /// Sets the [filter] to be used by the composed `Subscriber`.
     ///
     /// [filter]: ../trait.Filter.html
-    pub fn with_filter<F>(filter: F) -> Composed<F, O, R>
+    pub fn with_filter<F>(self, filter: F) -> Composed<F, O, R>
     where
         F: Filter,
     {
         Composed {
             filter,
-            ..self
+            observer: self.observer,
+            registry: self.registry,
         }
     }
 }
@@ -40,13 +41,14 @@ impl<F, R> Composed<F, (), R> {
     /// Sets the [observer] to be used by the composed `Subscriber`.
     ///
     /// [observer]: ../trait.Observe.html
-    pub fn with_observer<O>(observer: O) -> Composed<F, O, R>
+    pub fn with_observer<O>(self, observer: O) -> Composed<F, O, R>
     where
         O: Observe,
     {
         Composed {
+            filter: self.filter,
             observer,
-            ..self
+            registry: self.registry,
         }
     }
 }
@@ -55,13 +57,14 @@ impl<F, O> Composed<F, O, ()> {
     /// Sets the [span registry] to be used by the composed `Subscriber`.
     ///
     /// [span registry]: ../trait.Register.html
-    pub fn with_registry<R>(registry: R) -> Composed<F, O, R>
+    pub fn with_registry<R>(self, registry: R) -> Composed<F, O, R>
     where
-        R: Registry,
+        R: RegisterSpan,
     {
         Composed {
+            filter: self.filter,
+            observer: self.observer,
             registry,
-            ..self
         }
     }
 }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,5 +1,5 @@
-use ::{filter::NoFilter, observe::NoObserver, Observe, RegisterSpan, Filter};
-use tokio_trace::{span, Subscriber, Meta, Event, SpanData};
+use tokio_trace::{span, Event, Meta, SpanData, Subscriber};
+use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
 pub struct Composed<F, O, R> {
@@ -35,7 +35,6 @@ impl<O, R> Composed<NoFilter, O, R> {
         }
     }
 }
-
 
 impl<F, R> Composed<F, NoObserver, R> {
     /// Sets the [observer] to be used by the composed `Subscriber`.
@@ -96,7 +95,8 @@ where
     }
 
     fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
-        self.filter.should_invalidate_filter(metadata) || self.observer.filter().should_invalidate_filter(metadata)
+        self.filter.should_invalidate_filter(metadata)
+            || self.observer.filter().should_invalidate_filter(metadata)
     }
 
     fn new_span(&self, new_span: &span::NewSpan) -> span::Id {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -92,11 +92,11 @@ where
     R: RegisterSpan,
 {
     fn enabled(&self, metadata: &Meta) -> bool {
-        self.filter.enabled(metadata) && self.observer.enabled(metadata)
+        self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
     fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
-        self.filter.should_invalidate_filter(metadata) || self.observer.should_invalidate_filter(metadata)
+        self.filter.should_invalidate_filter(metadata) || self.observer.filter().should_invalidate_filter(metadata)
     }
 
     fn new_span(&self, new_span: &span::NewSpan) -> span::Id {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,0 +1,114 @@
+use super::{Notify, RegisterSpan, Filter};
+use tokio_trace::{span, Subscriber, Meta, Event, SpanData};
+
+#[derive(Debug, Clone)]
+pub struct Composed<F, O, R> {
+    filter: F,
+    observer: O,
+    registry: R,
+}
+
+impl Composed<(), (), ()> {
+    /// Returns a new instance of `Composed` which can be built using the
+    /// [`with_filter`], [`with_observer`], and [`with_registry`] methods.
+    pub fn builder() -> Self {
+        Composed {
+            filter: (),
+            observer: (),
+            registry: (),
+        }
+    }
+}
+
+impl<O, R> Composed<(), O, R> {
+    /// Sets the [filter] to be used by the composed `Subscriber`.
+    ///
+    /// [filter]: ../trait.Filter.html
+    pub fn with_filter<F>(filter: F) -> Composed<F, O, R>
+    where
+        F: Filter,
+    {
+        Composed {
+            filter,
+            ..self
+        }
+    }
+}
+
+
+impl<F, R> Composed<F, (), R> {
+    /// Sets the [observer] to be used by the composed `Subscriber`.
+    ///
+    /// [observer]: ../trait.Observe.html
+    pub fn with_observer<O>(observer: O) -> Composed<F, O, R>
+    where
+        O: Observe,
+    {
+        Composed {
+            observer,
+            ..self
+        }
+    }
+}
+
+impl<F, O> Composed<F, O, ()> {
+    /// Sets the [span registry] to be used by the composed `Subscriber`.
+    ///
+    /// [span registry]: ../trait.Register.html
+    pub fn with_registry<R>(registry: R) -> Composed<F, O, R>
+    where
+        R: Registry,
+    {
+        Composed {
+            registry,
+            ..self
+        }
+    }
+}
+
+impl<F, O, R> Composed<F, O, R> {
+    /// Construct a new composed `Subscriber`, given a [filter], an
+    /// [observer], and a [span registry].
+    ///
+    /// [filter]: ../trait.Filter.html
+    /// [observer]: ../trait.Observe.html
+    /// [span registry]: ../trait.Register.html
+    pub fn new(filter: F, observer: O, registry: R) -> Self {
+        Composed {
+            filter,
+            observer,
+            registry,
+        }
+    }
+}
+
+impl<F, O, R> Subscriber for Composed<F, O, R>
+where
+    F: Filter,
+    O: Observe,
+    R: RegisterSpan,
+{
+    fn enabled(&self, metadata: &Meta) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    fn new_span(&self, new_span: &span::NewSpan) -> span::Id {
+        self.registry.new_span(new_span)
+    }
+
+    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+        self.filter.should_invalidate_filter(metadata)
+    }
+
+    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+        self.observer.observe_event(event)
+    }
+
+    fn enter(&self, span: &SpanData) {
+        self.observer.enter(span)
+    }
+
+    fn exit(&self, span: &SpanData) {
+        self.observer.exit(span)
+    }
+}

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -1,0 +1,82 @@
+use super::Filter;
+use tokio_trace::Meta;
+
+pub trait FilterExt: Filter {
+
+    /// Construct a new `Filter` that enables a span or event if both `self`
+    /// *AND* `other` consider it enabled.
+    fn and<B>(self, other: B) -> And<Self, B>
+    where
+        B: Filter + Sized,
+        Self: Sized
+    {
+        And {
+            a: self,
+            b: other,
+        }
+    }
+
+    /// Construct a new `Filter` that enables a span or event if either `self`
+    /// *OR* `other` consider it enabled.
+    fn or<B>(self, other: B) -> Or<Self, B>
+    where
+        B: Filter + Sized,
+        Self: Sized
+    {
+        Or {
+            a: self,
+            b: other,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct And<A, B> {
+    a: A,
+    b: B,
+}
+
+#[derive(Debug, Clone)]
+pub struct Or<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<A, B> Filter for And<A, B>
+where
+    A: Filter,
+    B: Filter,
+{
+    fn enabled(&self, metadata: &Meta) -> bool {
+        self.a.enabled(metadata) && self.b.enabled(metadata)
+    }
+
+    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+        // Even though this is the `And` composition, that only applies to the
+        // actual filter result, not whether or not the filter needs to be
+        // invalidated. If either of the composed filters requests its cached
+        // results be invalidated, we need to honor that.
+        self.a.should_invalidate_filter(metadata) ||
+        self.b.should_invalidate_filter(metadata)
+    }
+}
+
+impl<A, B> Filter for Or<A, B>
+where
+    A: Filter,
+    B: Filter,
+{
+    fn enabled(&self, metadata: &Meta) -> bool {
+        self.a.enabled(metadata) || self.b.enabled(metadata)
+    }
+
+    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+        self.a.should_invalidate_filter(metadata) ||
+        self.b.should_invalidate_filter(metadata)
+    }
+}
+
+impl<F> FilterExt for F
+where
+    F: Filter
+{ }

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -32,6 +32,9 @@ pub trait FilterExt: Filter {
 }
 
 #[derive(Debug, Clone)]
+pub struct NoFilter;
+
+#[derive(Debug, Clone)]
 pub struct And<A, B> {
     a: A,
     b: B,
@@ -97,7 +100,7 @@ impl Sample {
 }
 
 impl Filter for Sample {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, _metadata: &Meta) -> bool {
         // TODO: it would be nice to be able to have a definition of sampling
         // that also enables all the children of a sampled span...figure that out.
         let current = self.count.fetch_add(1, Ordering::Acquire);
@@ -109,10 +112,20 @@ impl Filter for Sample {
         }
     }
 
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
         // The filter _needs_ to be re-evaluated every time, or else the counter
         // won't be updated.
         true
+    }
+}
+
+impl Filter for NoFilter {
+    fn enabled(&self, _metadata: &Meta) -> bool {
+        true
+    }
+
+    fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
+        false
     }
 }
 

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -2,7 +2,7 @@ use tokio_trace::Meta;
 
 use std::{
     collections::HashSet,
-    sync::atomic::{Ordering, AtomicUsize},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 /// The filtering portion of the [`Subscriber`] trait.
@@ -94,12 +94,9 @@ pub trait FilterExt: Filter {
     fn and<B>(self, other: B) -> And<Self, B>
     where
         B: Filter + Sized,
-        Self: Sized
+        Self: Sized,
     {
-        And {
-            a: self,
-            b: other,
-        }
+        And { a: self, b: other }
     }
 
     /// Construct a new `Filter` that enables a span or event if either `self`
@@ -107,12 +104,9 @@ pub trait FilterExt: Filter {
     fn or<B>(self, other: B) -> Or<Self, B>
     where
         B: Filter + Sized,
-        Self: Sized
+        Self: Sized,
     {
-        Or {
-            a: self,
-            b: other,
-        }
+        Or { a: self, b: other }
     }
 }
 
@@ -160,9 +154,7 @@ where
     String: From<<I as IntoIterator>::Item>,
 {
     let modules = modules.into_iter().map(String::from).collect();
-    ModuleBlacklist {
-        modules,
-    }
+    ModuleBlacklist { modules }
 }
 
 /// Returns a filter that enables only spans and events originating from a
@@ -173,9 +165,7 @@ where
     String: From<<I as IntoIterator>::Item>,
 {
     let modules = modules.into_iter().map(String::from).collect();
-    ModuleWhitelist {
-        modules,
-    }
+    ModuleWhitelist { modules }
 }
 
 impl<F> Filter for F
@@ -207,8 +197,7 @@ where
         // actual filter result, not whether or not the filter needs to be
         // invalidated. If either of the composed filters requests its cached
         // results be invalidated, we need to honor that.
-        self.a.should_invalidate_filter(metadata) ||
-        self.b.should_invalidate_filter(metadata)
+        self.a.should_invalidate_filter(metadata) || self.b.should_invalidate_filter(metadata)
     }
 }
 
@@ -222,8 +211,7 @@ where
     }
 
     fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
-        self.a.should_invalidate_filter(metadata) ||
-        self.b.should_invalidate_filter(metadata)
+        self.a.should_invalidate_filter(metadata) || self.b.should_invalidate_filter(metadata)
     }
 }
 
@@ -259,7 +247,6 @@ impl Filter for Sample {
     }
 }
 
-
 impl Filter for NoFilter {
     fn enabled(&self, _metadata: &Meta) -> bool {
         true
@@ -290,7 +277,4 @@ impl Filter for ModuleWhitelist {
     }
 }
 
-impl<F> FilterExt for F
-where
-    F: Filter
-{ }
+impl<F> FilterExt for F where F: Filter {}

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -88,8 +88,9 @@ pub trait FilterExt: Filter {
     ///     foo();
     ///     my_module::foo();
     ///     my_module::bar();
-    /// })
-    /// #}
+    /// });
+    ///
+    /// # }
     /// ```
     fn and<B>(self, other: B) -> And<Self, B>
     where

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -4,7 +4,6 @@ use tokio_trace::Meta;
 use std::sync::atomic::{Ordering, AtomicUsize};
 
 pub trait FilterExt: Filter {
-
     /// Construct a new `Filter` that enables a span or event if both `self`
     /// *AND* `other` consider it enabled.
     fn and<B>(self, other: B) -> And<Self, B>

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -1,6 +1,8 @@
 use super::Filter;
 use tokio_trace::Meta;
 
+use std::sync::atomic::{Ordering, AtomicUsize};
+
 pub trait FilterExt: Filter {
 
     /// Construct a new `Filter` that enables a span or event if both `self`
@@ -42,6 +44,13 @@ pub struct Or<A, B> {
     b: B,
 }
 
+/// A filter that enables some fraction of events.
+#[derive(Debug)]
+pub struct Sample {
+    every: usize,
+    count: AtomicUsize,
+}
+
 impl<A, B> Filter for And<A, B>
 where
     A: Filter,
@@ -73,6 +82,38 @@ where
     fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
         self.a.should_invalidate_filter(metadata) ||
         self.b.should_invalidate_filter(metadata)
+    }
+}
+
+impl Sample {
+    /// Construct a new filter that is enabled for every `every` spans/events.
+    pub fn every(every: usize) -> Self {
+        Self {
+            every,
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    // TODO: constructors with ratios, percentages, etc?
+}
+
+impl Filter for Sample {
+    fn enabled(&self, metadata: &Meta) -> bool {
+        // TODO: it would be nice to be able to have a definition of sampling
+        // that also enables all the children of a sampled span...figure that out.
+        let current = self.count.fetch_add(1, Ordering::Acquire);
+        if current % self.every == 0 {
+            self.count.store(0, Ordering::Release);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+        // The filter _needs_ to be re-evaluated every time, or else the counter
+        // won't be updated.
+        true
     }
 }
 

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -17,8 +17,8 @@ pub use observe::ObserveExt;
 /// The notification processing portion of the [`Subscriber`] trait.
 ///
 /// Implementations of this trait describe the logic needed to process envent
-/// and span notifications, but don't implement filtering or span registration.
-pub trait Observe {
+/// and span notifications, but don't implement span registration.
+pub trait Observe: Filter {
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
     fn enter(&self, span: &SpanData);
     fn exit(&self, span: &SpanData);

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -18,10 +18,14 @@ pub use observe::ObserveExt;
 ///
 /// Implementations of this trait describe the logic needed to process envent
 /// and span notifications, but don't implement span registration.
-pub trait Observe: Filter {
+pub trait Observe {
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
     fn enter(&self, span: &SpanData);
     fn exit(&self, span: &SpanData);
+
+    fn filter(&self) -> &dyn Filter {
+        &filter::NoFilter
+    }
 }
 
 /// The filtering portion of the [`Subscriber`] trait.

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -1,10 +1,14 @@
 //! Utilities and helpers for implementing and composing subscribers.
+
 extern crate tokio_trace;
 
 use tokio_trace::{span, Event, Meta, SpanData};
 
 mod compose;
-pub use compose::Compose;
+pub use compose::Composed;
+
+pub mod filter;
+pub use filter::FilterExt;
 
 /// The notification processing portion of the [`Subscriber`] trait.
 ///

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -3,11 +3,13 @@ extern crate tokio_trace;
 
 use tokio_trace::{span, Event, Meta, SpanData};
 
+mod compose;
+
 /// The notification processing portion of the [`Subscriber`] trait.
 ///
 /// Implementations of this trait describe the logic needed to process envent
 /// and span notifications, but don't implement filtering or span registration.
-pub trait Notify {
+pub trait Observe {
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
     fn enter(&self, span: &SpanData);
     fn exit(&self, span: &SpanData);

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -8,9 +8,10 @@ mod compose;
 pub use compose::Composed;
 
 pub mod filter;
-pub use filter::FilterExt;
-
 pub mod observe;
+pub mod registry;
+
+pub use filter::FilterExt;
 pub use observe::ObserveExt;
 
 /// The notification processing portion of the [`Subscriber`] trait.
@@ -86,4 +87,13 @@ pub trait RegisterSpan {
     ///
     /// [span ID]: ../span/struct.Id.html
     fn new_span(&self, new_span: &span::NewSpan) -> span::Id;
+}
+
+impl<T> RegisterSpan for T
+where
+    T: Fn(&span::NewSpan) -> span::Id,
+{
+    fn new_span(&self, new_span: &span::NewSpan) -> span::Id {
+        self(new_span)
+    }
 }

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -10,6 +10,9 @@ pub use compose::Composed;
 pub mod filter;
 pub use filter::FilterExt;
 
+pub mod observe;
+pub use observe::ObserveExt;
+
 /// The notification processing portion of the [`Subscriber`] trait.
 ///
 /// Implementations of this trait describe the logic needed to process envent

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -101,3 +101,18 @@ where
         self(new_span)
     }
 }
+
+impl<F> Filter for F
+where
+    F: for<'a, 'b> Fn(&'a Meta<'b>) -> bool,
+{
+    fn enabled(&self, meta: &Meta) -> bool {
+        self(meta)
+    }
+
+    fn should_invalidate_filter(&self, _: &Meta) -> bool {
+        // Since this implementation is for immutable closures only, we can
+        // treat these functions as stateless and assume they remain valid.
+        false
+    }
+}

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -4,6 +4,7 @@ extern crate tokio_trace;
 use tokio_trace::{span, Event, Meta, SpanData};
 
 mod compose;
+pub use compose::Compose;
 
 /// The notification processing portion of the [`Subscriber`] trait.
 ///

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -1,0 +1,79 @@
+//! Utilities and helpers for implementing and composing subscribers.
+extern crate tokio_trace;
+
+use tokio_trace::{span, Event, Meta, SpanData};
+
+/// The notification processing portion of the [`Subscriber`] trait.
+///
+/// Implementations of this trait describe the logic needed to process envent
+/// and span notifications, but don't implement filtering or span registration.
+pub trait Notify {
+    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
+    fn enter(&self, span: &SpanData);
+    fn exit(&self, span: &SpanData);
+}
+
+/// The filtering portion of the [`Subscriber`] trait.
+///
+/// Implementations of this trait represent _just_ the logic necessary to filter
+/// events and spans, but none of the processing or registration logic.
+pub trait Filter {
+    /// Determines if a span or event with the specified metadata would be recorded.
+    ///
+    /// This is used by the dispatcher to avoid allocating for span construction
+    /// if the span would be discarded anyway.
+    fn enabled(&self, metadata: &Meta) -> bool;
+
+    /// Returns `true` if the cached result to a call to `enabled` for a span
+    /// with the given metadata is still valid.
+    ///
+    /// By default, this function assumes that cached filter results will remain
+    /// valid, but should be overridden when this is not the case.
+    ///
+    /// If this returns `false`, then the prior value may be used.
+    /// `Subscriber`s which require their filters to be run every time an event
+    /// occurs or a span is entered/exited should always return `true`.
+    ///
+    /// For example, suppose a sampling subscriber is implemented by incrementing a
+    /// counter every time `enabled` is called and only returning `true` when
+    /// the counter is divisible by a specified sampling rate. If that
+    /// subscriber returns `false` from `should_invalidate_filter`, then the
+    /// filter will not be re-evaluated once it has been applied to a given set
+    /// of metadata. Thus, the counter will not be incremented, and the span or
+    /// event that correspands to the metadata will never be `enabled`.
+    ///
+    /// Similarly, if a `Subscriber` has a filtering strategy that can be
+    /// changed dynamically at runtime, it would need to invalidate any cached
+    /// filter results when the filtering rules change.
+    ///
+    /// A subscriber which manages fanout to multiple other subscribers should
+    /// proxy this decision to all of its child subscribers, returning `false`
+    /// only if _all_ such children return `false`. If the set of subscribers to
+    /// which spans are broadcast may change dynamically, adding a new
+    /// subscriber should also invalidate cached filters.
+    fn should_invalidate_filter(&self, metadata: &Meta) -> bool;
+}
+
+/// The span registration portion of the [`Subscriber`] trait.
+///
+/// Implementations of this trait represent the logic run on span creation. They
+/// handle span ID generation.
+pub trait RegisterSpan {
+    /// Record the construction of a new [`Span`], returning a a new [span ID] for
+    /// the span being constructed.
+    ///
+    /// Span IDs are used to uniquely identify spans, so span equality will be
+    /// based on the returned ID. Thus, if the subscriber wishes for all spans
+    /// with the same metadata to be considered equal, it should return the same
+    /// ID every time it is given a particular set of metadata. Similarly, if it
+    /// wishes for two separate instances of a span with the same metadata to *not*
+    /// be equal, it should return a distinct ID every time this function is called,
+    /// regardless of the metadata.
+    ///
+    /// Subscribers which do not rely on the implementations of `PartialEq`,
+    /// `Eq`, and `Hash` for `Span`s are free to return span IDs with value 0
+    /// from all calls to this function, if they so choose.
+    ///
+    /// [span ID]: ../span/struct.Id.html
+    fn new_span(&self, new_span: &span::NewSpan) -> span::Id;
+}

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate tokio_trace;
 
-use tokio_trace::{span, Event, Meta, SpanData};
-
 mod compose;
 pub use compose::Composed;
 
@@ -11,108 +9,6 @@ pub mod filter;
 pub mod observe;
 pub mod registry;
 
-pub use filter::FilterExt;
-pub use observe::ObserveExt;
-
-/// The notification processing portion of the [`Subscriber`] trait.
-///
-/// Implementations of this trait describe the logic needed to process envent
-/// and span notifications, but don't implement span registration.
-pub trait Observe {
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
-    fn enter(&self, span: &SpanData);
-    fn exit(&self, span: &SpanData);
-
-    fn filter(&self) -> &dyn Filter {
-        &filter::NoFilter
-    }
-}
-
-/// The filtering portion of the [`Subscriber`] trait.
-///
-/// Implementations of this trait represent _just_ the logic necessary to filter
-/// events and spans, but none of the processing or registration logic.
-pub trait Filter {
-    /// Determines if a span or event with the specified metadata would be recorded.
-    ///
-    /// This is used by the dispatcher to avoid allocating for span construction
-    /// if the span would be discarded anyway.
-    fn enabled(&self, metadata: &Meta) -> bool;
-
-    /// Returns `true` if the cached result to a call to `enabled` for a span
-    /// with the given metadata is still valid.
-    ///
-    /// By default, this function assumes that cached filter results will remain
-    /// valid, but should be overridden when this is not the case.
-    ///
-    /// If this returns `false`, then the prior value may be used.
-    /// `Subscriber`s which require their filters to be run every time an event
-    /// occurs or a span is entered/exited should always return `true`.
-    ///
-    /// For example, suppose a sampling subscriber is implemented by incrementing a
-    /// counter every time `enabled` is called and only returning `true` when
-    /// the counter is divisible by a specified sampling rate. If that
-    /// subscriber returns `false` from `should_invalidate_filter`, then the
-    /// filter will not be re-evaluated once it has been applied to a given set
-    /// of metadata. Thus, the counter will not be incremented, and the span or
-    /// event that correspands to the metadata will never be `enabled`.
-    ///
-    /// Similarly, if a `Subscriber` has a filtering strategy that can be
-    /// changed dynamically at runtime, it would need to invalidate any cached
-    /// filter results when the filtering rules change.
-    ///
-    /// A subscriber which manages fanout to multiple other subscribers should
-    /// proxy this decision to all of its child subscribers, returning `false`
-    /// only if _all_ such children return `false`. If the set of subscribers to
-    /// which spans are broadcast may change dynamically, adding a new
-    /// subscriber should also invalidate cached filters.
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool;
-}
-
-/// The span registration portion of the [`Subscriber`] trait.
-///
-/// Implementations of this trait represent the logic run on span creation. They
-/// handle span ID generation.
-pub trait RegisterSpan {
-    /// Record the construction of a new [`Span`], returning a a new [span ID] for
-    /// the span being constructed.
-    ///
-    /// Span IDs are used to uniquely identify spans, so span equality will be
-    /// based on the returned ID. Thus, if the subscriber wishes for all spans
-    /// with the same metadata to be considered equal, it should return the same
-    /// ID every time it is given a particular set of metadata. Similarly, if it
-    /// wishes for two separate instances of a span with the same metadata to *not*
-    /// be equal, it should return a distinct ID every time this function is called,
-    /// regardless of the metadata.
-    ///
-    /// Subscribers which do not rely on the implementations of `PartialEq`,
-    /// `Eq`, and `Hash` for `Span`s are free to return span IDs with value 0
-    /// from all calls to this function, if they so choose.
-    ///
-    /// [span ID]: ../span/struct.Id.html
-    fn new_span(&self, new_span: &span::NewSpan) -> span::Id;
-}
-
-impl<T> RegisterSpan for T
-where
-    T: Fn(&span::NewSpan) -> span::Id,
-{
-    fn new_span(&self, new_span: &span::NewSpan) -> span::Id {
-        self(new_span)
-    }
-}
-
-impl<F> Filter for F
-where
-    F: for<'a, 'b> Fn(&'a Meta<'b>) -> bool,
-{
-    fn enabled(&self, meta: &Meta) -> bool {
-        self(meta)
-    }
-
-    fn should_invalidate_filter(&self, _: &Meta) -> bool {
-        // Since this implementation is for immutable closures only, we can
-        // treat these functions as stateless and assume they remain valid.
-        false
-    }
-}
+pub use filter::{Filter, FilterExt};
+pub use observe::{Observe, ObserveExt};
+pub use registry::RegisterSpan;

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -24,6 +24,7 @@ pub trait ObserveExt: Observe {
     /// ```
     /// #[macro_use]
     /// extern crate tokio_trace;
+    /// extern crate tokio_trace_log;
     /// extern crate tokio_trace_subscriber;
     /// use tokio_trace_subscriber::{registry, filter, Observe, ObserveExt};
     /// # use tokio_trace::{Level, Meta};

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -1,5 +1,5 @@
 use filter::{self, Filter};
-use tokio_trace::{Event, SpanData, Meta};
+use tokio_trace::{Event, Meta, SpanData};
 
 /// The notification processing portion of the [`Subscriber`] trait.
 ///
@@ -56,7 +56,7 @@ pub trait ObserveExt: Observe {
     fn tee_to<I>(self, other: I) -> Tee<Self, I::Observer>
     where
         I: IntoObserver,
-        Self: Sized
+        Self: Sized,
     {
         Tee {
             a: self,
@@ -132,7 +132,7 @@ pub trait ObserveExt: Observe {
     {
         WithFilter {
             inner: self,
-            filter
+            filter,
         }
     }
 }
@@ -219,7 +219,7 @@ pub struct Tee<A, B> {
 #[derive(Debug, Clone)]
 pub struct WithFilter<O, F> {
     inner: O,
-    filter: F
+    filter: F,
 }
 
 impl<O, F> Filter for WithFilter<O, F>
@@ -234,8 +234,8 @@ where
 
     #[inline]
     fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
-         self.filter.should_invalidate_filter(metadata) ||
-         self.inner.filter().should_invalidate_filter(metadata)
+        self.filter.should_invalidate_filter(metadata)
+            || self.inner.filter().should_invalidate_filter(metadata)
     }
 }
 
@@ -268,10 +268,7 @@ pub fn none() -> NoObserver {
     NoObserver
 }
 
-impl<T> ObserveExt for T
-where
-    T: Observe,
-{ }
+impl<T> ObserveExt for T where T: Observe {}
 
 impl<T> IntoObserver for T
 where
@@ -319,8 +316,8 @@ where
     }
 
     fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
-        self.a.filter().should_invalidate_filter(metadata) ||
-        self.b.filter().should_invalidate_filter(metadata)
+        self.a.filter().should_invalidate_filter(metadata)
+            || self.b.filter().should_invalidate_filter(metadata)
     }
 }
 
@@ -372,11 +369,11 @@ where
 }
 
 impl Observe for NoObserver {
-    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) { }
+    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {}
 
-    fn enter(&self, _span: &SpanData) { }
+    fn enter(&self, _span: &SpanData) {}
 
-    fn exit(&self, _span: &SpanData) { }
+    fn exit(&self, _span: &SpanData) {}
 
     fn filter(&self) -> &dyn Filter {
         self

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -14,7 +14,15 @@ pub trait ObserveExt: Observe {
         }
     }
 
-    /// Construct a new observer that filters events with the given `filter`.
+    /// Composes `self` with a [`Filter`].
+    ///
+    /// This function is intended to be used with composing observers from
+    /// external crates with user-defined filters, so that the resulting
+    /// observer is [`enabled`] only for a subset of the events and spans for
+    /// which the original observer would be enabled.
+    ///
+    /// [`Filter`]: ../trait.Filter.html
+    /// [`enabled`]: ../trait.Filter.html#tymethod.enabled
     fn with_filter<F>(self, filter: F) -> WithFilter<Self, F>
     where
         F: Filter,
@@ -214,11 +222,11 @@ impl Observe for NoObserver {
 }
 
 impl Filter for NoObserver {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, _metadata: &Meta) -> bool {
         false
     }
 
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
         false
     }
 }

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -1,6 +1,22 @@
-use ::{Observe, Filter};
+use filter::{self, Filter};
 use tokio_trace::{Event, SpanData, Meta};
 
+/// The notification processing portion of the [`Subscriber`] trait.
+///
+/// Implementations of this trait describe the logic needed to process envent
+/// and span notifications, but don't implement span registration.
+pub trait Observe {
+    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
+    fn enter(&self, span: &SpanData);
+    fn exit(&self, span: &SpanData);
+
+    fn filter(&self) -> &dyn Filter {
+        &filter::NoFilter
+    }
+}
+
+/// Extension trait providing combinators and helper methods for working with
+/// instances of `Observe`.
 pub trait ObserveExt: Observe {
     /// Construct a new observer that sends events to both `self` and `other`.
     ///
@@ -61,7 +77,7 @@ pub trait ObserveExt: Observe {
     /// extern crate tokio_trace;
     /// extern crate tokio_trace_subscriber;
     /// use tokio_trace_subscriber::{registry, Observe, ObserveExt};
-    /// # use tokio_trace_subscriber::{Filter, filter::NoFilter};
+    /// # use tokio_trace_subscriber::filter::{Filter, NoFilter};
     /// # use tokio_trace::{Level, Meta, Event, SpanData};
     /// # fn main() {
     ///
@@ -140,7 +156,7 @@ pub struct NoObserver;
 /// # extern crate tokio_trace;
 /// extern crate tokio_trace_subscriber;
 /// use tokio_trace_subscriber::{observe, Observe};
-/// # use tokio_trace_subscriber::{Filter, filter::NoFilter};
+/// # use tokio_trace_subscriber::filter::{Filter, NoFilter};
 /// # use tokio_trace::{Event, SpanData};
 /// # fn main() {}
 ///

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -2,7 +2,41 @@ use ::{Observe, Filter};
 use tokio_trace::{Event, SpanData, Meta};
 
 pub trait ObserveExt: Observe {
-    /// Construct a new observer that sends events to both `self` and `other.
+    /// Construct a new observer that sends events to both `self` and `other`.
+    ///
+    /// For example:
+    /// ```
+    /// #[macro_use]
+    /// extern crate tokio_trace;
+    /// extern crate tokio_trace_subscriber;
+    /// use tokio_trace_subscriber::{registry, filter, Observe, ObserveExt};
+    /// # use tokio_trace::{Level, Meta};
+    /// # fn main() {
+    ///
+    /// let observer = tokio_trace_log::TraceLogger::new()
+    ///     // Subscribe *only* to spans named "foo".
+    ///     .with_filter(|meta: &Meta| {
+    ///         meta.name == Some("foo")
+    ///     });
+    ///
+    /// let subscriber = tokio_trace_subscriber::Composed::builder()
+    ///     .with_observer(observer)
+    ///     .with_registry(registry::increasing_counter);
+    ///
+    /// tokio_trace::Dispatch::to(subscriber).with(|| {
+    ///     /// // This span will be logged.
+    ///     span!("foo", enabled = true) .enter(|| {
+    ///         // do work;
+    ///     });
+    ///     // This span will *not* be logged.
+    ///     span!("bar", enabled = false).enter(|| {
+    ///         // This event also will not be logged.
+    ///         event!(Level::Debug, { enabled = false },"this won't be logged");
+    ///     });
+    /// });
+    /// # }
+    /// ```
+    ///
     fn tee_to<I>(self, other: I) -> Tee<Self, I::Observer>
     where
         I: IntoObserver,
@@ -20,6 +54,58 @@ pub trait ObserveExt: Observe {
     /// external crates with user-defined filters, so that the resulting
     /// observer is [`enabled`] only for a subset of the events and spans for
     /// which the original observer would be enabled.
+    ///
+    /// For example:
+    /// ```
+    /// #[macro_use]
+    /// extern crate tokio_trace;
+    /// extern crate tokio_trace_subscriber;
+    /// use tokio_trace_subscriber::{registry, Observe, ObserveExt};
+    /// # use tokio_trace_subscriber::{Filter, filter::NoFilter};
+    /// # use tokio_trace::{Level, Meta, Event, SpanData};
+    /// # fn main() {
+    ///
+    /// struct Foo {
+    ///     // ...
+    /// }
+    ///
+    /// struct Bar {
+    ///     // ...
+    /// }
+    ///
+    /// impl Observe for Foo {
+    ///     // ...
+    /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+    /// # fn enter(&self, _: &SpanData) {}
+    /// # fn exit(&self, _: &SpanData) {}
+    /// # fn filter(&self) -> &dyn Filter { &NoFilter}
+    /// }
+    ///
+    /// impl Observe for Bar {
+    ///     // ...
+    /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+    /// # fn enter(&self, _: &SpanData) {}
+    /// # fn exit(&self, _: &SpanData) {}
+    /// # fn filter(&self) -> &dyn Filter { &NoFilter}
+    /// }
+    ///
+    /// let foo = Foo { };
+    /// let bar = Bar { };
+    ///
+    /// let observer = foo.tee_to(bar);
+    ///
+    /// let subscriber = tokio_trace_subscriber::Composed::builder()
+    ///     .with_observer(observer)
+    ///     .with_registry(registry::increasing_counter);
+    ///
+    /// tokio_trace::Dispatch::to(subscriber).with(|| {
+    ///     // This span will be seen by both `foo` and `bar`.
+    ///     span!("my great span").enter(|| {
+    ///         // ...
+    ///     })
+    /// });
+    /// # }
+    /// ```
     ///
     /// [`Filter`]: ../trait.Filter.html
     /// [`enabled`]: ../trait.Filter.html#tymethod.enabled
@@ -40,20 +126,80 @@ pub trait IntoObserver {
     fn into_observer(self) -> Self::Observer;
 }
 
+/// An observer which does nothing.
 pub struct NoObserver;
 
+/// An observer which is an instance of one of two types that implement
+/// `Observe`.
+///
+/// This is intended to be used when an observer implementation is chosen
+/// conditionally, and the overhead of `Box<dyn Observe>` is unwanted.
+///
+/// For example:
+/// ```
+/// # extern crate tokio_trace;
+/// extern crate tokio_trace_subscriber;
+/// use tokio_trace_subscriber::{observe, Observe};
+/// # use tokio_trace_subscriber::{Filter, filter::NoFilter};
+/// # use tokio_trace::{Event, SpanData};
+/// # fn main() {}
+///
+/// struct Foo {
+///     // ...
+/// }
+///
+/// struct Bar {
+///     // ...
+/// }
+///
+/// impl Observe for Foo {
+///     // ...
+/// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+/// # fn enter(&self, _: &SpanData) {}
+/// # fn exit(&self, _: &SpanData) {}
+/// # fn filter(&self) -> &dyn Filter { &NoFilter}
+/// }
+///
+/// impl Observe for Bar {
+///     // ...
+/// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+/// # fn enter(&self, _: &SpanData) {}
+/// # fn exit(&self, _: &SpanData) {}
+/// # fn filter(&self) -> &dyn Filter { &NoFilter}
+/// }
+///
+/// fn foo_or_bar(foo: bool) -> observe::Either<Foo, Bar> {
+///     if foo {
+///         observe::Either::A(Foo { })
+///     } else {
+///         observe::Either::B(Bar { })
+///     }
+/// }
+/// ```
 #[derive(Copy, Clone)]
 pub enum Either<A, B> {
     A(A),
     B(B),
 }
 
+/// An observer that forwards events and spans to two other types implementing
+/// `Observe`.
+///
+/// The `Tee`'s filter composes the filters of its child observers, so that a
+/// span or event is enabled if either of the child observers' filters consider
+/// it enabled. Similarly, cached filter evaluations should be invalidated if
+/// either child observer's filter indicates that they should be.
 #[derive(Copy, Clone)]
 pub struct Tee<A, B> {
     a: A,
     b: B,
 }
 
+/// An observer composed with an additional filter.
+///
+/// This observer's filter considers a span or event enabled if **both** the
+/// wrapped observer's filter and the composed filter enable it. However, cached
+/// filters are invalidated if **either** filter indicates that they should be.
 #[derive(Debug, Clone)]
 pub struct WithFilter<O, F> {
     inner: O,

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -1,0 +1,111 @@
+use super::Observe;
+use tokio_trace::{Event, SpanData};
+
+pub trait ObserveExt: Observe {
+    /// Construct a new observer that sends events to both `self` and `other.
+    fn tee_to<I>(self, other: I) -> Tee<Self, I::Observer>
+    where
+        I: IntoObserver,
+        Self: Sized
+    {
+        Tee {
+            a: self,
+            b: other.into_observer(),
+        }
+    }
+}
+
+pub trait IntoObserver {
+    type Observer: Observe;
+    fn into_observer(self) -> Self::Observer;
+}
+
+pub struct NoObserver;
+
+#[derive(Copy, Clone)]
+pub enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+#[derive(Copy, Clone)]
+pub struct Tee<A, B> {
+    a: A,
+    b: B,
+}
+
+pub fn none() -> NoObserver {
+    NoObserver
+}
+
+impl<T> ObserveExt for T
+where
+    T: Observe,
+{ }
+
+impl<T> IntoObserver for T
+where
+    T: Observe,
+{
+    type Observer = Self;
+    fn into_observer(self) -> Self::Observer {
+        self
+    }
+}
+
+// XXX: maybe this should just be an impl of `Observe` for tuples of `(Observe, Observe)`...?
+impl<A, B> Observe for Tee<A, B>
+where
+    A: Observe,
+    B: Observe,
+{
+    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+        self.a.observe_event(event);
+        self.b.observe_event(event);
+    }
+
+    fn enter(&self, span: &SpanData) {
+        self.a.enter(span);
+        self.b.enter(span);
+    }
+
+    fn exit(&self, span: &SpanData) {
+        self.a.exit(span);
+        self.b.exit(span);
+    }
+}
+
+impl<A, B> Observe for Either<A, B>
+where
+    A: Observe,
+    B: Observe,
+{
+    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+        match self {
+            Either::A(a) => a.observe_event(event),
+            Either::B(b) => b.observe_event(event),
+        }
+    }
+
+    fn enter(&self, span: &SpanData) {
+        match self {
+            Either::A(a) => a.enter(span),
+            Either::B(b) => b.enter(span),
+        }
+    }
+
+    fn exit(&self, span: &SpanData) {
+        match self {
+            Either::A(a) => a.exit(span),
+            Either::B(b) => b.exit(span),
+        }
+    }
+}
+
+impl Observe for NoObserver {
+    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) { }
+
+    fn enter(&self, _span: &SpanData) { }
+
+    fn exit(&self, _span: &SpanData) { }
+}

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,6 @@
-use super::RegisterSpan;
 use tokio_trace::span::{NewSpan, Id};
 
-use std::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
 /// Registers new span IDs with an increasing `usize` counter.
 ///

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,0 +1,13 @@
+use super::RegisterSpan;
+use tokio_trace::span::{NewSpan, Id};
+
+use std::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+
+/// Registers new span IDs with an increasing `usize` counter.
+///
+/// This should not be used on 32-bit machines.
+pub fn increasing_counter(new_span: &NewSpan) -> Id {
+    static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+    let next = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    Id::from_u64(next as u64)
+}

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 /// Registers new span IDs with an increasing `usize` counter.
 ///
 /// This should not be used on 32-bit machines.
-pub fn increasing_counter(new_span: &NewSpan) -> Id {
+pub fn increasing_counter(_new_span: &NewSpan) -> Id {
     static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
     let next = NEXT_ID.fetch_add(1, Ordering::SeqCst);
     Id::from_u64(next as u64)

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -2,11 +2,44 @@ use tokio_trace::span::{NewSpan, Id};
 
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
+/// The span registration portion of the [`Subscriber`] trait.
+///
+/// Implementations of this trait represent the logic run on span creation. They
+/// handle span ID generation.
+pub trait RegisterSpan {
+    /// Record the construction of a new [`Span`], returning a a new [span ID] for
+    /// the span being constructed.
+    ///
+    /// Span IDs are used to uniquely identify spans, so span equality will be
+    /// based on the returned ID. Thus, if the subscriber wishes for all spans
+    /// with the same metadata to be considered equal, it should return the same
+    /// ID every time it is given a particular set of metadata. Similarly, if it
+    /// wishes for two separate instances of a span with the same metadata to *not*
+    /// be equal, it should return a distinct ID every time this function is called,
+    /// regardless of the metadata.
+    ///
+    /// Subscribers which do not rely on the implementations of `PartialEq`,
+    /// `Eq`, and `Hash` for `Span`s are free to return span IDs with value 0
+    /// from all calls to this function, if they so choose.
+    ///
+    /// [span ID]: ../span/struct.Id.html
+    fn new_span(&self, new_span: &NewSpan) -> Id;
+}
+
 /// Registers new span IDs with an increasing `usize` counter.
 ///
-/// This should not be used on 32-bit machines.
+/// This may overflow on 32-bit machines.
 pub fn increasing_counter(_new_span: &NewSpan) -> Id {
     static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
     let next = NEXT_ID.fetch_add(1, Ordering::SeqCst);
     Id::from_u64(next as u64)
+}
+
+impl<T> RegisterSpan for T
+where
+    T: Fn(&NewSpan) -> Id,
+{
+    fn new_span(&self, new_span: &NewSpan) -> Id {
+        self(new_span)
+    }
 }

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,6 @@
-use tokio_trace::span::{NewSpan, Id};
+use tokio_trace::span::{Id, NewSpan};
 
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 /// The span registration portion of the [`Subscriber`] trait.
 ///

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -7,7 +7,7 @@ use tokio_trace::Level;
 
 fn main() {
     env_logger::Builder::new().parse("info").init();
-    let subscriber = tokio_trace_log::LogSubscriber::new();
+    let subscriber = tokio_trace_log::TraceLogger::new();
 
     tokio_trace::Dispatch::to(subscriber).with(|| {
         let foo = 3;


### PR DESCRIPTION
As discussed in #40, we can implement a lot of the functionality which
previously would require a global dispatcher in terms of traits
representing _subsets_ of the `Subscriber` API. `Subscriber` has some
trait methods which ought to be user-customizable, but also don't
compose well --- it doesn't make sense to have multiple subscribers
active in a given scope each generating their own span IDs, for example.
However, selected subsets of the subscriber API _can_ be composed,
allowing us to implement features like fan-out in terms of just the
portion that observes spans and events, with a single source of truth
for span ID generation.

For example, I imagine an application being able to compose subscribers
like this:
```rust
subscriber::Composed::builder()
    .with_registry(registry::increasing_counter)
    .with_observer(
        LogObserver::new()
            .tee_to(PrometheusObserver::new())
            .tee_to(FooObserver::new())
    )
     .with_filter(
        filter::Sample::every(10)
            .and(filter::module_blacklist(["foo", "bar"]))
    )
```
(note that only some of the functionality above is currently implemented
in this sketch; names may change, et cetera)