### PR TITLE
Make the dispatcher sticky

### DIFF
--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -122,7 +122,7 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
     tokio_trace_env_logger::try_init().expect("init log adapter");
 
-    tokio_trace::Dispatch::to(subscriber).with(|| {
+    tokio_trace::Dispatch::to(subscriber).as_default(|| {
         let addr: ::std::net::SocketAddr = ([127, 0, 0, 1], 3000).into();
         let server_span = span!("server", local = &addr);
         server_span.clone().enter(|| {

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -114,7 +114,7 @@ impl<T: Future> Future for WithDispatch<T> {
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let dispatch = &self.dispatch;
         let inner = &mut self.inner;
-        dispatch.with(|| inner.poll())
+        dispatch.as_default(|| inner.poll())
     }
 }
 
@@ -164,7 +164,7 @@ mod tests {
                     .named(Some("foo"))
                     .with_state(span::State::Done),
             ).run();
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
                 .wait()
@@ -203,7 +203,7 @@ mod tests {
                     .named(Some("foo"))
                     .with_state(span::State::Idle),
             ).run();
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             let foo = span!("foo");
             MyFuture { polls: 0 }
                 .instrument(foo.clone())
@@ -243,7 +243,7 @@ mod tests {
                     .named(Some("foo"))
                     .with_state(span::State::Done),
             ).run();
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
                 .wait()
@@ -275,7 +275,7 @@ mod tests {
                     .named(Some("foo"))
                     .with_state(span::State::Done),
             ).run();
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             stream::iter_ok::<_, ()>(&[1, 2, 3])
                 .instrument(span!("foo"))
                 .for_each(|_| future::ok(()))

--- a/tokio-trace-macros/examples/basic.rs
+++ b/tokio-trace-macros/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::new();
 
-    tokio_trace::Dispatch::to(subscriber).with(|| {
+    tokio_trace::Dispatch::to(subscriber).as_default(|| {
         let num = 1;
 
         let span = span!("Getting rec from another function.", number_of_recs = &num);

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -84,7 +84,7 @@ pub trait FilterExt: Filter {
     ///     .with_registry(tokio_trace_subscriber::registry::increasing_counter())
     ///     .with_filter(name_filter.and(mod_filter));
     ///
-    /// tokio_trace::Dispatch::to(subscriber).with(|| {
+    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
     ///     foo();
     ///     my_module::foo();
     ///     my_module::bar();

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -67,7 +67,7 @@ pub trait ObserveExt: Observe {
     ///     .with_observer(observer)
     ///     .with_registry(registry::increasing_counter());
     ///
-    /// tokio_trace::Dispatch::to(subscriber).with(|| {
+    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
     ///     // This span will be seen by both `foo` and `bar`.
     ///     span!("my great span").enter(|| {
     ///         // ...
@@ -114,7 +114,7 @@ pub trait ObserveExt: Observe {
     ///     .with_observer(observer)
     ///     .with_registry(registry::increasing_counter());
     ///
-    /// tokio_trace::Dispatch::to(subscriber).with(|| {
+    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
     ///     /// // This span will be logged.
     ///     span!("foo", enabled = &true) .enter(|| {
     ///         // do work;

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -108,7 +108,7 @@ impl NewService for NewSvc {
 fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
-    tokio_trace::Dispatch::to(subscriber).with(|| {
+    tokio_trace::Dispatch::to(subscriber).as_default(|| {
         let mut rt = Runtime::new().unwrap();
         let reactor = rt.executor();
 

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -9,7 +9,7 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::new();
 
-    tokio_trace::Dispatch::to(subscriber).with(|| {
+    tokio_trace::Dispatch::to(subscriber).as_default(|| {
         let foo = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -118,7 +118,7 @@ impl Counters {
 fn main() {
     let (counters, subscriber) = Counters::new();
 
-    tokio_trace::Dispatch::to(subscriber).with(|| {
+    tokio_trace::Dispatch::to(subscriber).as_default(|| {
         let mut foo: usize = 2;
         span!("my_great_span", foo_count = &foo).enter(|| {
             foo += 1;

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -21,7 +21,7 @@ use self::sloggish_subscriber::SloggishSubscriber;
 fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
-    tokio_trace::Dispatch::to(subscriber).with(|| {
+    tokio_trace::Dispatch::to(subscriber).as_default(|| {
         span!("", version = &5.0).enter(|| {
             span!("server", host = &"localhost", port = &8080).enter(|| {
                 event!(Level::Info, {}, "starting");

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -1,5 +1,5 @@
 use {
-    span,
+    span::{self, Span},
     subscriber::{self, Subscriber},
     Event, IntoValue, Meta,
 };
@@ -7,6 +7,7 @@ use {
 use std::{
     cell::RefCell,
     collections::{hash_map::DefaultHasher, HashSet},
+    default::Default,
     fmt,
     hash::{Hash, Hasher},
     sync::Arc,
@@ -30,7 +31,7 @@ impl Dispatch {
     }
 
     pub fn current() -> Dispatch {
-        CURRENT_DISPATCH.with(|current| current.borrow().dispatch.clone())
+        Span::current().dispatch().cloned().unwrap_or_default()
     }
 
     pub fn to<S>(subscriber: S) -> Self
@@ -64,6 +65,12 @@ impl Dispatch {
 impl fmt::Debug for Dispatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("Dispatch(...)")
+    }
+}
+
+impl Default for Dispatch {
+    fn default() -> Self {
+        CURRENT_DISPATCH.with(|current| current.borrow().dispatch.clone())
     }
 }
 

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -196,7 +196,8 @@ mod tests {
             foo.clone().enter(|| {});
             foo
         });
-        Dispatch::to(subscriber::mock().run()).as_default(move || foo.enter(|| span!("bar").enter(|| {})))
+        Dispatch::to(subscriber::mock().run())
+            .as_default(move || foo.enter(|| span!("bar").enter(|| {})))
     }
 
     #[test]

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -173,8 +173,11 @@ impl Subscriber for NoSubscriber {
 
 #[cfg(test)]
 mod tests {
-    use ::{subscriber, span::{self, State}};
     use super::*;
+    use {
+        span::{self, State},
+        subscriber,
+    };
 
     #[test]
     fn dispatcher_is_sticky() {
@@ -193,11 +196,7 @@ mod tests {
             foo.clone().enter(|| {});
             foo
         });
-        Dispatch::to(subscriber::mock().run()).with(move || {
-            foo.enter(|| {
-                span!("bar").enter(|| {})
-            })
-        })
+        Dispatch::to(subscriber::mock().run()).with(move || foo.enter(|| span!("bar").enter(|| {})))
     }
 
     #[test]
@@ -224,16 +223,10 @@ mod tests {
             foo.clone().enter(|| {});
             foo
         });
-        let baz = Dispatch::to(subscriber2).with(|| {
-            span!("baz")
-        });
+        let baz = Dispatch::to(subscriber2).with(|| span!("baz"));
         Dispatch::to(subscriber::mock().run()).with(move || {
-            foo.enter(|| {
-                span!("bar").enter(|| {})
-            });
-            baz.enter(|| {
-                span!("quux").enter(|| {})
-            })
+            foo.enter(|| span!("bar").enter(|| {}));
+            baz.enter(|| span!("quux").enter(|| {}))
         })
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -223,6 +223,12 @@ impl Span {
         }
     }
 
+    /// Returns a reference to the dispatcher that tracks this span, or `None`
+    /// if the span is disabled.
+    pub(crate) fn dispatch(&self) -> Option<&Dispatch> {
+        self.inner.as_ref().map(|inner| &inner.inner.subscriber)
+    }
+
     pub fn enter<F: FnOnce() -> T, T>(self, f: F) -> T {
         match self.inner {
             Some(inner) => inner.enter(f),

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -629,7 +629,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")).with_state(State::Done))
             .run();
 
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             span!("foo",).enter(|| {
                 let bar = span!("bar",);
                 bar.clone().enter(|| {
@@ -667,7 +667,7 @@ mod tests {
             .exit(span::mock().named(Some("baz")).with_state(State::Done))
             .run();
 
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             let barrier1 = Arc::new(Barrier::new(2));
             let barrier2 = Arc::new(Barrier::new(2));
             // Make copies of the barriers for thread 2 to wait on.
@@ -707,7 +707,7 @@ mod tests {
         // `Subscriber::enabled`, so that the spans will be constructed. We
         // won't enter any spans in this test, so the subscriber won't actually
         // expect to see any spans.
-        Dispatch::to(subscriber::mock().run()).with(|| {
+        Dispatch::to(subscriber::mock().run()).as_default(|| {
             let foo1 = span!("foo");
             let foo2 = foo1.clone();
 
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn handles_to_different_spans_are_not_equal() {
-        Dispatch::to(subscriber::mock().run()).with(|| {
+        Dispatch::to(subscriber::mock().run()).as_default(|| {
             // Even though these spans have the same name and fields, they will have
             // differing metadata, since they were created on different lines.
             let foo1 = span!("foo", bar = &1, baz = &false);
@@ -740,7 +740,7 @@ mod tests {
             span!("foo", bar = &1, baz = &false)
         }
 
-        Dispatch::to(subscriber::mock().run()).with(|| {
+        Dispatch::to(subscriber::mock().run()).as_default(|| {
             let foo1 = make_span();
             let foo2 = make_span();
 
@@ -759,14 +759,14 @@ mod tests {
         let subscriber1 = Dispatch::to(subscriber1.run());
         let subscriber2 = Dispatch::to(subscriber::mock().run());
 
-        let foo = subscriber1.with(|| {
+        let foo = subscriber1.as_default(|| {
             let foo = span!("foo");
             foo.clone().enter(|| {});
             foo
         });
         // Even though we enter subscriber 2's context, the subscriber that
         // tagged the span should see the enter/exit.
-        subscriber2.with(move || foo.enter(|| {}));
+        subscriber2.as_default(move || foo.enter(|| {}));
     }
 
     #[test]
@@ -777,7 +777,7 @@ mod tests {
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")).with_state(State::Done));
         let subscriber1 = Dispatch::to(subscriber1.run());
-        let foo = subscriber1.with(|| {
+        let foo = subscriber1.as_default(|| {
             let foo = span!("foo");
             foo.clone().enter(|| {});
             foo
@@ -786,7 +786,7 @@ mod tests {
         // Even though we enter subscriber 2's context, the subscriber that
         // tagged the span should see the enter/exit.
         thread::spawn(move || {
-            Dispatch::to(subscriber::mock().run()).with(|| {
+            Dispatch::to(subscriber::mock().run()).as_default(|| {
                 foo.enter(|| {});
             })
         }).join()

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -349,7 +349,7 @@ mod tests {
                 _ => false,
             }).run();
 
-        Dispatch::to(subscriber).with(move || {
+        Dispatch::to(subscriber).as_default(move || {
             // Enter "foo" and then "bar". The dispatcher expects to see "bar" but
             // not "foo."
             let foo = span!("foo");
@@ -452,15 +452,15 @@ mod tests {
             assert_eq!(bar_count.load(Ordering::Relaxed), n);
         };
 
-        subscriber1.with(|| {
+        subscriber1.as_default(|| {
             do_test(1);
         });
 
-        subscriber2.with(|| do_test(2));
+        subscriber2.as_default(|| do_test(2));
 
-        subscriber1.with(|| do_test(3));
+        subscriber1.as_default(|| do_test(3));
 
-        subscriber2.with(|| do_test(4));
+        subscriber2.as_default(|| do_test(4));
     }
 
     #[test]
@@ -498,9 +498,9 @@ mod tests {
                 }).run();
             // barrier1.wait();
             let subscriber = Dispatch::to(subscriber);
-            subscriber.with(do_test);
+            subscriber.as_default(do_test);
             barrier1.wait();
-            subscriber.with(do_test)
+            subscriber.as_default(do_test)
         });
 
         let thread2 = thread::spawn(move || {
@@ -520,9 +520,9 @@ mod tests {
                     _ => false,
                 }).run();
             let subscriber = Dispatch::to(subscriber);
-            subscriber.with(do_test);
+            subscriber.as_default(do_test);
             barrier.wait();
-            subscriber.with(do_test)
+            subscriber.as_default(do_test)
         });
 
         // the threads have completed, but the spans should still notify their
@@ -563,7 +563,7 @@ mod tests {
                 _ => false,
             }).run();
 
-        Dispatch::to(subscriber).with(move || {
+        Dispatch::to(subscriber).as_default(move || {
             // Enter "foo" and then "bar". The dispatcher expects to see "bar" but
             // not "foo."
             let foo = span!("foo");
@@ -629,7 +629,7 @@ mod tests {
                 true
             }).run();
 
-        Dispatch::to(subscriber).with(|| {
+        Dispatch::to(subscriber).as_default(|| {
             // Call the function once. The filter should be re-evaluated.
             assert!(my_great_function());
             assert_eq!(count.load(Ordering::Relaxed), 1);


### PR DESCRIPTION
Currently, spans have a reference to the dispatcher in whose context
they were created. When those spans are entered or exited, the
enter/exit notifications are sent to that dispatcher rather than the
thread's current dispatcher.

However in the current design, when we’re inside of a given span, if we
enter a new child of that span, that span is created with the _thread's_
current dispatcher, _not_ the dispatcher for the current span's parent.
That means that if the thread's current default dispatcher changes,
parts of a trace tree can be collected by two different dispatchers.
This is a problem.

Dispatchers should be able to collect whole trace trees, as span IDs are
only expected to be meaningful within the context of a dispatcher. For
example, if a new child span is created in the context of a different
dispatcher than its parent, the child's span ID for its parent may refer
to an unrelated span in the current dispatcher's context. This would
result in the collection of an incorrect trace tree.

This branch changes this behaviour by having the `Dispatch::current`
function return the current _span_'s dispatcher, if the thread is inside
of a span. Otherwise, it returns the span's default dispatcher. An
implementation of `std::default::Default` for `Dispatch` was added that
returns the dispatcher whose context the thread is currently inside.
Futhermore, `Dispatch::with` was renamed to `Dispatch::as_default`, to
better reflect that function's behaviour.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>