### PR TITLE
Fix tokio-trace-futures tests not actually doing anything

### DIFF
--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -225,11 +225,7 @@ mod test_support {
             Ok(())
         }
 
-        fn add_prior_span(
-            &self,
-            _span: &span::Id,
-            _follows: span::Id,
-        ) -> Result<(), PriorError> {
+        fn add_prior_span(&self, _span: &span::Id, _follows: span::Id) -> Result<(), PriorError> {
             // TODO: it should be possible to expect spans to follow from other spans
             Ok(())
         }


### PR DESCRIPTION
This fixes an issue where the tests in the `tokio-trace-futures` crate
weren't actually making any assertions. 

`MockSubscriber::run()` _used_ to set the mock subscriber as the current
subscriber, but that behaviour changed in #40. Now, it's necessary to
use `Dispatch::to(...).with(...)` to set the subscriber context. The
tests in the core crate were updated, but the `tokio-trace-futures`
tests evidentally weren't.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>