### PR TITLE
Better family values

### DIFF
--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -130,7 +130,7 @@ impl<T> WithDispatch<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{future, prelude::*, stream, task};
+    use futures::{future, stream, task};
     use tokio_trace::{span, subscriber};
 
     #[test]

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -27,7 +27,11 @@ use std::{
     fmt, io,
     sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
 };
-use tokio_trace::{span, subscriber::{self, Subscriber}, Event, Meta, IntoValue};
+use tokio_trace::{
+    span,
+    subscriber::{self, Subscriber},
+    Event, IntoValue, Meta,
+};
 use tokio_trace_subscriber::SpanRef;
 
 /// Format a log record as a trace event in the current span.
@@ -180,7 +184,12 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(
+        &self,
+        _span: &span::Id,
+        _name: &'static str,
+        _value: &dyn IntoValue,
+    ) -> Result<(), subscriber::AddValueError> {
         // XXX eventually this should Do Something...
         Ok(())
     }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -27,7 +27,7 @@ use std::{
     fmt, io,
     sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
 };
-use tokio_trace::{span, subscriber::{self, Subscriber}, Event, Meta, Value};
+use tokio_trace::{span, subscriber::{self, Subscriber}, Event, Meta, Duplicate};
 use tokio_trace_subscriber::SpanRef;
 
 /// Format a log record as a trace event in the current span.
@@ -180,7 +180,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Value) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Duplicate) -> Result<(), subscriber::AddValueError> {
         // XXX eventually this should Do Something...
         Ok(())
     }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -27,7 +27,7 @@ use std::{
     fmt, io,
     sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
 };
-use tokio_trace::{span, subscriber::{self, Subscriber}, Event, Meta, Duplicate};
+use tokio_trace::{span, subscriber::{self, Subscriber}, Event, Meta, IntoValue};
 use tokio_trace_subscriber::SpanRef;
 
 /// Format a log record as a trace event in the current span.
@@ -180,7 +180,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Duplicate) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
         // XXX eventually this should Do Something...
         Ok(())
     }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -180,7 +180,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
         // XXX eventually this should Do Something...
         Ok(())
     }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,8 @@
-use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, IntoValue};
+use tokio_trace::{
+    span,
+    subscriber::{AddValueError, Subscriber},
+    Event, IntoValue, Meta, SpanData,
+};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, OwnedValue, Duplicate};
+use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, OwnedValue, IntoValue};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -107,7 +107,7 @@ where
         &self,
         span: &span::Id,
         name: &'static str,
-        value: &dyn Duplicate,
+        value: &dyn IntoValue,
     ) -> Result<(), AddValueError> {
         self.registry.add_value(span, name, value)
     }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, OwnedValue};
+use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, OwnedValue, Duplicate};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -107,7 +107,7 @@ where
         &self,
         span: &span::Id,
         name: &'static str,
-        value: &dyn OwnedValue,
+        value: &dyn Duplicate,
     ) -> Result<(), AddValueError> {
         self.registry.add_value(span, name, value)
     }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, Value};
+use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, OwnedValue};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -107,7 +107,7 @@ where
         &self,
         span: &span::Id,
         name: &'static str,
-        value: &dyn Value,
+        value: &dyn OwnedValue,
     ) -> Result<(), AddValueError> {
         self.registry.add_value(span, name, value)
     }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span, Event, Meta, SpanData, Subscriber};
+use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, Value};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -101,6 +101,15 @@ where
 
     fn new_span(&self, new_span: SpanData) -> span::Id {
         self.registry.new_span(new_span)
+    }
+
+    fn add_value(
+        &self,
+        span: &span::Id,
+        name: &'static str,
+        value: &dyn Value,
+    ) -> Result<(), AddValueError> {
+        self.registry.add_value(span, name, value)
     }
 
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, OwnedValue, IntoValue};
+use tokio_trace::{span, Event, Meta, SpanData, subscriber::{AddValueError, Subscriber}, IntoValue};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -116,11 +116,11 @@ pub trait ObserveExt: Observe {
     ///
     /// tokio_trace::Dispatch::to(subscriber).with(|| {
     ///     /// // This span will be logged.
-    ///     span!("foo", enabled = true) .enter(|| {
+    ///     span!("foo", enabled = &true) .enter(|| {
     ///         // do work;
     ///     });
     ///     // This span will *not* be logged.
-    ///     span!("bar", enabled = false).enter(|| {
+    ///     span!("bar", enabled = &false).enter(|| {
     ///         // This event also will not be logged.
     ///         event!(Level::Debug, { enabled = false },"this won't be logged");
     ///     });

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
     span::{Data, Id, State},
     subscriber::AddValueError,
-    OwnedValue, Value,
+    OwnedValue, Duplicate,
 };
 
 use std::{
@@ -37,7 +37,7 @@ pub trait RegisterSpan {
     /// [span ID]: ../span/struct.Id.html
     fn new_span(&self, new_span: Data) -> Id;
 
-    fn add_value(&self, span: &Id, name: &'static str, value: &dyn OwnedValue) -> Result<(), AddValueError>;
+    fn add_value(&self, span: &Id, name: &'static str, value: &dyn Duplicate) -> Result<(), AddValueError>;
 
     fn with_span<F>(&self, id: &Id, state: State, f: F)
     where
@@ -107,7 +107,7 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn add_value(&self, span: &Id, name: &'static str, value: &dyn OwnedValue) -> Result<(), AddValueError> {
+    fn add_value(&self, span: &Id, name: &'static str, value: &dyn Duplicate) -> Result<(), AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
         if let Some(i) = span.field_names().position(|field| field == &name) {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
     span::{Data, Id, State},
     subscriber::AddValueError,
-    OwnedValue, IntoValue,
+    IntoValue, OwnedValue,
 };
 
 use std::{
@@ -37,7 +37,12 @@ pub trait RegisterSpan {
     /// [span ID]: ../span/struct.Id.html
     fn new_span(&self, new_span: Data) -> Id;
 
-    fn add_value(&self, span: &Id, name: &'static str, value: &dyn IntoValue) -> Result<(), AddValueError>;
+    fn add_value(
+        &self,
+        span: &Id,
+        name: &'static str,
+        value: &dyn IntoValue,
+    ) -> Result<(), AddValueError>;
 
     fn with_span<F>(&self, id: &Id, state: State, f: F)
     where
@@ -107,7 +112,12 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn add_value(&self, span: &Id, name: &'static str, value: &dyn IntoValue) -> Result<(), AddValueError> {
+    fn add_value(
+        &self,
+        span: &Id,
+        name: &'static str,
+        value: &dyn IntoValue,
+    ) -> Result<(), AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
         span.add_value(name, value)

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,5 +1,6 @@
 use tokio_trace::{
     span::{Data, Id, State},
+    subscriber::AddValueError,
     Value,
 };
 
@@ -35,6 +36,8 @@ pub trait RegisterSpan {
     ///
     /// [span ID]: ../span/struct.Id.html
     fn new_span(&self, new_span: Data) -> Id;
+
+    fn add_value(&self, span: &Id, name: &'static str, value: &dyn Value) -> Result<(), AddValueError>;
 
     fn with_span<F>(&self, id: &Id, state: State, f: F)
     where
@@ -102,6 +105,15 @@ impl RegisterSpan for IncreasingCounter {
             spans.insert(id.clone(), new_span);
         }
         id
+    }
+
+    fn add_value(&self, span: &Id, name: &'static str, value: &dyn Value) -> Result<(), AddValueError> {
+        let spans = self.spans.lock().expect("mutex poisoned!");
+        let mut span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
+        if !span.static_meta.field_names.contains(name) {
+            return Err(AddValueError::NoField);
+        }
+        span.field_values
     }
 
     fn with_span<F>(&self, id: &Id, state: State, f: F)

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
     span::{Data, Id, State},
     subscriber::AddValueError,
-    Value,
+    Value, ToValue,
 };
 
 use std::{
@@ -109,12 +109,12 @@ impl RegisterSpan for IncreasingCounter {
 
     fn add_value(&self, span: &Id, name: &'static str, value: &dyn Value) -> Result<(), AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
-        let mut span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
+        let span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
         if let Some(i) = span.field_names().position(|field| field == &name) {
             span.field_values[i] = Some(value.duplicate());
             Ok(())
         } else {
-             Err(AddValueError::NoField)
+            Err(AddValueError::NoField)
         }
 
     }

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -110,13 +110,7 @@ impl RegisterSpan for IncreasingCounter {
     fn add_value(&self, span: &Id, name: &'static str, value: &dyn IntoValue) -> Result<(), AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
-        if let Some(i) = span.field_names().position(|field| field == &name) {
-            span.field_values[i] = Some(value.into_value());
-            Ok(())
-        } else {
-            Err(AddValueError::NoField)
-        }
-
+        span.add_value(name, value)
     }
 
     fn with_span<F>(&self, id: &Id, state: State, f: F)

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
     span::{Data, Id, State},
     subscriber::AddValueError,
-    IntoValue, OwnedValue,
+    value::{IntoValue, OwnedValue},
 };
 
 use std::{

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -67,7 +67,7 @@ impl<'a, 'b> cmp::PartialEq<SpanRef<'b>> for SpanRef<'a> {
 impl<'a> cmp::Eq for SpanRef<'a> {}
 
 impl<'a> IntoIterator for &'a SpanRef<'a> {
-    type Item = (&'a str, &'a dyn OwnedValue);
+    type Item = (&'a str, &'a OwnedValue);
     type IntoIter = Box<Iterator<Item = Self::Item> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         self.data

--- a/tokio-trace-tower-http/Cargo.toml
+++ b/tokio-trace-tower-http/Cargo.toml
@@ -18,6 +18,10 @@ string = { git = "https://github.com/carllerche/string" }
 tokio = "0.1"
 tokio-current-thread = "0.1.1"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
+tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }
+tokio-trace-log = { path = "../tokio-trace-log" }
 tokio-io = "0.1"
 ansi_term = "0.11"
 humantime = "1.1.1"
+
+env_logger = "0.5"

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -7,8 +7,11 @@ extern crate tokio;
 extern crate tokio_trace;
 extern crate tokio_trace_futures;
 extern crate tokio_trace_tower_http;
+extern crate tokio_trace_subscriber;
+extern crate tokio_trace_log;
 extern crate tower_h2;
 extern crate tower_service;
+extern crate env_logger;
 
 use bytes::Bytes;
 use futures::*;
@@ -20,9 +23,9 @@ use tokio_trace_futures::Instrument;
 use tower_h2::{Body, RecvBody, Server};
 use tower_service::{NewService, Service};
 
-#[path = "../../tokio-trace/examples/sloggish/sloggish_subscriber.rs"]
-mod sloggish;
-use self::sloggish::SloggishSubscriber;
+// #[path = "../../tokio-trace/examples/sloggish/sloggish_subscriber.rs"]
+// mod sloggish;
+// use self::sloggish::SloggishSubscriber;
 
 type Response = http::Response<RspBody>;
 

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -5,13 +5,13 @@ extern crate http;
 extern crate tokio;
 #[macro_use]
 extern crate tokio_trace;
+extern crate env_logger;
 extern crate tokio_trace_futures;
-extern crate tokio_trace_tower_http;
-extern crate tokio_trace_subscriber;
 extern crate tokio_trace_log;
+extern crate tokio_trace_subscriber;
+extern crate tokio_trace_tower_http;
 extern crate tower_h2;
 extern crate tower_service;
-extern crate env_logger;
 
 use bytes::Bytes;
 use futures::*;

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -23,9 +23,9 @@ use tokio_trace_futures::Instrument;
 use tower_h2::{Body, RecvBody, Server};
 use tower_service::{NewService, Service};
 
-// #[path = "../../tokio-trace/examples/sloggish/sloggish_subscriber.rs"]
-// mod sloggish;
-// use self::sloggish::SloggishSubscriber;
+#[path = "../../tokio-trace/examples/sloggish/sloggish_subscriber.rs"]
+mod sloggish;
+use self::sloggish::SloggishSubscriber;
 
 type Response = http::Response<RspBody>;
 
@@ -115,7 +115,7 @@ fn main() {
         let addr = "[::1]:8888".parse().unwrap();
         let bind = TcpListener::bind(&addr).expect("bind");
 
-        let server_span = span!("serve", local_ip = addr.ip(), local_port = addr.port());
+        let server_span = span!("serve", local_ip = &addr.ip(), local_port = &addr.port());
         server_span.clone().enter(move || {
             let new_svc = tokio_trace_tower_http::InstrumentedNewService::new(NewSvc);
             let h2 = Server::new(new_svc, Default::default(), reactor.clone());
@@ -124,7 +124,7 @@ fn main() {
                 .incoming()
                 .fold((h2, reactor), |(h2, reactor), sock| {
                     let addr = sock.peer_addr().expect("can't get addr");
-                    let conn_span = span!("conn", remote_ip = addr.ip(), remote_port = addr.port());
+                    let conn_span = span!("conn", remote_ip = &addr.ip(), remote_port = &addr.port());
                     conn_span.clone().enter(|| {
                         if let Err(e) = sock.set_nodelay(true) {
                             return Err(e);

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -124,7 +124,8 @@ fn main() {
                 .incoming()
                 .fold((h2, reactor), |(h2, reactor), sock| {
                     let addr = sock.peer_addr().expect("can't get addr");
-                    let conn_span = span!("conn", remote_ip = &addr.ip(), remote_port = &addr.port());
+                    let conn_span =
+                        span!("conn", remote_ip = &addr.ip(), remote_port = &addr.port());
                     conn_span.clone().enter(|| {
                         if let Err(e) = sock.set_nodelay(true) {
                             return Err(e);

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -102,10 +102,10 @@ where
         span.enter(move || {
             let request_span = span!(
                 "request",
-                method = request.method().clone(),
-                version = request.version().clone(),
-                uri = request.uri().clone(),
-                headers = request.headers().clone()
+                method = request.method(),
+                version = &request.version(),
+                uri = request.uri(),
+                headers = request.headers()
             );
             request_span
                 .clone()

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -36,14 +36,14 @@ where
         span.enter(|| inner.poll_ready())
     }
 
-    fn call(&mut self, request: Self::Request) -> Self::Future {
+    fn call(&mut self, req: Self::Request) -> Self::Future {
         let span = self.span.clone();
         let inner = &mut self.inner;
         span.enter(|| {
-            let request_span = span!("request", request = &request);
+            let request_span = span!("request", request = &req);
             request_span
                 .clone()
-                .enter(move || inner.call(request).instrument(request_span))
+                .enter(move || inner.call(req).instrument(request_span))
         })
     }
 }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -40,7 +40,7 @@ where
         let span = self.span.clone();
         let inner = &mut self.inner;
         span.enter(|| {
-            let request_span = span!("request", request = request.clone());
+            let request_span = span!("request", request = &request);
             request_span
                 .clone()
                 .enter(move || inner.call(request).instrument(request_span))

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -15,7 +15,11 @@ fn main() {
 
         let span = span!("my_great_span", foo = &4, baz = &5);
         span.enter(|| {
-            event!(Level::Info, { yak_shaved = &true }, "hi from inside my span");
+            event!(
+                Level::Info,
+                { yak_shaved = &true },
+                "hi from inside my span"
+            );
         });
     });
 }

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -13,9 +13,9 @@ fn main() {
         let foo = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 
-        let span = span!("my_great_span", foo = 4, baz = 5);
+        let span = span!("my_great_span", foo = &4, baz = &5);
         span.enter(|| {
-            event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
+            event!(Level::Info, { yak_shaved = &true }, "hi from inside my span");
         });
     });
 }

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -1,0 +1,115 @@
+#[macro_use]
+extern crate tokio_trace;
+
+use tokio_trace::{Level, Event, span, subscriber::{self, Subscriber}, Meta, IntoValue};
+
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{
+        Arc,
+        RwLock,
+        atomic::{AtomicUsize, Ordering},
+    }
+};
+
+#[derive(Clone)]
+struct Counters(Arc<RwLock<HashMap<&'static str, AtomicUsize>>>);
+
+struct CounterSubscriber {
+    ids: AtomicUsize,
+    counters: Counters,
+    spans: RwLock<HashMap<span::Id, span::Data>>,
+}
+
+impl Subscriber for CounterSubscriber {
+    fn new_span(&self, new_span: span::Data) -> span::Id {
+        let id = self.ids.fetch_add(1, Ordering::SeqCst);
+        let id = span::Id::from_u64(id as u64);
+        let mut registry = self.counters.0.write().unwrap();
+        for name in new_span.meta().field_names {
+            if name.contains("count") {
+                let _ = registry.entry(name)
+                    .or_insert_with(|| AtomicUsize::new(0));
+            }
+        }
+        self.spans.write().unwrap().insert(id.clone(), new_span);
+        id
+    }
+
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
+        self.spans.write().unwrap().get_mut(span)
+            .ok_or(subscriber::AddValueError::NoSpan)?
+            .add_value(name, value)
+    }
+
+    fn enabled(&self, metadata: &Meta) -> bool {
+        metadata.is_span() && metadata.field_names.iter()
+            .any(|name| name.contains("count"))
+    }
+
+    fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
+        false
+    }
+    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {}
+
+    fn enter(&self, span: span::Id, state: span::State) {}
+
+    fn exit(&self, span: span::Id, state: span::State) {
+        if state != span::State::Done {
+            return;
+        }
+        let registry = self.counters.0.read().unwrap();
+        if let Some(span) = self.spans.read().unwrap().get(&span) {
+            for (counter, value) in span.fields()
+                .filter_map(|(k, v)| {
+                    if !k.contains("count") {
+                        return None;
+                    }
+                    let any: &(dyn Any + 'static) = v;
+                    let v = Any::downcast_ref::<usize>(any)?;
+                    let c = registry.get(k)?;
+                    Some((c, v))
+                })
+            {
+                counter.fetch_add(*value, Ordering::Release);
+            }
+        }
+    }
+}
+
+impl Counters {
+    fn print_counters(&self) {
+        for (k, v) in self.0.read().unwrap().iter() {
+            println!("{}: {}", k, v.load(Ordering::Acquire));
+        }
+    }
+
+    fn new() -> (Self, CounterSubscriber) {
+        let counters = Counters(Arc::new(RwLock::new(HashMap::new())));
+        let subscriber = CounterSubscriber {
+            ids: AtomicUsize::new(0),
+            counters: counters.clone(),
+            spans: RwLock::new(HashMap::new()),
+        };
+        (counters, subscriber)
+    }
+}
+
+
+fn main() {
+    let (counters, subscriber) = Counters::new();
+
+    tokio_trace::Dispatch::to(subscriber).with(|| {
+        let mut foo = 2;
+        span!("my_great_span", foo_count = &foo).enter(|| {
+            event!(Level::Info, { yak_shaved = &true }, "hi from inside my span");
+            foo += 1;
+            span!("my other span", foo_count = &foo, baz_count = &5).enter(|| {
+
+            })
+        });
+    });
+
+    counters.print_counters();
+}

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -115,7 +115,7 @@ fn main() {
             foo += 1;
             event!(
                 Level::Info,
-                { yak_shaved = &true, },
+                { yak_shaved = &true },
                 "hi from inside my span"
             );
             span!("my other span", foo_count = &foo, baz_count = &5usize).enter(|| {})

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -22,16 +22,16 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
     tokio_trace::Dispatch::to(subscriber).with(|| {
-        span!("", version = 5.0).enter(|| {
-            span!("server", host = "localhost", port = 8080).enter(|| {
+        span!("", version = &5.0).enter(|| {
+            span!("server", host = &"localhost", port = &8080).enter(|| {
                 event!(Level::Info, {}, "starting");
                 event!(Level::Info, {}, "listening");
-                let peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381);
+                let peer1 = span!("conn", peer_addr = &"82.9.9.9", port = &42381);
                 peer1.clone().enter(|| {
                     event!(Level::Debug, {}, "connected");
                     event!(Level::Debug, { length = 2 }, "message received");
                 });
-                let peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230);
+                let peer2 = span!("conn", peer_addr = &"8.8.8.8", port = &18230);
                 peer2.clone().enter(|| {
                     event!(Level::Debug, {}, "connected");
                 });

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -13,7 +13,7 @@
 extern crate ansi_term;
 extern crate humantime;
 use self::ansi_term::{Color, Style};
-use super::tokio_trace::{self, Level, SpanData, SpanId};
+use super::tokio_trace::{self, Level, SpanData, SpanId, subscriber::{self, Subscriber}};
 
 use std::{
     collections::HashMap,
@@ -59,9 +59,10 @@ impl SloggishSubscriber {
         }
     }
 
-    fn print_kvs<'a, I>(&self, writer: &mut impl Write, kvs: I, leading: &str) -> io::Result<()>
+    fn print_kvs<'a, I, T>(&self, writer: &mut impl Write, kvs: I, leading: &str) -> io::Result<()>
     where
-        I: IntoIterator<Item = (&'a str, &'a dyn tokio_trace::Value)>,
+        I: IntoIterator<Item = (&'a str, T)>,
+        T: fmt::Debug,
     {
         let mut kvs = kvs.into_iter();
         if let Some((k, v)) = kvs.next() {
@@ -96,7 +97,7 @@ impl SloggishSubscriber {
     }
 }
 
-impl tokio_trace::Subscriber for SloggishSubscriber {
+impl Subscriber for SloggishSubscriber {
     fn enabled(&self, _metadata: &tokio_trace::Meta) -> bool {
         true
     }
@@ -106,6 +107,17 @@ impl tokio_trace::Subscriber for SloggishSubscriber {
         let id = tokio_trace::span::Id::from_u64(next);
         self.spans.lock().unwrap().insert(id.clone(), span);
         id
+    }
+
+    fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::Value) -> Result<(), subscriber::AddValueError> {
+        let mut spans = self.spans.lock().expect("mutex poisoned!");
+        let span = spans.get_mut(span).ok_or(subscriber::AddValueError::NoSpan)?;
+        if let Some(i) = span.field_names().position(|field| field == &name) {
+            span.field_values[i] = Some(value.duplicate());
+            Ok(())
+        } else {
+            Err(subscriber::AddValueError::NoField)
+        }
     }
 
     #[inline]

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -109,11 +109,11 @@ impl Subscriber for SloggishSubscriber {
         id
     }
 
-    fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::Duplicate) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::IntoValue) -> Result<(), subscriber::AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(subscriber::AddValueError::NoSpan)?;
         if let Some(i) = span.field_names().position(|field| field == &name) {
-            span.field_values[i] = Some(value.duplicate());
+            span.field_values[i] = Some(value.into_value());
             Ok(())
         } else {
             Err(subscriber::AddValueError::NoField)

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -13,7 +13,11 @@
 extern crate ansi_term;
 extern crate humantime;
 use self::ansi_term::{Color, Style};
-use super::tokio_trace::{self, Level, SpanData, SpanId, subscriber::{self, Subscriber}};
+use super::tokio_trace::{
+    self,
+    subscriber::{self, Subscriber},
+    Level, SpanData, SpanId,
+};
 
 use std::{
     collections::HashMap,
@@ -109,9 +113,16 @@ impl Subscriber for SloggishSubscriber {
         id
     }
 
-    fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::IntoValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(
+        &self,
+        span: &tokio_trace::SpanId,
+        name: &'static str,
+        value: &dyn tokio_trace::IntoValue,
+    ) -> Result<(), subscriber::AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
-        let span = spans.get_mut(span).ok_or(subscriber::AddValueError::NoSpan)?;
+        let span = spans
+            .get_mut(span)
+            .ok_or(subscriber::AddValueError::NoSpan)?;
         span.add_value(name, value)
     }
 

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -109,7 +109,7 @@ impl Subscriber for SloggishSubscriber {
         id
     }
 
-    fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::Value) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::Duplicate) -> Result<(), subscriber::AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(subscriber::AddValueError::NoSpan)?;
         if let Some(i) = span.field_names().position(|field| field == &name) {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -112,12 +112,7 @@ impl Subscriber for SloggishSubscriber {
     fn add_value(&self, span: &tokio_trace::SpanId, name: &'static str, value: &dyn tokio_trace::IntoValue) -> Result<(), subscriber::AddValueError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(subscriber::AddValueError::NoSpan)?;
-        if let Some(i) = span.field_names().position(|field| field == &name) {
-            span.field_values[i] = Some(value.into_value());
-            Ok(())
-        } else {
-            Err(subscriber::AddValueError::NoField)
-        }
+        span.add_value(name, value)
     }
 
     #[inline]

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use {span, subscriber::{self, Subscriber}, Event, Meta, OwnedValue};
+use {span, subscriber::{self, Subscriber}, Event, Meta, Duplicate};
 
 use std::{
     cell::RefCell,
@@ -84,7 +84,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn OwnedValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Duplicate) -> Result<(), subscriber::AddValueError> {
         self.0.add_value(span, name, value)
     }
 
@@ -116,7 +116,7 @@ impl Subscriber for NoSubscriber {
         span::Id::from_u64(0)
     }
 
-    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn OwnedValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn Duplicate) -> Result<(), subscriber::AddValueError> {
         Ok(())
     }
 

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,4 +1,8 @@
-use {span, subscriber::{self, Subscriber}, Event, Meta, IntoValue};
+use {
+    span,
+    subscriber::{self, Subscriber},
+    Event, IntoValue, Meta,
+};
 
 use std::{
     cell::RefCell,
@@ -84,7 +88,12 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(
+        &self,
+        span: &span::Id,
+        name: &'static str,
+        value: &dyn IntoValue,
+    ) -> Result<(), subscriber::AddValueError> {
         self.0.add_value(span, name, value)
     }
 
@@ -116,7 +125,12 @@ impl Subscriber for NoSubscriber {
         span::Id::from_u64(0)
     }
 
-    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
+    fn add_value(
+        &self,
+        _span: &span::Id,
+        _name: &'static str,
+        _value: &dyn IntoValue,
+    ) -> Result<(), subscriber::AddValueError> {
         Ok(())
     }
 

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use {span, subscriber::{self, Subscriber}, Event, Meta, Duplicate};
+use {span, subscriber::{self, Subscriber}, Event, Meta, IntoValue};
 
 use std::{
     cell::RefCell,
@@ -84,7 +84,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Duplicate) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
         self.0.add_value(span, name, value)
     }
 
@@ -116,7 +116,7 @@ impl Subscriber for NoSubscriber {
         span::Id::from_u64(0)
     }
 
-    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn Duplicate) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn IntoValue) -> Result<(), subscriber::AddValueError> {
         Ok(())
     }
 

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use {span, subscriber::Subscriber, Event, Meta};
+use {span, subscriber::{self, Subscriber}, Event, Meta, Value};
 
 use std::{
     cell::RefCell,
@@ -84,6 +84,11 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Value) -> Result<(), subscriber::AddValueError> {
+        self.0.add_value(span, name, value)
+    }
+
+    #[inline]
     fn enabled(&self, metadata: &Meta) -> bool {
         self.0.enabled(metadata)
     }
@@ -109,6 +114,10 @@ struct NoSubscriber;
 impl Subscriber for NoSubscriber {
     fn new_span(&self, _span: span::Data) -> span::Id {
         span::Id::from_u64(0)
+    }
+
+    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn Value) -> Result<(), subscriber::AddValueError> {
+        Ok(())
     }
 
     fn enabled(&self, _metadata: &Meta) -> bool {

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use {span, subscriber::{self, Subscriber}, Event, Meta, Value};
+use {span, subscriber::{self, Subscriber}, Event, Meta, OwnedValue};
 
 use std::{
     cell::RefCell,
@@ -84,7 +84,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn Value) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, span: &span::Id, name: &'static str, value: &dyn OwnedValue) -> Result<(), subscriber::AddValueError> {
         self.0.add_value(span, name, value)
     }
 
@@ -116,7 +116,7 @@ impl Subscriber for NoSubscriber {
         span::Id::from_u64(0)
     }
 
-    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn Value) -> Result<(), subscriber::AddValueError> {
+    fn add_value(&self, _span: &span::Id, _name: &'static str, _value: &dyn OwnedValue) -> Result<(), subscriber::AddValueError> {
         Ok(())
     }
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -240,7 +240,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{SpanId, Subscriber, Dispatch, Meta, SpanData, Event, Value};
+            use $crate::{SpanId, Subscriber, Dispatch, Meta, SpanData, Event, ToValue};
             static META: Meta<'static> = meta! { event:
                 $lvl,
                 target:
@@ -248,7 +248,7 @@ macro_rules! event {
             };
             let dispatcher = Dispatch::current();
             if cached_filter!(&META, dispatcher) {
-                let field_values: &[& Value] = &[ $( & $val),* ];
+                let field_values: &[& dyn ToValue] = &[ $( & $val),* ];
                 dispatcher.observe_event(&Event {
                     parent: SpanId::current(),
                     follows_from: &[],
@@ -300,14 +300,26 @@ pub use self::{
 };
 
 // XXX: im using fmt::Debug for prototyping purposes, it should probably leave.
-pub trait Value: Any + fmt::Debug + Send + Sync {
+pub trait ToValue: fmt::Debug + Send + Sync { }
+
+
+pub trait Value: ToValue + Any {
     // like `Clone`, but "different"
     fn duplicate(&self) -> Box<dyn Value>;
 }
 
+impl<T> ToValue for T
+where
+    T: fmt::Debug + Send + Sync,
+{
+
+}
+
 impl<T> Value for T
 where
-    T: Any + Clone + fmt::Debug + Send + Sync,
+    T: Any + fmt::Debug + Send + Sync,
+    T: Clone,
+    // <T as Clone>::Owned: Any + ToValue,
 {
     fn duplicate(&self) -> Box<dyn Value> {
         Box::new(self.clone())
@@ -328,7 +340,7 @@ pub struct Event<'event, 'meta> {
 
     pub meta: &'meta Meta<'meta>,
     // TODO: agh box
-    pub field_values: &'event [&'event dyn Value],
+    pub field_values: &'event [&'event dyn ToValue],
     pub message: fmt::Arguments<'event>,
 }
 
@@ -432,7 +444,7 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,
     /// returns `None`.
-    pub fn field<Q>(&'event self, name: Q) -> Option<&'event dyn Value>
+    pub fn field<Q>(&'event self, name: Q) -> Option<&'event dyn ToValue>
     where
         &'event str: PartialEq<Q>,
     {
@@ -442,7 +454,7 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
     }
 
     /// Returns an iterator over all the field names and values on this event.
-    pub fn fields(&'event self) -> impl Iterator<Item = (&'event str, &'event dyn Value)> {
+    pub fn fields(&'event self) -> impl Iterator<Item = (&'event str, &'event dyn ToValue)> {
         self.field_names()
             .enumerate()
             .filter_map(move |(idx, &name)| self.field_values.get(idx).map(|&val| (name, val)))
@@ -450,26 +462,27 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
 
     /// Returns a struct that can be used to format all the fields on this
     /// `Event` with `fmt::Debug`.
-    pub fn debug_fields<'a: 'meta>(&'a self) -> DebugFields<'a, Self> {
+    pub fn debug_fields<'a: 'meta>(&'a self) -> DebugFields<'a, Self, &'a dyn ToValue> {
         DebugFields(self)
     }
 }
 
 impl<'a, 'm: 'a> IntoIterator for &'a Event<'a, 'm> {
-    type Item = (&'a str, &'a dyn Value);
-    type IntoIter = Box<Iterator<Item = (&'a str, &'a dyn Value)> + 'a>; // TODO: unbox
+    type Item = (&'a str, &'a dyn ToValue);
+    type IntoIter = Box<Iterator<Item = (&'a str, &'a dyn ToValue)> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.fields())
     }
 }
 
-pub struct DebugFields<'a, I: 'a>(&'a I)
+pub struct DebugFields<'a, I: 'a, T: 'a>(&'a I)
 where
-    &'a I: IntoIterator<Item = (&'a str, &'a dyn Value)>;
+    &'a I: IntoIterator<Item = (&'a str, T)>;
 
-impl<'a, I: 'a> fmt::Debug for DebugFields<'a, I>
+impl<'a, I: 'a, T: 'a> fmt::Debug for DebugFields<'a, I, T>
 where
-    &'a I: IntoIterator<Item = (&'a str, &'a dyn Value)>,
+    &'a I: IntoIterator<Item = (&'a str, T)>,
+    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -427,7 +427,7 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
     {
         self.field_names()
             .position(|&field_name| field_name == name)
-            .and_then(|i| self.field_values.get(i).map(|&val| BorrowedValue::new(val)))
+            .and_then(|i| self.field_values.get(i).map(|&val| value::borrowed(val)))
     }
 
     /// Returns an iterator over all the field names and values on this event.
@@ -437,7 +437,7 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
             .filter_map(move |(idx, &name)| {
                 self.field_values
                     .get(idx)
-                    .map(|&val| (name, BorrowedValue::new(val)))
+                    .map(|&val| (name, value::borrowed(val)))
             })
     }
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -230,7 +230,7 @@ macro_rules! span {
             };
             $(
                 span.add_value(stringify!($k), $( $val )* )
-                    .expect(concat!("adding value for field ", stringify!($k), " failed!"));
+                    .expect(concat!("adding value for field ", stringify!($k), " failed"));
             )*
             span
         }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -207,7 +207,7 @@ macro_rules! cached_filter {
 /// # #[macro_use]
 /// # extern crate tokio_trace;
 /// # fn main() {
-/// span!("my span", foo = 2, bar = "a string").enter(|| {
+/// span!("my span", foo = &2, bar = &"a string").enter(|| {
 ///     // do work inside the span...
 /// });
 /// # }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -241,7 +241,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{SpanId, Subscriber, Dispatch, Meta, SpanData, Event, Value};
+            use $crate::{SpanId, Subscriber, Dispatch, Meta, SpanData, Event, value::AsValue};
             static META: Meta<'static> = meta! { event:
                 $lvl,
                 target:
@@ -249,7 +249,7 @@ macro_rules! event {
             };
             let dispatcher = Dispatch::current();
             if cached_filter!(&META, dispatcher) {
-                let field_values: &[& dyn Value] = &[ $( & $val),* ];
+                let field_values: &[ &dyn AsValue ] = &[ $( &$val ),* ];
                 dispatcher.observe_event(&Event {
                     parent: SpanId::current(),
                     follows_from: &[],
@@ -299,8 +299,9 @@ pub use self::{
     dispatcher::Dispatch,
     span::{Data as SpanData, Id as SpanId, Span},
     subscriber::Subscriber,
-    value::*,
+    value::{AsValue, Value, IntoValue},
 };
+use value::BorrowedValue;
 
 /// **Note**: `Event` must be generic over two lifetimes, that of `Event` itself
 /// (the `'event` lifetime) *and* the lifetime of the event's metadata (the
@@ -315,8 +316,8 @@ pub struct Event<'event, 'meta> {
     pub follows_from: &'event [SpanId],
 
     pub meta: &'meta Meta<'meta>,
-    // TODO: agh box
-    pub field_values: &'event [&'event dyn Value],
+
+    pub field_values: &'event [ &'event dyn AsValue ],
     pub message: fmt::Arguments<'event>,
 }
 
@@ -420,32 +421,36 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,
     /// returns `None`.
-    pub fn field<Q>(&'event self, name: Q) -> Option<&'event dyn Value>
+    pub fn field<Q>(&self, name: Q) -> Option<value::BorrowedValue>
     where
         &'event str: PartialEq<Q>,
     {
         self.field_names()
             .position(|&field_name| field_name == name)
-            .and_then(|i| self.field_values.get(i).map(|&val| val))
+            .and_then(|i| self.field_values.get(i).map(|&val| BorrowedValue::new(val)))
     }
 
     /// Returns an iterator over all the field names and values on this event.
-    pub fn fields(&'event self) -> impl Iterator<Item = (&'event str, &'event dyn Value)> {
+    pub fn fields<'a: 'event>(&'a self) -> impl Iterator<Item = (&'event str, BorrowedValue<'a>)> {
         self.field_names()
             .enumerate()
-            .filter_map(move |(idx, &name)| self.field_values.get(idx).map(|&val| (name, val)))
+            .filter_map(move |(idx, &name)| {
+                self.field_values
+                    .get(idx)
+                    .map(|&val| (name, BorrowedValue::new(val)))
+            })
     }
 
     /// Returns a struct that can be used to format all the fields on this
     /// `Event` with `fmt::Debug`.
-    pub fn debug_fields<'a: 'meta>(&'a self) -> DebugFields<'a, Self, &'a dyn Value> {
+    pub fn debug_fields<'a: 'event>(&'a self) -> DebugFields<'a, Self, BorrowedValue<'event>> {
         DebugFields(self)
     }
 }
 
 impl<'a, 'm: 'a> IntoIterator for &'a Event<'a, 'm> {
-    type Item = (&'a str, &'a dyn Value);
-    type IntoIter = Box<Iterator<Item = (&'a str, &'a dyn Value)> + 'a>; // TODO: unbox
+    type Item = (&'a str, BorrowedValue<'a>);
+    type IntoIter = Box<Iterator<Item = (&'a str, BorrowedValue<'a>)> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.fields())
     }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -113,7 +113,7 @@
 
 extern crate futures;
 
-use std::{any::Any, fmt, slice};
+use std::{fmt, slice};
 
 #[doc(hidden)]
 #[macro_export]
@@ -292,45 +292,14 @@ pub enum Level {
 mod dispatcher;
 pub mod span;
 pub mod subscriber;
+pub mod value;
 
 pub use self::{
     dispatcher::Dispatch,
     span::{Data as SpanData, Id as SpanId, Span},
     subscriber::Subscriber,
+    value::*,
 };
-
-// XXX: im using fmt::Debug for prototyping purposes, it should probably leave.
-pub trait Value: fmt::Debug + Send + Sync { }
-
-pub trait OwnedValue: Value + Any {
-}
-
-impl<T> Value for T
-where
-    T: fmt::Debug + Send + Sync,
-{
-
-}
-
-pub trait Duplicate: Value {
-    // like `Clone`, but "different"
-    fn duplicate(&self) -> Box<dyn OwnedValue>;
-}
-
-impl<T> OwnedValue for T
-where
-    T: Any + Value,
-{ }
-
-impl<T> Duplicate for T
-where
-    T: Value + ToOwned,
-    <T as ToOwned>::Owned: OwnedValue,
-{
-    fn duplicate(&self) -> Box<dyn OwnedValue> {
-        Box::new(self.to_owned())
-    }
-}
 
 /// **Note**: `Event` must be generic over two lifetimes, that of `Event` itself
 /// (the `'event` lifetime) *and* the lifetime of the event's metadata (the

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -302,10 +302,7 @@ pub use self::{
 // XXX: im using fmt::Debug for prototyping purposes, it should probably leave.
 pub trait Value: fmt::Debug + Send + Sync { }
 
-
 pub trait OwnedValue: Value + Any {
-    // like `Clone`, but "different"
-    fn duplicate(&self) -> Box<dyn OwnedValue>;
 }
 
 impl<T> Value for T
@@ -315,14 +312,23 @@ where
 
 }
 
+pub trait Duplicate: Value {
+    // like `Clone`, but "different"
+    fn duplicate(&self) -> Box<dyn OwnedValue>;
+}
+
 impl<T> OwnedValue for T
 where
-    T: Any + fmt::Debug + Send + Sync,
-    T: Clone,
-    // <T as Clone>::Owned: Any + Value,
+    T: Any + Value,
+{ }
+
+impl<T> Duplicate for T
+where
+    T: Value + ToOwned,
+    <T as ToOwned>::Owned: OwnedValue,
 {
     fn duplicate(&self) -> Box<dyn OwnedValue> {
-        Box::new(self.clone())
+        Box::new(self.to_owned())
     }
 }
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -300,13 +300,18 @@ pub use self::{
 };
 
 // XXX: im using fmt::Debug for prototyping purposes, it should probably leave.
-pub trait Value: Any + fmt::Debug + Send + Sync { }
+pub trait Value: Any + fmt::Debug + Send + Sync {
+    // like `Clone`, but "different"
+    fn duplicate(&self) -> Box<dyn Value>;
+}
 
 impl<T> Value for T
 where
-    T: Any + fmt::Debug + Send + Sync,
+    T: Any + Clone + fmt::Debug + Send + Sync,
 {
-
+    fn duplicate(&self) -> Box<dyn Value> {
+        Box::new(self.clone())
+    }
 }
 
 /// **Note**: `Event` must be generic over two lifetimes, that of `Event` itself

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -113,7 +113,11 @@
 
 extern crate futures;
 
-use std::{fmt, slice};
+use std::{
+    any::Any,
+    fmt,
+    slice,
+};
 
 #[doc(hidden)]
 #[macro_export]
@@ -245,7 +249,7 @@ macro_rules! event {
             };
             let dispatcher = Dispatch::current();
             if cached_filter!(&META, dispatcher) {
-                let field_values: &[& dyn Value] = &[ $( & $val),* ];
+                let field_values: &[& Value] = &[ $( & $val),* ];
                 dispatcher.observe_event(&Event {
                     parent: SpanId::current(),
                     follows_from: &[],
@@ -297,11 +301,12 @@ pub use self::{
 };
 
 // XXX: im using fmt::Debug for prototyping purposes, it should probably leave.
-pub trait Value: fmt::Debug + Send + Sync {
-    // ... ?
-}
+pub type Value = Any + fmt::Debug + Send + Sync;
 
-impl<T> Value for T where T: fmt::Debug + Send + Sync {}
+enum ValueInner {
+    Borrowed(&'static (dyn Any + fmt::Debug + Send + Sync)),
+    Owned(Arc<dyn Any + fmt::Debug + Send + Sync>),
+}
 
 /// **Note**: `Event` must be generic over two lifetimes, that of `Event` itself
 /// (the `'event` lifetime) *and* the lifetime of the event's metadata (the
@@ -317,7 +322,7 @@ pub struct Event<'event, 'meta> {
 
     pub meta: &'meta Meta<'meta>,
     // TODO: agh box
-    pub field_values: &'event [&'event dyn Value],
+    pub field_values: &'event [&'event Value],
     pub message: fmt::Arguments<'event>,
 }
 
@@ -421,7 +426,7 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,
     /// returns `None`.
-    pub fn field<Q>(&'event self, name: Q) -> Option<&'event dyn Value>
+    pub fn field<Q>(&'event self, name: Q) -> Option<&'event Value>
     where
         &'event str: PartialEq<Q>,
     {
@@ -445,8 +450,8 @@ impl<'event, 'meta: 'event> Event<'event, 'meta> {
 }
 
 impl<'a, 'm: 'a> IntoIterator for &'a Event<'a, 'm> {
-    type Item = (&'a str, &'a dyn Value);
-    type IntoIter = Box<Iterator<Item = (&'a str, &'a dyn Value)> + 'a>; // TODO: unbox
+    type Item = (&'a str, &'a Value);
+    type IntoIter = Box<Iterator<Item = (&'a str, &'a Value)> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.fields())
     }
@@ -454,11 +459,11 @@ impl<'a, 'm: 'a> IntoIterator for &'a Event<'a, 'm> {
 
 pub struct DebugFields<'a, I: 'a>(&'a I)
 where
-    &'a I: IntoIterator<Item = (&'a str, &'a dyn Value)>;
+    &'a I: IntoIterator<Item = (&'a str, &'a Value)>;
 
 impl<'a, I: 'a> fmt::Debug for DebugFields<'a, I>
 where
-    &'a I: IntoIterator<Item = (&'a str, &'a dyn Value)>,
+    &'a I: IntoIterator<Item = (&'a str, &'a Value)>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -229,7 +229,8 @@ macro_rules! span {
                 Span::new_disabled()
             };
             $(
-                span.add_value(stringify!($k), $( $val )* );
+                span.add_value(stringify!($k), $( $val )* )
+                    .expect(concat!("adding value for field ", stringify!($k), " failed!"));
             )*
             span
         }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -194,10 +194,9 @@ impl Span {
     pub fn new(
         dispatch: Dispatch,
         static_meta: &'static StaticMeta,
-        field_values: Vec<Option<Box<dyn Value>>>,
     ) -> Span {
         let parent = Active::current();
-        let data = Data::new(parent.as_ref().map(Active::id), static_meta, field_values);
+        let data = Data::new(parent.as_ref().map(Active::id), static_meta);
         let id = dispatch.new_span(data);
         let inner = Some(Active::new(id, dispatch, parent));
         Self { inner }
@@ -265,12 +264,11 @@ impl Data {
     fn new(
         parent: Option<Id>,
         static_meta: &'static StaticMeta,
-        field_values: Vec<Option<Box<dyn Value>>>,
     ) -> Self {
         Data {
             parent,
             static_meta,
-            field_values,
+            field_values: Vec::new(),
         }
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -10,7 +10,8 @@ use std::{
 };
 use {
     subscriber::{AddValueError, Subscriber},
-    DebugFields, Dispatch, IntoValue, OwnedValue, StaticMeta,
+    value::{IntoValue, OwnedValue},
+    DebugFields, Dispatch, StaticMeta,
 };
 
 thread_local! {
@@ -516,7 +517,7 @@ pub use self::test_support::*;
 #[cfg(any(test, feature = "test-support"))]
 mod test_support {
     use std::collections::HashMap;
-    use {span::State, OwnedValue};
+    use {span::State, value::OwnedValue};
 
     pub struct MockSpan {
         pub name: Option<Option<&'static str>>,

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -32,7 +32,7 @@ thread_local! {
 /// # #[macro_use] extern crate tokio_trace;
 /// # fn main() {
 /// let my_var = 5;
-/// let my_span = span!("my_span", my_var = my_var);
+/// let my_span = span!("my_span", my_var = &my_var);
 ///
 /// my_span.clone().enter(|| {
 ///     // perform some work in the context of `my_span`...

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -294,6 +294,15 @@ impl Data {
         self.static_meta.field_names.iter()
     }
 
+    /// Returns true if a field named 'name' has been declared on this span,
+    /// even if the field does not currently have a value.
+    pub fn has_field<Q>(&self, key: Q) -> bool
+    where
+        &'static str: PartialEq<Q>,
+    {
+        self.field_names().any(|&name| name == key)
+    }
+
     /// Borrows the value of the field named `name`, if it exists. Otherwise,
     /// returns `None`.
     pub fn field<Q>(&self, key: Q) -> Option<&dyn Value>

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -1,5 +1,6 @@
-use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, Value};
+use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, ToValue, Value};
 use std::{
+    borrow::Borrow,
     cell::RefCell,
     cmp, fmt,
     hash::{Hash, Hasher},
@@ -327,7 +328,7 @@ impl Data {
 
     /// Returns a struct that can be used to format all the fields on this
     /// span ith `fmt::Debug`.
-    pub fn debug_fields<'a>(&'a self) -> DebugFields<'a, Self> {
+    pub fn debug_fields<'a>(&'a self) -> DebugFields<'a, Self, &'a dyn Value> {
         DebugFields(self)
     }
 }
@@ -657,8 +658,8 @@ mod tests {
         Dispatch::to(subscriber::mock().run()).with(|| {
             // Even though these spans have the same name and fields, they will have
             // differing metadata, since they were created on different lines.
-            let foo1 = span!("foo", bar = 1, baz = false);
-            let foo2 = span!("foo", bar = 1, baz = false);
+            let foo1 = span!("foo", bar = &1, baz = &false);
+            let foo2 = span!("foo", bar = &1, baz = &false);
 
             assert_ne!(foo1, foo2);
             // assert_ne!(foo1.data(), foo2.data());
@@ -670,7 +671,7 @@ mod tests {
         // Every time time this function is called, it will return a _new
         // instance_ of a span with the same metadata, name, and fields.
         fn make_span() -> Span {
-            span!("foo", bar = 1, baz = false)
+            span!("foo", bar = &1, baz = &false)
         }
 
         Dispatch::to(subscriber::mock().run()).with(|| {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -243,7 +243,8 @@ impl Span {
                 Err(e) => Err(e),
             }
         } else {
-            Err(AddValueError::NoSpan)
+            // If the span doesn't exist, silently do nothing.
+            Ok(())
         }
     }
 }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -1,4 +1,4 @@
-use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, Value, OwnedValue};
+use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, Value, OwnedValue, Duplicate};
 use std::{
     borrow::Borrow,
     cell::RefCell,
@@ -231,7 +231,7 @@ impl Span {
         self.inner.as_ref().and_then(Active::parent)
     }
 
-    pub fn add_value(&self, field: &'static str, value: &dyn OwnedValue) -> Result<(), AddValueError> {
+    pub fn add_value(&self, field: &'static str, value: &dyn Duplicate) -> Result<(), AddValueError> {
         if let Some(ref inner) = self.inner {
             let inner = &inner.inner;
             match inner.subscriber.add_value(&inner.id, field, value) {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -104,7 +104,7 @@ pub struct Data {
 
     pub static_meta: &'static StaticMeta,
 
-    pub field_values: Vec<Box<dyn Value>>,
+    pub field_values: Vec<Box<Value>>,
 }
 
 /// Identifies a span within the context of a process.
@@ -194,7 +194,7 @@ impl Span {
     pub fn new(
         dispatch: Dispatch,
         static_meta: &'static StaticMeta,
-        field_values: Vec<Box<dyn Value>>,
+        field_values: Vec<Box<Value>>,
     ) -> Span {
         let parent = Active::current();
         let data = Data::new(parent.as_ref().map(Active::id), static_meta, field_values);
@@ -252,7 +252,7 @@ impl Data {
     fn new(
         parent: Option<Id>,
         static_meta: &'static StaticMeta,
-        field_values: Vec<Box<dyn Value>>,
+        field_values: Vec<Box<Value>>,
     ) -> Self {
         Data {
             parent,
@@ -283,7 +283,7 @@ impl Data {
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,
     /// returns `None`.
-    pub fn field<Q>(&self, key: Q) -> Option<&dyn Value>
+    pub fn field<Q>(&self, key: Q) -> Option<&Value>
     where
         &'static str: PartialEq<Q>,
     {
@@ -293,7 +293,7 @@ impl Data {
     }
 
     /// Returns an iterator over all the field names and values on this span.
-    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a dyn Value)> {
+    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a Value)> {
         self.field_names()
             .enumerate()
             .filter_map(move |(i, &name)| {
@@ -311,8 +311,8 @@ impl Data {
 }
 
 impl<'a> IntoIterator for &'a Data {
-    type Item = (&'a str, &'a dyn Value);
-    type IntoIter = Box<Iterator<Item = (&'a str, &'a dyn Value)> + 'a>; // TODO: unbox
+    type Item = (&'a str, &'a Value);
+    type IntoIter = Box<Iterator<Item = (&'a str, &'a Value)> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.fields())
     }
@@ -477,7 +477,7 @@ mod test_support {
     pub struct MockSpan {
         pub name: Option<Option<&'static str>>,
         pub state: Option<State>,
-        pub fields: HashMap<String, Box<dyn Value>>,
+        pub fields: HashMap<String, Box<Value>>,
         // TODO: more
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -104,7 +104,7 @@ pub struct Data {
 
     pub static_meta: &'static StaticMeta,
 
-    pub field_values: Vec<Option<Box<dyn OwnedValue>>>,
+    pub field_values: Vec<Option<OwnedValue>>,
 }
 
 /// Identifies a span within the context of a process.
@@ -303,7 +303,7 @@ impl Data {
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,
     /// returns `None`.
-    pub fn field<Q>(&self, key: Q) -> Option<&dyn OwnedValue>
+    pub fn field<Q>(&self, key: Q) -> Option<&OwnedValue>
     where
         &'static str: PartialEq<Q>,
     {
@@ -313,12 +313,11 @@ impl Data {
                 self.field_values
                     .get(i)?
                     .as_ref()
-                    .map(Box::as_ref)
             })
     }
 
     /// Returns an iterator over all the field names and values on this span.
-    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a dyn OwnedValue)> {
+    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (&'a str, &'a OwnedValue)> {
         self.field_names()
             .filter_map(move |&name| {
                 self.field(name).map(move |val| (name, val))
@@ -343,14 +342,14 @@ impl Data {
 
     /// Returns a struct that can be used to format all the fields on this
     /// span ith `fmt::Debug`.
-    pub fn debug_fields<'a>(&'a self) -> DebugFields<'a, Self, &'a dyn OwnedValue> {
+    pub fn debug_fields<'a>(&'a self) -> DebugFields<'a, Self, &'a OwnedValue> {
         DebugFields(self)
     }
 }
 
 impl<'a> IntoIterator for &'a Data {
-    type Item = (&'a str, &'a dyn OwnedValue);
-    type IntoIter = Box<Iterator<Item = (&'a str, &'a dyn OwnedValue)> + 'a>; // TODO: unbox
+    type Item = (&'a str, &'a OwnedValue);
+    type IntoIter = Box<Iterator<Item = (&'a str, &'a OwnedValue)> + 'a>; // TODO: unbox
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.fields())
     }
@@ -515,7 +514,7 @@ mod test_support {
     pub struct MockSpan {
         pub name: Option<Option<&'static str>>,
         pub state: Option<State>,
-        pub fields: HashMap<String, Box<dyn OwnedValue>>,
+        pub fields: HashMap<String, Box<OwnedValue>>,
         // TODO: more
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -1,4 +1,4 @@
-use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, Value, OwnedValue, Duplicate};
+use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, Value, OwnedValue, IntoValue};
 use std::{
     borrow::Borrow,
     cell::RefCell,
@@ -231,7 +231,7 @@ impl Span {
         self.inner.as_ref().and_then(Active::parent)
     }
 
-    pub fn add_value(&self, field: &'static str, value: &dyn Duplicate) -> Result<(), AddValueError> {
+    pub fn add_value(&self, field: &'static str, value: &dyn IntoValue) -> Result<(), AddValueError> {
         if let Some(ref inner) = self.inner {
             let inner = &inner.inner;
             match inner.subscriber.add_value(&inner.id, field, value) {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -1,6 +1,5 @@
-use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, Value, OwnedValue, IntoValue};
+use ::{DebugFields, Dispatch, StaticMeta, subscriber::{AddValueError, Subscriber}, IntoValue, OwnedValue};
 use std::{
-    borrow::Borrow,
     cell::RefCell,
     cmp, fmt,
     hash::{Hash, Hasher},

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -325,6 +325,22 @@ impl Data {
             })
     }
 
+    pub fn add_value(&mut self, name: &'static str, value: &dyn IntoValue) -> Result<(), AddValueError> {
+        if let Some(field) = self.field_names()
+            .position(|&field_name| field_name == name)
+            .and_then(|idx| self.field_values.get_mut(idx))
+        {
+            if field.is_some() {
+                Err(AddValueError::FieldAlreadyExists)
+            } else {
+                *field = Some(value.into_value());
+                Ok(())
+            }
+        } else {
+            Err(AddValueError::NoField)
+        }
+    }
+
     /// Returns a struct that can be used to format all the fields on this
     /// span ith `fmt::Debug`.
     pub fn debug_fields<'a>(&'a self) -> DebugFields<'a, Self, &'a dyn OwnedValue> {

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -1,4 +1,4 @@
-use ::{span, Event, Meta, SpanId, Value};
+use ::{span, Event, Meta, SpanId, OwnedValue};
 
 pub trait Subscriber {
     // === Span registry methods ==============================================
@@ -35,7 +35,7 @@ pub trait Subscriber {
         &self,
         span: &span::Id,
         name: &'static str,
-        value: &dyn Value,
+        value: &dyn OwnedValue,
     ) -> Result<(), AddValueError>;
 
     // === Filtering methods ==================================================
@@ -105,7 +105,7 @@ pub use self::test_support::*;
 mod test_support {
     use super::*;
     use span::{self, MockSpan};
-    use {Event, Meta, SpanData, SpanId, Value};
+    use {Event, Meta, SpanData, SpanId, OwnedValue};
 
     use std::{
         collections::{HashMap, VecDeque},
@@ -185,7 +185,7 @@ mod test_support {
             &self,
             _span: &span::Id,
             _name: &'static str,
-            _value: &dyn Value,
+            _value: &dyn OwnedValue,
         ) -> Result<(), AddValueError> {
             // TODO: it should be possible to expect values...
             Ok(())

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -1,4 +1,4 @@
-use ::{span, Event, Meta, SpanId, IntoValue};
+use {span, Event, IntoValue, Meta, SpanId};
 
 pub trait Subscriber {
     // === Span registry methods ==============================================
@@ -105,7 +105,7 @@ pub use self::test_support::*;
 mod test_support {
     use super::*;
     use span::{self, MockSpan};
-    use {Event, Meta, SpanData, SpanId, IntoValue};
+    use {Event, IntoValue, Meta, SpanData, SpanId};
 
     use std::{
         collections::{HashMap, VecDeque},

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -24,6 +24,9 @@ pub trait Subscriber {
     // // XXX: should this be a subscriber method or should it have its own type???
     // fn span_data(&self, id: &span::Id) -> Option<&span::Data>;
 
+    /// Attach a field to a span.
+    fn add_field<T: Any + Debug>(&self, span: &span::Id, name: &'static str, value: T) -> Result<(), AddFieldError>;
+
     // === Filtering methods ==================================================
 
     /// Determines if a span or event with the specified metadata would be recorded.
@@ -72,6 +75,16 @@ pub trait Subscriber {
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
     fn enter(&self, span: SpanId, state: span::State);
     fn exit(&self, span: SpanId, state: span::State);
+}
+
+#[derive(Clone, Debug)]
+pub enum AddFieldError {
+    /// The span with the given ID does not exist.
+    NoSpan,
+    /// The span exists, but does not have the specified field.
+    NoField,
+    /// The named field already has a value.
+    FieldAlreadyExists,
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -1,4 +1,4 @@
-use ::{span, Event, Meta, SpanId, Duplicate};
+use ::{span, Event, Meta, SpanId, IntoValue};
 
 pub trait Subscriber {
     // === Span registry methods ==============================================
@@ -35,7 +35,7 @@ pub trait Subscriber {
         &self,
         span: &span::Id,
         name: &'static str,
-        value: &dyn Duplicate,
+        value: &dyn IntoValue,
     ) -> Result<(), AddValueError>;
 
     // === Filtering methods ==================================================
@@ -105,7 +105,7 @@ pub use self::test_support::*;
 mod test_support {
     use super::*;
     use span::{self, MockSpan};
-    use {Event, Meta, SpanData, SpanId, Duplicate};
+    use {Event, Meta, SpanData, SpanId, IntoValue};
 
     use std::{
         collections::{HashMap, VecDeque},
@@ -185,7 +185,7 @@ mod test_support {
             &self,
             _span: &span::Id,
             _name: &'static str,
-            _value: &dyn Duplicate,
+            _value: &dyn IntoValue,
         ) -> Result<(), AddValueError> {
             // TODO: it should be possible to expect values...
             Ok(())

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -1,4 +1,4 @@
-use ::{span, Event, Meta, SpanId, OwnedValue};
+use ::{span, Event, Meta, SpanId, Duplicate};
 
 pub trait Subscriber {
     // === Span registry methods ==============================================
@@ -35,7 +35,7 @@ pub trait Subscriber {
         &self,
         span: &span::Id,
         name: &'static str,
-        value: &dyn OwnedValue,
+        value: &dyn Duplicate,
     ) -> Result<(), AddValueError>;
 
     // === Filtering methods ==================================================
@@ -105,7 +105,7 @@ pub use self::test_support::*;
 mod test_support {
     use super::*;
     use span::{self, MockSpan};
-    use {Event, Meta, SpanData, SpanId, OwnedValue};
+    use {Event, Meta, SpanData, SpanId, Duplicate};
 
     use std::{
         collections::{HashMap, VecDeque},
@@ -185,7 +185,7 @@ mod test_support {
             &self,
             _span: &span::Id,
             _name: &'static str,
-            _value: &dyn OwnedValue,
+            _value: &dyn Duplicate,
         ) -> Result<(), AddValueError> {
             // TODO: it should be possible to expect values...
             Ok(())

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -305,6 +305,24 @@ impl Value for OwnedValue {
     }
 }
 
+impl<'a> Value for &'a OwnedValue {
+    #[inline]
+    fn downcast_ref<T: AsValue + 'static>(&self) -> Option<&T>
+    where
+        Self: 'static,
+    {
+        (*self).downcast_ref()
+    }
+
+    #[inline]
+    fn is<T: AsValue + 'static>(&self) -> bool
+    where
+        Self: 'static,
+    {
+        (*self).is::<T>()
+    }
+}
+
 impl fmt::Debug for OwnedValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt_value(f)

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -2,6 +2,13 @@ use std::{any::Any, borrow::Borrow, fmt};
 
 pub trait Value: fmt::Debug + Send + Sync {}
 
+/// An owned, dynamically-typed value.
+///
+/// Like `Any`, references to `OwnedValue` may attempt to downcast the value to
+/// a concrete type. However, unlike `Any`, `OwnedValue`s are constructed from
+/// types known to implement `fmt::Debug`. This means that arbitrary
+/// `OwnedValue`s may be formatted using the erased type's `fmt::Debug`
+/// implementation, _even when the erased type is no longer known_.
 pub struct OwnedValue {
     my_debug_impl: fn(&Any, &mut fmt::Formatter) -> fmt::Result,
     any: Box<dyn Any + Send + Sync>,

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -166,3 +166,54 @@ where
         OwnedValue { my_debug_impl, any }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct Foo {
+        bar: &'static str,
+    }
+
+    impl fmt::Display for Foo {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "hello, I'm {}", self.bar)
+        }
+    }
+
+    #[test]
+    fn display_value_formats_with_display() {
+        let foo = Foo { bar: "foo" };
+        let display_foo = display(foo.clone());
+
+        assert_eq!(format!("{:?}", foo), "Foo { bar: \"foo\" }".to_owned());
+        assert_eq!(format!("{:?}", display_foo), format!("{}", foo));
+    }
+
+    #[test]
+    fn display_value_is_into_value() {
+        let foo = Foo { bar: "foo" };
+        let display_foo = display(foo.clone());
+
+        let owned_value: OwnedValue = display_foo.into_value();
+        assert_eq!(format!("{:?}", owned_value), format!("{}", foo));
+    }
+
+    #[test]
+    fn display_value_downcasts_to_original_type() {
+        let foo = Foo { bar: "foo" };
+        let display_foo = display(foo);
+
+        let owned_value: OwnedValue = display_foo.into_value();
+        assert!(owned_value.downcast_ref::<Foo>().is_some());
+    }
+
+    #[test]
+    fn owned_value_downcasts_to_original_type() {
+        let foo = Foo { bar: "foo" };
+
+        let owned_value: OwnedValue = foo.into_value();
+        assert!(owned_value.downcast_ref::<Foo>().is_some());
+    }
+}

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -1,0 +1,33 @@
+use std::{any::Any, fmt};
+
+pub trait Value: fmt::Debug + Send + Sync { }
+
+pub trait OwnedValue: Value + Any {
+}
+
+impl<T> Value for T
+where
+    T: fmt::Debug + Send + Sync,
+{
+
+}
+
+pub trait Duplicate: Value {
+    // like `Clone`, but "different"
+    fn duplicate(&self) -> Box<dyn OwnedValue>;
+}
+
+impl<T> OwnedValue for T
+where
+    T: Any + Value,
+{ }
+
+impl<T> Duplicate for T
+where
+    T: Value + ToOwned,
+    <T as ToOwned>::Owned: OwnedValue,
+{
+    fn duplicate(&self) -> Box<dyn OwnedValue> {
+        Box::new(self.to_owned())
+    }
+}

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -1,8 +1,10 @@
+//! Arbitrarily typed field values.
 use std::{any::Any, borrow::Borrow, fmt};
 
+/// A formattable field value of an erased type.
 pub trait Value: fmt::Debug + Send + Sync {}
 
-/// An owned, dynamically-typed value.
+/// An owned value of an erased type.
 ///
 /// Like `Any`, references to `OwnedValue` may attempt to downcast the value to
 /// a concrete type. However, unlike `Any`, `OwnedValue`s are constructed from
@@ -16,30 +18,36 @@ pub struct OwnedValue {
 
 impl<T> Value for T where T: fmt::Debug + Send + Sync {}
 
-// TODO: should `IntoValue` also be `Value`?
-pub trait IntoValue {
+/// Trait representing a value which may be converted into an `OwnedValue`.
+///
+/// References to types implementing `IntoValue` may be formatted (as `Value`s),
+/// _or_ may be converted into owned `OwnedValue`s. In addition to being owned,
+/// instances of `OwnedValue` may also be downcast to their original erased type.
+pub trait IntoValue: Value {
     // like `Clone`, but "different"
     fn into_value(&self) -> OwnedValue;
 }
 
 impl<T, V> IntoValue for T
 where
-    T: ToOwned<Owned = V>,
+    T: ToOwned<Owned = V> + Value,
     V: Borrow<T> + Value + 'static,
 {
     fn into_value(&self) -> OwnedValue {
         let any: Box<dyn Any + Send + Sync> = Box::new(self.to_owned());
-        debug_assert!(any.as_ref().downcast_ref::<V>().is_some());
-        // I'll just make the damn vtable *myself*!
+        debug_assert!(
+            any.as_ref().downcast_ref::<V>().is_some(),
+            "Box<Any> must be downcastable for OwnedValue to work",
+        );
+        // This closure "remembers" the original type `V` before it is erased, and
+        // can thus format the `Any` by downcasting it back to `V` and calling
+        // `V`'s debug impl.
         let my_debug_impl = |me: &Any, f: &mut fmt::Formatter| {
-            let me = me.downcast_ref::<V>()
-                .expect("type should downcast to its pre-erasure type");
-            fmt::Debug::fmt(me, f)
+            me.downcast_ref::<V>()
+                .expect("type should downcast to its pre-erasure type")
+                .fmt(f)
         };
-        OwnedValue {
-            my_debug_impl,
-            any,
-        }
+        OwnedValue { my_debug_impl, any }
     }
 }
 

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -2,8 +2,7 @@ use std::{any::Any, fmt};
 
 pub trait Value: fmt::Debug + Send + Sync { }
 
-pub trait OwnedValue: Value + Any {
-}
+pub struct OwnedValue(Box<dyn Any + Send + Sync>);
 
 impl<T> Value for T
 where
@@ -13,20 +12,33 @@ where
 // TODO: should `IntoValue` also be `Value`?
 pub trait IntoValue {
     // like `Clone`, but "different"
-    fn into_value(&self) -> Box<dyn OwnedValue>;
+    fn into_value(&self) -> OwnedValue;
 }
-
-impl<T> OwnedValue for T
-where
-    T: Any + Value,
-{ }
 
 impl<T> IntoValue for T
 where
     T: ToOwned,
-    <T as ToOwned>::Owned: OwnedValue,
+    <T as ToOwned>::Owned: Value + 'static,
 {
-    fn into_value(&self) -> Box<dyn OwnedValue> {
-        Box::new(self.to_owned())
+    fn into_value(&self) -> OwnedValue {
+        OwnedValue(Box::new(self.to_owned()))
+    }
+}
+
+impl OwnedValue {
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
+}
+
+impl fmt::Debug for OwnedValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let this = unsafe {
+            // An impl of `Debug` for the boxed type is known to exist, because
+            // the `OwnedValue` constructor requires a type implementing
+            // `Debug`.
+            ::std::mem::transmute::<&dyn Any, &dyn fmt::Debug>(self.0.as_ref())
+        };
+        fmt::Debug::fmt(this, f)
     }
 }

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -8,13 +8,12 @@ pub trait OwnedValue: Value + Any {
 impl<T> Value for T
 where
     T: fmt::Debug + Send + Sync,
-{
+{ }
 
-}
-
-pub trait Duplicate: Value {
+// TODO: should `IntoValue` also be `Value`?
+pub trait IntoValue {
     // like `Clone`, but "different"
-    fn duplicate(&self) -> Box<dyn OwnedValue>;
+    fn into_value(&self) -> Box<dyn OwnedValue>;
 }
 
 impl<T> OwnedValue for T
@@ -22,12 +21,12 @@ where
     T: Any + Value,
 { }
 
-impl<T> Duplicate for T
+impl<T> IntoValue for T
 where
-    T: Value + ToOwned,
+    T: ToOwned,
     <T as ToOwned>::Owned: OwnedValue,
 {
-    fn duplicate(&self) -> Box<dyn OwnedValue> {
+    fn into_value(&self) -> Box<dyn OwnedValue> {
         Box::new(self.to_owned())
     }
 }

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -1,17 +1,13 @@
-use std::{any::Any, fmt, borrow::Borrow};
+use std::{any::Any, borrow::Borrow, fmt};
 
-pub trait Value: fmt::Debug + Send + Sync { }
+pub trait Value: fmt::Debug + Send + Sync {}
 
 pub struct OwnedValue {
     my_debug_impl: fn(&(), &mut fmt::Formatter) -> fmt::Result,
     any: Box<dyn Any + Send + Sync>,
 }
 
-
-impl<T> Value for T
-where
-    T: fmt::Debug + Send + Sync,
-{ }
+impl<T> Value for T where T: fmt::Debug + Send + Sync {}
 
 // TODO: should `IntoValue` also be `Value`?
 pub trait IntoValue {
@@ -47,9 +43,7 @@ impl OwnedValue {
 
 impl fmt::Debug for OwnedValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let me = unsafe {
-            &*(self.any.as_ref() as *const _ as *const ())
-        };
+        let me = unsafe { &*(self.any.as_ref() as *const _ as *const ()) };
         (self.my_debug_impl)(me, f)
     }
 }

--- a/tokio-trace/src/value.rs
+++ b/tokio-trace/src/value.rs
@@ -47,6 +47,10 @@ impl OwnedValue {
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         self.any.downcast_ref()
     }
+
+    pub fn is<T: Any>(&self) -> bool {
+        self.any.is::<T>()
+    }
 }
 
 impl fmt::Debug for OwnedValue {


### PR DESCRIPTION
The current representation of values for span and event fields has some
significant issues:
+ It always allocates span values on the heap, even when the subscriber
  immediately discards them,
+ It completely erases the original type of the value, and treats it
  as a `fmt::Debug` trait object,
+ Values implementing both `Display` and `Debug` are always formatted
  using `Debug`, while values implementing only `Display` cannot be
  created.
  
However, representing values as trait objects does have one significant
advantage: it allows arbitrary user-defined types to be used as values,
rather than restricting them to a set of Rust primitives. While this is
not _strictly_ necessary, it is nice to allow complex user-defined
types to be treated as field values. 

This is especially worth considering since other logging libraries make
this extremely easy, by using the `fmt::*` implementations of those
types. Not allowing this, and instead requiring users to destructure
their types into fields, increases the overhead of transitioning to
`tokio-trace` --- especially in cases such as when a library provides
opaque newtypes which can be formatted but not converted back into
primitives.

This branch improves the representation of values significantly in the
following ways:
+ Values may now be downcast to their original types, similarly to
  `std::error::Error`. This gives subscribers the ability to do more
  with values than just formatting them with the debug formatter.
+ It is now possible to create a value which will be formatted using
  `fmt::Display`, as well as `fmt::Debug`.
+ Values are now only allocated on the heap when a subscriber 
  explicitly choses to do so.
+ In addition, span values may now be added after when a span is 
  created (see #26).

Closes #26. Closes #12.

See also: #25, #32.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>