### PR TITLE
Minor improvements to metadata

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -55,7 +55,7 @@ impl<'a> AsLog for Meta<'a> {
     fn as_log(&self) -> Self::Log {
         log::Metadata::builder()
             .level(self.level.as_log())
-            .target(self.target.unwrap_or(""))
+            .target(self.target)
             .build()
     }
 }
@@ -65,14 +65,11 @@ impl<'a> AsTrace for log::Record<'a> {
     fn as_trace(&self) -> Self::Trace {
         Meta {
             name: None,
-            target: Some(self.target()),
+            target: self.target(),
             level: self.level().as_trace(),
-            module_path: self
-                .module_path()
-                // TODO: make symmetric
-                .unwrap_or_else(|| self.target()),
-            line: self.line().unwrap_or(0),
-            file: self.file().unwrap_or("???"),
+            module_path: self.module_path(),
+            line: self.line(),
+            file: self.file(),
             field_names: &[],
         }
     }
@@ -169,9 +166,9 @@ impl Subscriber for TraceLogger {
             logger.log(
                 &log::Record::builder()
                     .metadata(meta)
-                    .module_path(Some(event.meta.module_path))
-                    .file(Some(event.meta.file))
-                    .line(Some(event.meta.line))
+                    .module_path(event.meta.module_path)
+                    .file(event.meta.file)
+                    .line(event.meta.line)
                     .args(format_args!(
                         "[{}] {:?} {}",
                         parents.join(":"),

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -63,15 +63,14 @@ impl<'a> AsLog for Meta<'a> {
 impl<'a> AsTrace for log::Record<'a> {
     type Trace = Meta<'a>;
     fn as_trace(&self) -> Self::Trace {
-        Meta {
-            name: None,
-            target: self.target(),
-            level: self.level().as_trace(),
-            module_path: self.module_path(),
-            line: self.line(),
-            file: self.file(),
-            field_names: &[],
-        }
+        Meta::new_event(
+            self.target(),
+            self.level().as_trace(),
+            self.module_path(),
+            self.file(),
+            self.line(),
+            &[],
+        )
     }
 }
 

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -260,7 +260,10 @@ impl Filter for NoFilter {
 
 impl Filter for ModuleBlacklist {
     fn enabled(&self, metadata: &Meta) -> bool {
-        !self.modules.contains(metadata.module_path)
+        metadata.module_path
+            .map(|module| !self.modules.contains(module))
+            .unwrap_or(true)
+
     }
 
     fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
@@ -270,7 +273,9 @@ impl Filter for ModuleBlacklist {
 
 impl Filter for ModuleWhitelist {
     fn enabled(&self, metadata: &Meta) -> bool {
-        self.modules.contains(metadata.module_path)
+        metadata.module_path
+            .map(|module| self.modules.contains(module))
+            .unwrap_or(false)
     }
 
     fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -78,7 +78,7 @@ pub trait FilterExt: Filter {
     /// }
     ///
     /// let name_filter = |meta: &Meta| { meta.name == Some("foo") };
-    /// let mod_filter = |meta: &Meta| { meta.module_path == "my_module" };
+    /// let mod_filter = |meta: &Meta| { meta.module_path == Some("my_module") };
     ///
     /// let subscriber = tokio_trace_subscriber::Composed::builder()
     ///     .with_registry(tokio_trace_subscriber::registry::increasing_counter)

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -136,50 +136,50 @@ pub struct Sample {
 /// A filter that enables all spans and events, except those originating
 /// from a specified set of module paths.
 #[derive(Debug)]
-pub struct ModuleBlacklist {
+pub struct ExceptModules {
     modules: HashSet<String>,
 }
 
 /// A filter that enables only spans and events originating from a specified
 /// set of module paths.
 #[derive(Debug)]
-pub struct ModuleWhitelist {
+pub struct OnlyModules {
     modules: HashSet<String>,
 }
 
 /// A filter that enables all spans and events, except those with a specified
 /// set of targets.
 #[derive(Debug)]
-pub struct TargetBlacklist {
+pub struct ExceptTargets {
     targets: HashSet<String>,
 }
 
 /// A filter that enables onlu spans and events with a specified set of targets.
 #[derive(Debug)]
-pub struct TargetWhitelist {
+pub struct OnlyTargets {
     targets: HashSet<String>,
 }
 
 /// Returns a filter that enables all spans and events, except those originating
 /// from a specified set of module paths.
-pub fn module_blacklist<I>(modules: I) -> ModuleBlacklist
+pub fn except_modules<I>(modules: I) -> ExceptModules
 where
     I: IntoIterator,
     String: From<<I as IntoIterator>::Item>,
 {
     let modules = modules.into_iter().map(String::from).collect();
-    ModuleBlacklist { modules }
+    ExceptModules { modules }
 }
 
 /// Returns a filter that enables only spans and events originating from a
 /// specified set of module paths.
-pub fn module_whitelist<I>(modules: I) -> ModuleWhitelist
+pub fn only_modules<I>(modules: I) -> OnlyModules
 where
     I: IntoIterator,
     String: From<<I as IntoIterator>::Item>,
 {
     let modules = modules.into_iter().map(String::from).collect();
-    ModuleWhitelist { modules }
+    OnlyModules { modules }
 }
 
 /// A filter which only enables spans.
@@ -194,24 +194,24 @@ pub fn events_only<'a, 'b>(metadata: &'a Meta<'b>) -> bool {
 
 /// Returns a filter that enables all spans and events, except those originating
 /// with a specified set of targets.
-pub fn target_blacklist<I>(targets: I) -> TargetBlacklist
+pub fn except_targets<I>(targets: I) -> ExceptTargets
 where
     I: IntoIterator,
     String: From<<I as IntoIterator>::Item>,
 {
     let targets = targets.into_iter().map(String::from).collect();
-    TargetBlacklist { targets }
+    ExceptTargets { targets }
 }
 
 /// Returns a filter that enables only spans and events with a specified set of
 /// targets.
-pub fn target_whitelist<I>(targets: I) -> TargetWhitelist
+pub fn only_targets<I>(targets: I) -> OnlyTargets
 where
     I: IntoIterator,
     String: From<<I as IntoIterator>::Item>,
 {
     let targets = targets.into_iter().map(String::from).collect();
-    TargetWhitelist { targets }
+    OnlyTargets { targets }
 }
 
 impl<F> Filter for F
@@ -303,7 +303,7 @@ impl Filter for NoFilter {
     }
 }
 
-impl Filter for ModuleBlacklist {
+impl Filter for ExceptModules {
     fn enabled(&self, metadata: &Meta) -> bool {
         metadata.module_path
             .map(|module| !self.modules.contains(module))
@@ -316,7 +316,7 @@ impl Filter for ModuleBlacklist {
     }
 }
 
-impl Filter for ModuleWhitelist {
+impl Filter for OnlyModules {
     fn enabled(&self, metadata: &Meta) -> bool {
         metadata.module_path
             .map(|module| self.modules.contains(module))
@@ -329,7 +329,7 @@ impl Filter for ModuleWhitelist {
 }
 
 
-impl Filter for TargetBlacklist {
+impl Filter for ExceptTargets {
     fn enabled(&self, metadata: &Meta) -> bool {
         !self.targets.contains(metadata.target)
     }
@@ -339,7 +339,7 @@ impl Filter for TargetBlacklist {
     }
 }
 
-impl Filter for TargetWhitelist {
+impl Filter for OnlyTargets {
     fn enabled(&self, metadata: &Meta) -> bool {
         self.targets.contains(metadata.target)
     }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -87,7 +87,7 @@ impl SloggishSubscriber {
             writer,
             "{level} {target} ",
             level = ColorLevel(meta.level),
-            target = meta.target.unwrap_or(meta.module_path),
+            target = meta.target,
         )
     }
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -121,28 +121,28 @@ use self::dedup::IteratorDedup;
 #[macro_export]
 macro_rules! static_meta {
     ($($k:ident),*) => (
-        static_meta!(@ None, None, $crate::Level::Trace, $($k),* )
+        static_meta!(@ None, module_path!(), $crate::Level::Trace, $($k),* )
     );
     (level: $lvl:expr, $($k:ident),*) => (
-        static_meta!(@ None, None, $lvl, $($k),* )
+        static_meta!(@ None, module_path!(), $lvl, $($k),* )
     );
     (target: $target:expr, level: $lvl:expr, $($k:ident),*) => (
-        static_meta!(@ None, Some($target), $lvl, $($k),* )
+        static_meta!(@ None, $target, $lvl, $($k),* )
     );
     (target: $target:expr, $($k:ident),*) => (
-        static_meta!(@ None, Some($target), $crate::Level::Trace, $($k),* )
+        static_meta!(@ None, $target, $crate::Level::Trace, $($k),* )
     );
     ($name:expr) => (
-        static_meta!(@ Some($name), None, $crate::Level::Trace, )
+        static_meta!(@ Some($name), module_path!(), $crate::Level::Trace, )
     );
     ($name:expr, $($k:ident),*) => (
-        static_meta!(@ Some($name), None, $crate::Level::Trace, $($k),* )
+        static_meta!(@ Some($name), module_path!(), $crate::Level::Trace, $($k),* )
     );
     ($name:expr, level: $lvl:expr, $($k:ident),*) => (
-        static_meta!(@ Some($name),None, $lvl, $($k),* )
+        static_meta!(@ Some($name), module_path!(), $lvl, $($k),* )
     );
     ($name:expr, target: $target:expr, level: $lvl:expr, $($k:ident),*) => (
-        static_meta!(@ Some($name), Some($target), $lvl, $($k),* )
+        static_meta!(@ Some($name), $target, $lvl, $($k),* )
     );
     ($name:expr, target: $target:expr, $($k:ident),*) => (
         static_meta!(@ Some($name), Some($target), $crate::Level::Trace, $($k),* )
@@ -152,9 +152,9 @@ macro_rules! static_meta {
             name: $name,
             target: $target,
             level: $lvl,
-            module_path: module_path!(),
-            file: file!(),
-            line: line!(),
+            module_path: Some(module_path!()),
+            file: Some(file!()),
+            line: Some(line!()),
             field_names: &[ $(stringify!($k)),* ],
         }
     )
@@ -268,7 +268,9 @@ macro_rules! event {
             }
         }
     });
-    ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (event!(target: None, $lvl, { $($k = $val),* }, $($arg)+))
+    ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
+        event!(target: module_path!(), $lvl, { $($k = $val),* }, $($arg)+)
+    )
 }
 
 #[repr(usize)]
@@ -335,12 +337,12 @@ pub struct Event<'event, 'meta> {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Meta<'a> {
     pub name: Option<&'a str>,
-    pub target: Option<&'a str>,
+    pub target: &'a str,
     pub level: Level,
 
-    pub module_path: &'a str,
-    pub file: &'a str,
-    pub line: u32,
+    pub module_path: Option<&'a str>,
+    pub file: Option<&'a str>,
+    pub line: Option<u32>,
 
     pub field_names: &'a [&'a str],
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -356,7 +356,11 @@ pub struct Parents<'a> {
 }
 
 // ===== impl Meta =====
+
 impl<'a> Meta<'a> {
+
+    /// Construct new metadata for a span, with a name, target, level, field
+    /// names, and optional source code location.
     pub fn new_span(
         name: Option<&'a str>,
         target: &'a str,
@@ -378,6 +382,8 @@ impl<'a> Meta<'a> {
         }
     }
 
+    /// Construct new metadata for an event, with a target, level, field names,
+    /// and optional source code location.
     pub fn new_event(
         target: &'a str,
         level: Level,


### PR DESCRIPTION
Fixes #36.

This branch makes some minor changes to the `Meta` type: 

+ Metadata now knows if it corresponds to a Span or an Event, and has
  `is_span`/`is_event` methods.
+ Made the `target` field non-optional, and the `module_path`, `file`, 
  and `line` fields optional. This mirrors what the `log` crate does,
  and is more correct --- metadata that is created manually rather than
  by a macro may not know its source code location, but must have a 
  target.
+ When creating metadata without a specified target, the module path
  is used. Again, this is what `log` does.
+ Added new filters: `only_targets`, `except_targets`, `spans_only`
  and `events_only`. What they do should be fairly obvious.
+ Changes to internal macros to support these changes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>