### PR TITLE
Make trace logger field formatting more consistent

### DIFF
--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,4 +1,7 @@
-use tokio_trace::span::{Id, Data, State};
+use tokio_trace::{
+    span::{Id, Data, State},
+    Value,
+};
 
 use std::{
     cmp,
@@ -59,7 +62,7 @@ impl<'a, 'b> cmp::PartialEq<SpanRef<'b>> for SpanRef<'a> {
 impl<'a> cmp::Eq for SpanRef<'a> { }
 
 impl<'a> IntoIterator for &'a SpanRef<'a> {
-    type Item = (&'a str, &'a dyn tokio_trace::Value);
+    type Item = (&'a str, &'a dyn Value);
     type IntoIter = Box<Iterator<Item = Self::Item> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         self.data.map(|data| {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -58,7 +58,17 @@ impl<'a, 'b> cmp::PartialEq<SpanRef<'b>> for SpanRef<'a> {
 
 impl<'a> cmp::Eq for SpanRef<'a> { }
 
-
+impl<'a> IntoIterator for &'a SpanRef<'a> {
+    type Item = (&'a str, &'a dyn tokio_trace::Value);
+    type IntoIter = Box<Iterator<Item = Self::Item> + 'a>; // TODO: unbox
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.map(|data| {
+            // This is necessary because of type inference.
+            let iter: Box<Iterator<Item = Self::Item> + 'a> = Box::new(data.fields());
+            iter
+        }).unwrap_or_else(|| Box::new(::std::iter::empty()))
+    }
+}
 // /// Registers new span IDs with an increasing `usize` counter.
 // ///
 // /// This may overflow on 32-bit machines.


### PR DESCRIPTION
This is a minor improvement to the `tokio-trace-log` crate that makes
the formatting of fields in spans/events consistent with the way the
rest of the log record is formatted.

Before:
```
➜ cargo run --example basic -p tokio-trace
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/examples/basic`
 INFO 2018-10-18T18:15:05Z: basic: hello world; in_span=None; { foo: 3, bar: "bar" };
TRACE 2018-10-18T18:15:05Z: basic: new_span: my_great_span { foo: 4, baz: 5 }; span=Id(0); parent=None;
TRACE 2018-10-18T18:15:05Z: enter: span=Id(0); state=Running;
 INFO 2018-10-18T18:15:05Z: basic: hi from inside my span; in_span=Some(Id(0)); { yak_shaved: true };
TRACE 2018-10-18T18:15:05Z: exit: id=Id(0); state=Done;
```

After:
```
➜ cargo run --example basic -p tokio-trace
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/examples/basic`
 INFO 2018-10-18T17:55:21Z: basic: hello world; in_span=None; foo=3; bar="bar";
TRACE 2018-10-18T17:55:21Z: basic: new_span: my_great_span; span=Id(0); parent=None; foo=4; baz=5;
TRACE 2018-10-18T17:55:21Z: enter: span=Id(0); state=Running;
 INFO 2018-10-18T17:55:21Z: basic: hi from inside my span; in_span=Some(Id(0)); yak_shaved=true;
TRACE 2018-10-18T17:55:21Z: exit: id=Id(0); state=Done;
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>