### PR TITLE
Instrument future executors as well as futures

### DIFF
--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -1,0 +1,49 @@
+use futures::{future::{Executor, ExecuteError}, Future};
+use tokio_trace::Span;
+use ::{Instrumented, Instrument};
+
+pub trait InstrumentExecutor<F>
+where
+    Self: Executor<Instrumented<F>>,
+    F: Future<Item = (), Error = ()>,
+{
+    fn instrument<G>(self, mk_span: G) -> InstrumentedExecutor<Self, G>
+    where
+        G: Fn() -> Span,
+        Self: Sized,
+    {
+        InstrumentedExecutor {
+            inner: self,
+            mk_span,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct InstrumentedExecutor<T, G> {
+    inner: T,
+    mk_span: G,
+}
+
+impl<T, F> InstrumentExecutor<F> for T
+where
+    T: Executor<Instrumented<F>>,
+    F: Future<Item = (), Error = ()>,
+{ }
+
+impl<T, F, N> Executor<F> for InstrumentedExecutor<T, N>
+where
+    T: Executor<Instrumented<F>>,
+    F: Future<Item = (), Error = ()>,
+    N: Fn() -> Span,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        self.inner
+            .execute(future.instrument((self.mk_span)()))
+            .map_err(|e| {
+                let kind = e.kind();
+                let future = e.into_future().inner;
+                ExecuteError::new(kind, future)
+            })
+    }
+}

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -5,6 +5,8 @@ extern crate futures;
 use tokio_trace::Span;
 use futures::{Async, Future, Sink, Stream, Poll, StartSend};
 
+pub mod executor;
+
 // TODO: seal?
 pub trait Instrument: Sized {
     fn instrument(self, span: Span) -> Instrumented<Self> {
@@ -91,7 +93,6 @@ impl<T: Sink> Sink for Instrumented<T> {
         })
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate tokio_trace;
 extern crate futures;
 
-use tokio_trace::Span;
+use tokio_trace::{Dispatch, Span, Subscriber};
 use futures::{Async, Future, Sink, Stream, Poll, StartSend};
 
 pub mod executor;
@@ -17,10 +17,28 @@ pub trait Instrument: Sized {
     }
 }
 
+pub trait WithSubscriber: Sized {
+    fn with_subscriber<S>(self, subscriber: S) -> WithDispatch<Self>
+    where
+        S: Subscriber + Send + Sync + 'static,
+    {
+        WithDispatch {
+            inner: self,
+            dispatch: Dispatch::to(subscriber),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Instrumented<T> {
     inner: T,
     span: Option<Span>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WithDispatch<T> {
+    inner: T,
+    dispatch: Dispatch,
 }
 
 impl<T: Sized> Instrument for T {}
@@ -91,6 +109,30 @@ impl<T: Sink> Sink for Instrumented<T> {
         span.enter(move || {
             inner.poll_complete()
         })
+    }
+}
+
+impl<T: Sized> WithSubscriber for T {}
+
+impl<T: Future> Future for WithDispatch<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let dispatch = &self.dispatch;
+        let inner = &mut self.inner;
+        dispatch.with(|| {
+            inner.poll()
+        })
+    }
+}
+
+impl<T> WithDispatch<T> {
+    pub(crate) fn with_dispatch <U: Sized>(&self, inner: U) -> WithDispatch<U> {
+        WithDispatch {
+            dispatch: self.dispatch.clone(),
+            inner,
+        }
     }
 }
 


### PR DESCRIPTION
This branch adds functionality to the `tokio-trace-futures`
compatibility crate for instrumenting future _executors_ as well as
futures. Instrumenting a future with a span works slightly differently
than instrumenting a future --- rather than taking a span which is
entered by all futures spawned on the executor, it takes a _function_
returning a span, so that all top-level futures spawned are inside of
their own unique span. This seemed like the correct behaviour for
executors.

Possibly more valuable is the ability to attach a `Subscriber` to an
executor, so that whenever futures spawned on that executor are polled,
the subscriber context switches to the attached subscriber.