### PR TITLE
Add trait methods for `follows_from`

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -194,13 +194,15 @@ impl Subscriber for TraceLogger {
         Ok(())
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) {
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
+        // TODO: this should eventually track the relationship?
         log::logger().log(
             &log::Record::builder()
                 .level(log::Level::Trace)
                 .args(format_args!("span {:?} follows_from={:?};", span, follows))
                 .build(),
         );
+        Ok(())
     }
 
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -194,6 +194,15 @@ impl Subscriber for TraceLogger {
         Ok(())
     }
 
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) {
+        log::logger().log(
+            &log::Record::builder()
+                .level(log::Level::Trace)
+                .args(format_args!("span {:?} follows_from={:?};", span, follows))
+                .build(),
+        );
+    }
+
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
         let meta = event.meta.as_log();
         let logger = log::logger();

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -194,7 +194,11 @@ impl Subscriber for TraceLogger {
         Ok(())
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
+    fn add_follows_from(
+        &self,
+        span: &span::Id,
+        follows: span::Id,
+    ) -> Result<(), subscriber::FollowsFromError> {
         // TODO: this should eventually track the relationship?
         log::logger().log(
             &log::Record::builder()

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -194,11 +194,11 @@ impl Subscriber for TraceLogger {
         Ok(())
     }
 
-    fn add_follows_from(
+    fn add_prior_span(
         &self,
         span: &span::Id,
         follows: span::Id,
-    ) -> Result<(), subscriber::FollowsFromError> {
+    ) -> Result<(), subscriber::PriorError> {
         // TODO: this should eventually track the relationship?
         log::logger().log(
             &log::Record::builder()

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -116,7 +116,7 @@ where
         self.registry.add_value(span, name, value)
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsFromError>  {
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsFromError> {
         self.registry.add_follows_from(span, follows)
     }
 

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     span,
-    subscriber::{AddValueError, Subscriber},
+    subscriber::{AddValueError, FollowsFromError, Subscriber},
     Event, IntoValue, Meta, SpanData,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
@@ -116,7 +116,7 @@ where
         self.registry.add_value(span, name, value)
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) {
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsFromError>  {
         self.registry.add_follows_from(span, follows)
     }
 

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     span,
-    subscriber::{AddValueError, FollowsFromError, Subscriber},
+    subscriber::{AddValueError, PriorError, Subscriber},
     Event, IntoValue, Meta, SpanData,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
@@ -116,8 +116,8 @@ where
         self.registry.add_value(span, name, value)
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsFromError> {
-        self.registry.add_follows_from(span, follows)
+    fn add_prior_span(&self, span: &span::Id, follows: span::Id) -> Result<(), PriorError> {
+        self.registry.add_prior_span(span, follows)
     }
 
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -116,6 +116,10 @@ where
         self.registry.add_value(span, name, value)
     }
 
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) {
+        self.registry.add_follows_from(span, follows)
+    }
+
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
         self.observer.observe_event(event)
     }

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     span::{Data, Id, State},
-    subscriber::AddValueError,
+    subscriber::{AddValueError, FollowsFromError},
     value::{IntoValue, OwnedValue},
 };
 
@@ -48,7 +48,7 @@ pub trait RegisterSpan {
     ) -> Result<(), AddValueError>;
 
     /// Indicates that `span` follows from `follows.
-    fn add_follows_from(&self, span: &Id, follows: Id);
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsFromError>;
 
     /// Queries the registry for an iterator over the IDs of the spans that
     /// `span` follows from.
@@ -135,8 +135,9 @@ impl RegisterSpan for IncreasingCounter {
         span.add_value(name, value)
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) {
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsFromError> {
         // unimplemented
+        Ok(())
     }
 
     fn get_follows_from(&self, span: &Id) -> Self::FollowsFrom {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -20,7 +20,7 @@ use std::{
 /// Implementations of this trait represent the logic run on span creation. They
 /// handle span ID generation.
 pub trait RegisterSpan {
-    type FollowsFrom: Iterator<Item=Id>;
+    type FollowsFrom: Iterator<Item = Id>;
 
     /// Record the construction of a new [`Span`], returning a a new [span ID] for
     /// the span being constructed.

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -44,6 +44,8 @@ pub trait RegisterSpan {
         value: &dyn IntoValue,
     ) -> Result<(), AddValueError>;
 
+    fn add_follows_from(&self, span: &Id, follows: Id);
+
     fn with_span<F>(&self, id: &Id, state: State, f: F)
     where
         F: for<'a> Fn(&'a SpanRef<'a>);
@@ -121,6 +123,10 @@ impl RegisterSpan for IncreasingCounter {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans.get_mut(span).ok_or(AddValueError::NoSpan)?;
         span.add_value(name, value)
+    }
+
+    fn add_follows_from(&self, span: &Id, follows: Id) {
+        // unimplemented
     }
 
     fn with_span<F>(&self, id: &Id, state: State, f: F)

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -53,8 +53,9 @@ impl Subscriber for CounterSubscriber {
             .add_value(name, value)
     }
 
-    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) {
+    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
         // unimplemented
+        Ok(())
     }
 
     fn enabled(&self, metadata: &Meta) -> bool {

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -53,6 +53,10 @@ impl Subscriber for CounterSubscriber {
             .add_value(name, value)
     }
 
+    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) {
+        // unimplemented
+    }
+
     fn enabled(&self, metadata: &Meta) -> bool {
         metadata.is_span() && metadata
             .field_names

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -53,11 +53,11 @@ impl Subscriber for CounterSubscriber {
             .add_value(name, value)
     }
 
-    fn add_follows_from(
+    fn add_prior_span(
         &self,
         _span: &span::Id,
         _follows: span::Id,
-    ) -> Result<(), subscriber::FollowsFromError> {
+    ) -> Result<(), subscriber::PriorError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -53,7 +53,11 @@ impl Subscriber for CounterSubscriber {
             .add_value(name, value)
     }
 
-    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
+    fn add_follows_from(
+        &self,
+        _span: &span::Id,
+        _follows: span::Id,
+    ) -> Result<(), subscriber::FollowsFromError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -126,6 +126,10 @@ impl Subscriber for SloggishSubscriber {
         span.add_value(name, value)
     }
 
+    fn add_follows_from(&self, _span: &tokio_trace::SpanId, _follows: tokio_trace::SpanId) {
+        // unimplemented
+    }
+
     #[inline]
     fn observe_event<'event, 'meta: 'event>(
         &self,

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -126,7 +126,11 @@ impl Subscriber for SloggishSubscriber {
         span.add_value(name, value)
     }
 
-    fn add_follows_from(&self, _span: &tokio_trace::SpanId, _follows: tokio_trace::SpanId) -> Result<(), subscriber::FollowsFromError> {
+    fn add_follows_from(
+        &self,
+        _span: &tokio_trace::SpanId,
+        _follows: tokio_trace::SpanId,
+    ) -> Result<(), subscriber::FollowsFromError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -126,8 +126,9 @@ impl Subscriber for SloggishSubscriber {
         span.add_value(name, value)
     }
 
-    fn add_follows_from(&self, _span: &tokio_trace::SpanId, _follows: tokio_trace::SpanId) {
+    fn add_follows_from(&self, _span: &tokio_trace::SpanId, _follows: tokio_trace::SpanId) -> Result<(), subscriber::FollowsFromError> {
         // unimplemented
+        Ok(())
     }
 
     #[inline]

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -126,11 +126,11 @@ impl Subscriber for SloggishSubscriber {
         span.add_value(name, value)
     }
 
-    fn add_follows_from(
+    fn add_prior_span(
         &self,
         _span: &tokio_trace::SpanId,
         _follows: tokio_trace::SpanId,
-    ) -> Result<(), subscriber::FollowsFromError> {
+    ) -> Result<(), subscriber::PriorError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -98,12 +98,12 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_follows_from(
+    fn add_prior_span(
         &self,
         span: &span::Id,
         follows: span::Id,
-    ) -> Result<(), subscriber::FollowsFromError> {
-        self.0.add_follows_from(span, follows)
+    ) -> Result<(), subscriber::PriorError> {
+        self.0.add_prior_span(span, follows)
     }
 
     #[inline]
@@ -143,11 +143,11 @@ impl Subscriber for NoSubscriber {
         Ok(())
     }
 
-    fn add_follows_from(
+    fn add_prior_span(
         &self,
         _span: &span::Id,
         _follows: span::Id,
-    ) -> Result<(), subscriber::FollowsFromError> {
+    ) -> Result<(), subscriber::PriorError> {
         Ok(())
     }
 

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -98,6 +98,11 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) {
+        self.0.add_follows_from(span, follows)
+    }
+
+    #[inline]
     fn enabled(&self, metadata: &Meta) -> bool {
         self.0.enabled(metadata)
     }
@@ -132,6 +137,10 @@ impl Subscriber for NoSubscriber {
         _value: &dyn IntoValue,
     ) -> Result<(), subscriber::AddValueError> {
         Ok(())
+    }
+
+    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) {
+
     }
 
     fn enabled(&self, _metadata: &Meta) -> bool {

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -98,7 +98,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) {
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
         self.0.add_follows_from(span, follows)
     }
 
@@ -139,8 +139,8 @@ impl Subscriber for NoSubscriber {
         Ok(())
     }
 
-    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) {
-
+    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
+        Ok(())
     }
 
     fn enabled(&self, _metadata: &Meta) -> bool {

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -98,7 +98,11 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
+    fn add_follows_from(
+        &self,
+        span: &span::Id,
+        follows: span::Id,
+    ) -> Result<(), subscriber::FollowsFromError> {
         self.0.add_follows_from(span, follows)
     }
 
@@ -139,7 +143,11 @@ impl Subscriber for NoSubscriber {
         Ok(())
     }
 
-    fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), subscriber::FollowsFromError> {
+    fn add_follows_from(
+        &self,
+        _span: &span::Id,
+        _follows: span::Id,
+    ) -> Result<(), subscriber::FollowsFromError> {
         Ok(())
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -9,7 +9,7 @@ use std::{
     },
 };
 use {
-    subscriber::{AddValueError, FollowsFromError, Subscriber},
+    subscriber::{AddValueError, PriorError, Subscriber},
     value::{IntoValue, OwnedValue},
     DebugFields, Dispatch, StaticMeta,
 };
@@ -253,13 +253,13 @@ impl Span {
         }
     }
 
-    pub fn follows<I: AsId>(&self, from: I) -> Result<(), FollowsFromError> {
+    pub fn proceeds<I: AsId>(&self, from: I) -> Result<(), PriorError> {
         if let Some(ref inner) = self.inner {
-            let from_id = from.as_id().ok_or(FollowsFromError::NoPreceedingId)?;
+            let from_id = from.as_id().ok_or(PriorError::NoPreceedingId)?;
             let inner = &inner.inner;
-            match inner.subscriber.add_follows_from(&inner.id, from_id) {
+            match inner.subscriber.add_prior_span(&inner.id, from_id) {
                 Ok(()) => Ok(()),
-                Err(FollowsFromError::NoSpan(ref id)) if id == &inner.id => {
+                Err(PriorError::NoSpan(ref id)) if id == &inner.id => {
                     panic!("span {:?} should exist to add a preceeding span", inner.id)
                 }
                 Err(e) => Err(e),

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -257,12 +257,11 @@ impl Span {
         if let Some(ref inner) = self.inner {
             let from_id = from.as_id().ok_or(FollowsFromError::NoPreceedingId)?;
             let inner = &inner.inner;
-            match inner.subscriber
-                .add_follows_from(&inner.id, from_id)
-            {
+            match inner.subscriber.add_follows_from(&inner.id, from_id) {
                 Ok(()) => Ok(()),
-                Err(FollowsFromError::NoSpan(ref id)) if id == &inner.id =>
-                    panic!("span {:?} should exist to add a preceeding span", inner.id),
+                Err(FollowsFromError::NoSpan(ref id)) if id == &inner.id => {
+                    panic!("span {:?} should exist to add a preceeding span", inner.id)
+                }
                 Err(e) => Err(e),
             }
         } else {
@@ -420,7 +419,6 @@ impl AsId for Id {
         Some(self.clone())
     }
 }
-
 
 // ===== impl Active =====
 

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -114,7 +114,6 @@ pub enum FollowsFromError {
     NoPreceedingId,
 }
 
-
 #[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::*;
 
@@ -208,7 +207,11 @@ mod test_support {
             Ok(())
         }
 
-        fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), FollowsFromError> {
+        fn add_follows_from(
+            &self,
+            _span: &span::Id,
+            _follows: span::Id,
+        ) -> Result<(), FollowsFromError> {
             // TODO: it should be possible to expect spans to follow from other spans
             Ok(())
         }

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -38,6 +38,8 @@ pub trait Subscriber {
         value: &dyn IntoValue,
     ) -> Result<(), AddValueError>;
 
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id);
+
     // === Filtering methods ==================================================
 
     /// Determines if a span or event with the specified metadata would be recorded.
@@ -189,6 +191,10 @@ mod test_support {
         ) -> Result<(), AddValueError> {
             // TODO: it should be possible to expect values...
             Ok(())
+        }
+
+        fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) {
+            // TODO: it should be possible to expect spans to follow from other spans
         }
 
         fn new_span(&self, span: SpanData) -> span::Id {

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -38,7 +38,7 @@ pub trait Subscriber {
         value: &dyn IntoValue,
     ) -> Result<(), AddValueError>;
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsFromError>;
+    fn add_prior_span(&self, span: &span::Id, follows: span::Id) -> Result<(), PriorError>;
 
     // === Filtering methods ==================================================
 
@@ -105,9 +105,9 @@ pub enum AddValueError {
 // TODO: before releasing core 0.1 this needs to be made private, to avoid
 // future breaking changes.
 #[derive(Clone, Debug)]
-pub enum FollowsFromError {
+pub enum PriorError {
     /// The span with the given ID does not exist.
-    /// TODO: can this error type be generalized between `FollowsFromError` and
+    /// TODO: can this error type be generalized between `PriorError` and
     /// `AddValueError`?
     NoSpan(SpanId),
     /// The span that this span follows from does not exist (it has no ID).
@@ -207,11 +207,11 @@ mod test_support {
             Ok(())
         }
 
-        fn add_follows_from(
+        fn add_prior_span(
             &self,
             _span: &span::Id,
             _follows: span::Id,
-        ) -> Result<(), FollowsFromError> {
+        ) -> Result<(), PriorError> {
             // TODO: it should be possible to expect spans to follow from other spans
             Ok(())
         }

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -38,7 +38,7 @@ pub trait Subscriber {
         value: &dyn IntoValue,
     ) -> Result<(), AddValueError>;
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id);
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsFromError>;
 
     // === Filtering methods ==================================================
 
@@ -90,6 +90,8 @@ pub trait Subscriber {
     fn exit(&self, span: SpanId, state: span::State);
 }
 
+// TODO: before releasing core 0.1 this needs to be made private, to avoid
+// future breaking changes.
 #[derive(Clone, Debug)]
 pub enum AddValueError {
     /// The span with the given ID does not exist.
@@ -99,6 +101,19 @@ pub enum AddValueError {
     /// The named field already has a value.
     FieldAlreadyExists,
 }
+
+// TODO: before releasing core 0.1 this needs to be made private, to avoid
+// future breaking changes.
+#[derive(Clone, Debug)]
+pub enum FollowsFromError {
+    /// The span with the given ID does not exist.
+    /// TODO: can this error type be generalized between `FollowsFromError` and
+    /// `AddValueError`?
+    NoSpan(SpanId),
+    /// The span that this span follows from does not exist (it has no ID).
+    NoPreceedingId,
+}
+
 
 #[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::*;
@@ -193,8 +208,9 @@ mod test_support {
             Ok(())
         }
 
-        fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) {
+        fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), FollowsFromError> {
             // TODO: it should be possible to expect spans to follow from other spans
+            Ok(())
         }
 
         fn new_span(&self, span: SpanData) -> span::Id {


### PR DESCRIPTION
This branch adds `Subscriber` and `Span` methods for annotating spans
with prior spans from which they follow. For the most part, this branch
doesn't add implementations of this interface for now, besides proxying
to it in composite subscribers.

It would be good to get a review of the interface before getting too deep 
into implementation.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>