### PR TITLE
Start running rustfmt on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: rust
-script: cargo test --all
+sudo: false
+
+jobs:
+  include:
+  - stage: test
+    script: cargo test --all
+    name: "tests"
+  - script: cargo fmt --all -- --check
+    install: rustup component add rustfmt-preview
+    name: "rustfmt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ jobs:
     script: cargo test --all
     name: "tests"
   - script: cargo fmt --all -- --check
-    install: rustup component add rustfmt-preview --toolchain nightly
+    install: rustup component add rustfmt-preview
     name: "rustfmt"
-    rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ jobs:
     script: cargo test --all
     name: "tests"
   - script: cargo fmt --all -- --check
-    install: rustup component add rustfmt-preview
+    install: rustup component add rustfmt-preview --toolchain nightly
     name: "rustfmt"
+    rust: nightly

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -564,20 +564,15 @@ mod tests {
             .enter(span::mock().named(Some("bar")))
             // The first time we exit "bar", there will be another handle with
             // which we could potentially re-enter bar.
-            .exit(span::mock().named(Some("bar"))
-                .with_state(State::Idle))
+            .exit(span::mock().named(Some("bar")).with_state(State::Idle))
             // Re-enter "bar", using the cloned handle.
             .enter(span::mock().named(Some("bar")))
             // Now, when we exit "bar", there is no handle to re-enter it, so
             // it should become "done".
-            .exit(span::mock().named(Some("bar"))
-                .with_state(State::Done)
-            )
+            .exit(span::mock().named(Some("bar")).with_state(State::Done))
             // "foo" never had more than one handle, so it should also become
             // "done" when we exit it.
-            .exit(span::mock().named(Some("foo"))
-                .with_state(State::Done)
-            )
+            .exit(span::mock().named(Some("foo")).with_state(State::Done))
             .run();
 
         Dispatch::to(subscriber).with(|| {
@@ -609,18 +604,13 @@ mod tests {
             .enter(span::mock().named(Some("quux")))
             // When the main thread exits "quux", it will still be running in the
             // spawned thread.
-            .exit(span::mock().named(Some("quux"))
-                .with_state(State::Running))
+            .exit(span::mock().named(Some("quux")).with_state(State::Running))
             // Now, when this thread exits "quux", there is no handle to re-enter it, so
             // it should become "done".
-            .exit(span::mock().named(Some("quux"))
-                .with_state(State::Done)
-            )
+            .exit(span::mock().named(Some("quux")).with_state(State::Done))
             // "baz" never had more than one handle, so it should also become
             // "done" when we exit it.
-            .exit(span::mock().named(Some("baz"))
-                .with_state(State::Done)
-            )
+            .exit(span::mock().named(Some("baz")).with_state(State::Done))
             .run();
 
         Dispatch::to(subscriber).with(|| {


### PR DESCRIPTION
This branch adds a rustfmt stage to the `tokio-trace` CI job. It's run
in a separate stage from the tests so that Travis' UI makes it clearer
whether the rustfmt check or the tests are failing. 

Note that this runs with the _stable_ rustfmt. This means that if you
run the nightly rustfmt, you may get formatting that's inconsistent with
what CI expects. I decided to go with stable here as its formatting will
change less frequently, so we don't get a constantly-broken CI build as
a result of not running `rustup update rustfmt` every morning.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>