### PR TITLE
Add Ergonomic event macros, closes #39 and #74.

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -139,6 +139,16 @@ impl Subscriber for Dispatch {
     fn close(&self, span: span::Id) {
         self.subscriber.close(span)
     }
+
+    #[inline]
+    fn clone_span(&self, id: span::Id) -> span::Id {
+        self.subscriber.clone_span(id)
+    }
+
+    #[inline]
+    fn drop_span(&self, id: span::Id) {
+        self.subscriber.drop_span(id)
+    }
 }
 
 struct NoSubscriber;

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -1,7 +1,7 @@
 use {
     callsite, field,
     span::{self, Span},
-    subscriber::{self, RecordError, Subscriber},
+    subscriber::{self, Subscriber},
     Id, Meta,
 };
 
@@ -102,37 +102,32 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) -> Result<(), RecordError> {
+    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) {
         self.subscriber.record_i64(span, field, value)
     }
 
     #[inline]
-    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) -> Result<(), RecordError> {
+    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) {
         self.subscriber.record_u64(span, field, value)
     }
 
     #[inline]
-    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) -> Result<(), RecordError> {
+    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) {
         self.subscriber.record_bool(span, field, value)
     }
 
     #[inline]
-    fn record_str(&self, span: &Id, field: &field::Key, value: &str) -> Result<(), RecordError> {
+    fn record_str(&self, span: &Id, field: &field::Key, value: &str) {
         self.subscriber.record_str(span, field, value)
     }
 
     #[inline]
-    fn record_fmt(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: fmt::Arguments,
-    ) -> Result<(), RecordError> {
+    fn record_fmt(&self, span: &Id, field: &field::Key, value: fmt::Arguments) {
         self.subscriber.record_fmt(span, field, value)
     }
 
     #[inline]
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         self.subscriber.add_follows_from(span, follows)
     }
 
@@ -173,18 +168,9 @@ impl Subscriber for NoSubscriber {
         Id::from_u64(0)
     }
 
-    fn record_fmt(
-        &self,
-        _span: &Id,
-        _key: &field::Key,
-        _value: fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        Ok(())
-    }
+    fn record_fmt(&self, _span: &Id, _key: &field::Key, _value: fmt::Arguments) {}
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
-        Ok(())
-    }
+    fn add_follows_from(&self, _span: &Id, _follows: Id) {}
 
     fn enabled(&self, _metadata: &Meta) -> bool {
         false

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -43,7 +43,7 @@ impl Dispatch {
     }
 
     /// Returns a `Dispatch` to the given [`Subscriber`](::Subscriber).
-    pub fn to<S>(subscriber: S) -> Self
+    pub fn new<S>(subscriber: S) -> Self
     // TODO: Add some kind of `UnsyncDispatch`?
     where
         S: Subscriber + Send + Sync + 'static,

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -1,8 +1,8 @@
 use {
     callsite, field,
     span::{self, Span},
-    subscriber::{self, Subscriber},
-    Event, Meta,
+    subscriber::{self, RecordError, Subscriber},
+    Id, Meta,
 };
 
 use std::{
@@ -92,26 +92,47 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn new_span(&self, span: span::Attributes) -> span::Id {
+    fn new_span(&self, span: span::SpanAttributes) -> Id {
         self.subscriber.new_span(span)
     }
 
     #[inline]
-    fn record(
-        &self,
-        span: &span::Id,
-        key: &field::Key,
-        value: &dyn field::Value,
-    ) -> Result<(), ::subscriber::RecordError> {
-        self.subscriber.record(span, key, value)
+    fn new_id(&self, span: span::Attributes) -> Id {
+        self.subscriber.new_id(span)
     }
 
     #[inline]
-    fn add_follows_from(
+    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) -> Result<(), RecordError> {
+        self.subscriber.record_i64(span, field, value)
+    }
+
+    #[inline]
+    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) -> Result<(), RecordError> {
+        self.subscriber.record_u64(span, field, value)
+    }
+
+    #[inline]
+    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) -> Result<(), RecordError> {
+        self.subscriber.record_bool(span, field, value)
+    }
+
+    #[inline]
+    fn record_str(&self, span: &Id, field: &field::Key, value: &str) -> Result<(), RecordError> {
+        self.subscriber.record_str(span, field, value)
+    }
+
+    #[inline]
+    fn record_fmt(
         &self,
-        span: &span::Id,
-        follows: span::Id,
-    ) -> Result<(), subscriber::FollowsError> {
+        span: &Id,
+        field: &field::Key,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError> {
+        self.subscriber.record_fmt(span, field, value)
+    }
+
+    #[inline]
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
         self.subscriber.add_follows_from(span, follows)
     }
 
@@ -121,56 +142,47 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        self.subscriber.observe_event(event)
-    }
-
-    #[inline]
-    fn enter(&self, span: span::Id) {
+    fn enter(&self, span: Id) {
         self.subscriber.enter(span)
     }
 
     #[inline]
-    fn exit(&self, span: span::Id) {
+    fn exit(&self, span: Id) {
         self.subscriber.exit(span)
     }
 
     #[inline]
-    fn close(&self, span: span::Id) {
+    fn close(&self, span: Id) {
         self.subscriber.close(span)
     }
 
     #[inline]
-    fn clone_span(&self, id: span::Id) -> span::Id {
+    fn clone_span(&self, id: Id) -> Id {
         self.subscriber.clone_span(id)
     }
 
     #[inline]
-    fn drop_span(&self, id: span::Id) {
+    fn drop_span(&self, id: Id) {
         self.subscriber.drop_span(id)
     }
 }
 
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
-    fn new_span(&self, _span: span::Attributes) -> span::Id {
-        span::Id::from_u64(0)
+    fn new_id(&self, _span: span::Attributes) -> Id {
+        Id::from_u64(0)
     }
 
-    fn record(
+    fn record_fmt(
         &self,
-        _span: &span::Id,
+        _span: &Id,
         _key: &field::Key,
-        _value: &dyn field::Value,
+        _value: fmt::Arguments,
     ) -> Result<(), ::subscriber::RecordError> {
         Ok(())
     }
 
-    fn add_follows_from(
-        &self,
-        _span: &span::Id,
-        _follows: span::Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
         Ok(())
     }
 
@@ -178,15 +190,11 @@ impl Subscriber for NoSubscriber {
         false
     }
 
-    fn observe_event<'a>(&self, _event: &'a Event<'a>) {
-        // Do nothing.
-    }
+    fn enter(&self, _span: Id) {}
 
-    fn enter(&self, _span: span::Id) {}
+    fn exit(&self, _span: Id) {}
 
-    fn exit(&self, _span: span::Id) {}
-
-    fn close(&self, _span: span::Id) {}
+    fn close(&self, _span: Id) {}
 }
 
 impl Registrar {

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -132,24 +132,24 @@ pub use self::{
 /// [`Span`]: ::span::Span
 pub struct Event<'a> {
     /// The span ID of the span in which this event occurred.
-    pub parent: Option<SpanId>,
+    parent: Option<SpanId>,
 
     /// The IDs of a set of spans which are causally linked with this event, but
     /// are not its direct parent.
-    pub follows_from: &'a [SpanId],
+    follows_from: &'a [SpanId],
 
     /// Metadata describing this event.
-    pub meta: &'a Meta<'a>,
+    meta: &'a Meta<'a>,
 
     /// The values of the fields on this event.
     ///
     /// The names of these fields are defined in the event's metadata. Each
     /// index in this array corresponds to the name at the same index in
     /// `self.meta.field_names`.
-    pub field_values: &'a [&'a dyn Value],
+    field_values: &'a [&'a dyn Value],
 
     /// A textual message describing the event that occurred.
-    pub message: fmt::Arguments<'a>,
+    message: fmt::Arguments<'a>,
 }
 
 /// Metadata describing a [`Span`] or [`Event`].
@@ -368,6 +368,24 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn has_field(&self, key: &field::Key) -> bool {
         self.meta.contains_key(key)
+    }
+
+    /// Returns a reference to the event's metadata.
+    #[inline]
+    pub fn metadata(&self) -> &Meta<'a> {
+        self.meta
+    }
+
+    /// Returns the ID of the event's parent span, if it has one.
+    #[inline]
+    pub fn parent(&self) -> Option<span::Id> {
+        self.parent.as_ref().cloned()
+    }
+
+    /// Returns the event's message.
+    #[inline]
+    pub fn message(&self) -> &fmt::Arguments<'a> {
+        &self.message
     }
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -404,6 +404,12 @@ impl<'a> Event<'a> {
             Some((key, val))
         })
     }
+
+    /// Returns a slice containing the IDs of the spans that this event follows
+    /// from.
+    pub fn follows(&self) -> &[SpanId] {
+        self.follows_from
+    }
 }
 
 impl<'a> IntoIterator for &'a Event<'a> {

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -115,7 +115,7 @@ pub mod subscriber;
 pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
-    field::{Key, Value},
+    field::Key,
     span::{Attributes, Event, Id, Span, SpanAttributes},
     subscriber::{Interest, Subscriber},
 };

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -250,17 +250,74 @@ impl Span {
             .and_then(|inner| inner.meta.key_for(name))
     }
 
-    /// Sets the field on this span named `name` to the given `value`.
+    /// Record a signed 64-bit integer value.
     ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
         if let Some(ref inner) = self.inner {
-            inner.record(field, value)
-        } else {
-            Ok(())
+            inner.record_value_i64(field, value)?;
         }
+        Ok(())
+    }
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_u64(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a boolean value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_bool(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a string value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_str(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a precompiled set of format arguments.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_fmt(field, value)?;
+        }
+        Ok(())
     }
 
     /// Signals that this span should close the next time it is exited, or when
@@ -386,6 +443,76 @@ impl<'a> Event<'a> {
         Ok(())
     }
 
+    /// Record a signed 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_i64(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_u64(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a boolean value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_bool(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a string value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_str(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a precompiled set of format arguments.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_fmt(field, value)?;
+        }
+        Ok(())
+    }
+
     /// Returns the `Id` of the parent of this span, if one exists.
     pub fn parent(&self) -> Option<Id> {
         self.inner.as_ref().and_then(Enter::parent)
@@ -400,18 +527,6 @@ impl<'a> Event<'a> {
         self.inner
             .as_ref()
             .and_then(|inner| inner.meta.key_for(name))
-    }
-
-    /// Sets the field on this span named `name` to the given `value`.
-    ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
-        if let Some(ref inner) = self.inner {
-            inner.record(field, value)?;
-        }
-        Ok(())
     }
 
     /// Returns `true` if this span was disabled by the subscriber and does not
@@ -556,21 +671,83 @@ impl<'a> Inner<'a> {
         self.meta
     }
 
-    /// Sets the field on this span named `name` to the given `value`.
+    /// Record a signed 64-bit integer value.
     ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
         if !self.meta.contains_key(field) {
             return Err(RecordError::no_field());
         }
 
-        match value.record(&self.id, field, &self.subscriber) {
-            Ok(()) => Ok(()),
-            Err(ref e) if e.is_no_span() => panic!("span should still exist!"),
-            Err(e) => Err(e),
+        self.subscriber.record_i64(&self.id, field, value)
+    }
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
         }
+
+        self.subscriber.record_u64(&self.id, field, value)
+    }
+
+    /// Record a boolean value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        self.subscriber.record_bool(&self.id, field, value)
+    }
+
+    /// Record a string value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        self.subscriber.record_str(&self.id, field, value)
+    }
+
+    /// Record a precompiled set of format arguments value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_fmt(
+        &self,
+        field: &Key,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        self.subscriber.record_fmt(&self.id, field, value)
     }
 
     fn new(id: Id, parent: Option<Id>, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {
@@ -761,8 +938,6 @@ pub use self::test_support::*;
 #[cfg(any(test, feature = "test-support"))]
 mod test_support {
     #![allow(missing_docs)]
-    use field;
-    use std::collections::HashMap;
 
     /// A mock span.
     ///
@@ -771,7 +946,6 @@ mod test_support {
     #[derive(Default)]
     pub struct MockSpan {
         pub name: Option<Option<&'static str>>,
-        pub fields: HashMap<String, Box<dyn field::Value>>,
         // TODO: more
     }
 

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -494,8 +494,9 @@ impl Enter {
     }
 
     fn duplicate(&self) -> Self {
+        let id = self.subscriber.clone_span(self.id.clone());
         Self {
-            id: self.id.clone(),
+            id,
             subscriber: self.subscriber.clone(),
             parent: self.parent.clone(),
             wants_close: AtomicBool::from(self.wants_close()),
@@ -547,6 +548,7 @@ impl Hash for Enter {
 
 impl Drop for Enter {
     fn drop(&mut self) {
+        self.subscriber.drop_span(self.id.clone());
         // If this handle wants to be closed, try to close it --- either by
         // closing it now if it is idle, or telling the current span to close
         // when it exits, if it is the current span.

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -9,7 +9,7 @@ use std::{
 use {
     callsite::Callsite,
     field::{self, Key},
-    subscriber::{FollowsError, Interest, RecordError, Subscriber},
+    subscriber::{Interest, Subscriber},
     Dispatch, Meta,
 };
 
@@ -249,75 +249,44 @@ impl Span {
             .as_ref()
             .and_then(|inner| inner.meta.key_for(name))
     }
-
     /// Record a signed 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_i64(field, value)?;
+            inner.record_value_i64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_u64(field, value)?;
+            inner.record_value_u64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a boolean value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_bool(field, value)?;
+            inner.record_value_bool(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a string value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+    pub fn record_value_str(&self, field: &Key, value: &str) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_str(field, value)?;
+            inner.record_value_str(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a precompiled set of format arguments.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_fmt(field, value)?;
+            inner.record_value_fmt(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Signals that this span should close the next time it is exited, or when
@@ -355,14 +324,13 @@ impl Span {
     /// executing. This is used to model causal relationships such as when a
     /// single future spawns several related background tasks, et cetera.
     ///
-    /// If this span is disabled, this function will do nothing. Otherwise, it
-    /// returns `Ok(())` if the other span was added as a precedent of this
-    /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
-        self.inner
-            .as_ref()
-            .map(move |inner| inner.follows_from(from))
-            .unwrap_or(Ok(()))
+    /// If this span is disabled, or the resulting follows-from relationship
+    /// would be invalid, this function will do nothing.
+    pub fn follows_from(&self, from: Id) -> &Self {
+        if let Some(ref inner) = self.inner {
+            inner.follows_from(from);
+        }
+        self
     }
 
     /// Returns this span's `Id`, if it is enabled.
@@ -432,85 +400,51 @@ impl<'a> Event<'a> {
     }
 
     /// Adds a formattable message describing the event that occurred.
-    pub fn message(
-        &mut self,
-        key: &field::Key,
-        message: fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
+    pub fn message(&mut self, key: &field::Key, message: fmt::Arguments) -> &mut Self {
         if let Some(ref mut inner) = self.inner {
-            inner.subscriber.record_fmt(&inner.id, key, message)?;
+            inner.subscriber.record_fmt(&inner.id, key, message);
         }
-        Ok(())
+        self
     }
 
     /// Record a signed 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> Result<(), RecordError> {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_i64(field, value)?;
+            inner.record_value_i64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_u64(field, value)?;
+            inner.record_value_u64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a boolean value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_bool(field, value)?;
+            inner.record_value_bool(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a string value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+    pub fn record_value_str(&self, field: &Key, value: &str) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_str(field, value)?;
+            inner.record_value_str(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a precompiled set of format arguments.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_fmt(field, value)?;
+            inner.record_value_fmt(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Returns the `Id` of the parent of this span, if one exists.
@@ -536,7 +470,7 @@ impl<'a> Event<'a> {
     }
 
     /// Indicates that the span with the given ID has an indirect causal
-    /// relationship with this span.
+    /// relationship with this event.
     ///
     /// This relationship differs somewhat from the parent-child relationship: a
     /// span may have any number of prior spans, rather than a single one; and
@@ -547,14 +481,13 @@ impl<'a> Event<'a> {
     /// executing. This is used to model causal relationships such as when a
     /// single future spawns several related background tasks, et cetera.
     ///
-    /// If this span is disabled, this function will do nothing. Otherwise, it
-    /// returns `Ok(())` if the other span was added as a precedent of this
-    /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
-        self.inner
-            .as_ref()
-            .map(move |inner| inner.follows_from(from))
-            .unwrap_or(Ok(()))
+    /// If this event is disabled, or the resulting follows-from relationship
+    /// would be invalid, this function will do nothing.
+    pub fn follows_from(&self, from: Id) -> &Self {
+        if let Some(ref inner) = self.inner {
+            inner.follows_from(from);
+        }
+        self
     }
 
     /// Returns this span's `Id`, if it is enabled.
@@ -652,7 +585,7 @@ impl<'a> Inner<'a> {
     /// If this span is disabled, this function will do nothing. Otherwise, it
     /// returns `Ok(())` if the other span was added as a precedent of this
     /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
+    pub fn follows_from(&self, from: Id) {
         self.subscriber.add_follows_from(&self.id, from)
     }
 
@@ -672,82 +605,38 @@ impl<'a> Inner<'a> {
     }
 
     /// Record a signed 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_i64(&self, field: &Key, value: i64) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_i64(&self.id, field, value)
         }
-
-        self.subscriber.record_i64(&self.id, field, value)
     }
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_u64(&self, field: &Key, value: u64) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_u64(&self.id, field, value)
         }
-
-        self.subscriber.record_u64(&self.id, field, value)
     }
 
     /// Record a boolean value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_bool(&self, field: &Key, value: bool) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_bool(&self.id, field, value)
         }
-
-        self.subscriber.record_bool(&self.id, field, value)
     }
 
     /// Record a string value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_str(&self, field: &Key, value: &str) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_str(&self.id, field, value)
         }
-
-        self.subscriber.record_str(&self.id, field, value)
     }
 
     /// Record a precompiled set of format arguments value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_fmt(
-        &self,
-        field: &Key,
-        value: fmt::Arguments,
-    ) -> Result<(), RecordError> {
+    pub(crate) fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) {
         if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+            self.subscriber.record_fmt(&self.id, field, value)
         }
-
-        self.subscriber.record_fmt(&self.id, field, value)
     }
 
     fn new(id: Id, parent: Option<Id>, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {

--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -123,7 +123,7 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
     tokio_trace_env_logger::try_init().expect("init log adapter");
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let addr: ::std::net::SocketAddr = ([127, 0, 0, 1], 3000).into();
         span!("server", local = &Value::debug(addr)).enter(|| {
             let server = tokio::net::TcpListener::bind(&addr)

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -26,7 +26,7 @@ pub trait WithSubscriber: Sized {
     {
         WithDispatch {
             inner: self,
-            dispatch: Dispatch::to(subscriber),
+            dispatch: Dispatch::new(subscriber),
         }
     }
 }
@@ -156,7 +156,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
                 .wait()
@@ -191,7 +191,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
                 .wait()
@@ -212,7 +212,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             stream::iter_ok::<_, ()>(&[1, 2, 3])
                 .instrument(span!("foo"))
                 .for_each(|_| future::ok(()))

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -269,19 +269,20 @@ impl Subscriber for TraceLogger {
     }
 
     fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        let meta = event.meta.as_log();
+        let meta = event.metadata();
+        let log_meta = meta.as_log();
         let logger = log::logger();
-        if logger.enabled(&meta) {
+        if logger.enabled(&log_meta) {
             logger.log(
                 &log::Record::builder()
-                    .metadata(meta)
-                    .module_path(event.meta.module_path)
-                    .file(event.meta.file)
-                    .line(event.meta.line)
+                    .metadata(log_meta)
+                    .module_path(meta.module_path)
+                    .file(meta.file)
+                    .line(meta.line)
                     .args(format_args!(
                         "{}; in_span={:?}; {:?}",
-                        event.message,
-                        event.parent,
+                        event.message(),
+                        event.parent(),
                         LogFields(event),
                     )).build(),
             );

--- a/tokio-trace-macros/examples/basic.rs
+++ b/tokio-trace-macros/examples/basic.rs
@@ -19,7 +19,7 @@ fn main() {
             let band = suggest_band();
             event!(
                 Level::Info,
-                { band_recommendation = field::Value::display(&band) },
+                { band_recommendation = field::display(&band) },
                 "Got a rec."
             );
         });

--- a/tokio-trace-macros/examples/basic.rs
+++ b/tokio-trace-macros/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::new();
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let num: u64 = 1;
 
         let mut span = span!("Getting rec from another function.", number_of_recs = &num);

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -136,4 +136,12 @@ where
             self.observer.close(span);
         });
     }
+
+    fn clone_span(&self, id: span::Id) -> span::Id {
+        self.registry.clone_span(id)
+    }
+
+    fn drop_span(&self, id: span::Id) {
+        self.registry.drop_span(id)
+    }
 }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
-    field, span,
+    span,
     subscriber::{FollowsError, RecordError, Subscriber},
-    Event, Meta,
+    Id, Meta,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
@@ -98,50 +98,50 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_span(&self, new_span: span::Attributes) -> span::Id {
+    fn new_span(&self, new_span: span::SpanAttributes) -> Id {
         self.registry.new_span(new_span)
     }
 
-    fn record(
-        &self,
-        span: &span::Id,
-        name: &tokio_trace::field::Key,
-        value: &dyn field::Value,
-    ) -> Result<(), RecordError> {
-        self.registry.record(span, name, value)
+    fn new_id(&self, new_id: span::Attributes) -> Id {
+        self.registry.new_id(new_id)
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsError> {
+    fn record_fmt(
+        &self,
+        _span: &Id,
+        _name: &tokio_trace::field::Key,
+        _value: ::std::fmt::Arguments,
+    ) -> Result<(), RecordError> {
+        unimplemented!()
+    }
+
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError> {
         self.registry.add_follows_from(span, follows)
     }
 
-    fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        self.observer.observe_event(event)
-    }
-
-    fn enter(&self, id: span::Id) {
+    fn enter(&self, id: Id) {
         self.registry.with_span(&id, |span| {
             self.observer.enter(span);
         });
     }
 
-    fn exit(&self, id: span::Id) {
+    fn exit(&self, id: Id) {
         self.registry.with_span(&id, |span| {
             self.observer.exit(span);
         });
     }
 
-    fn close(&self, id: span::Id) {
+    fn close(&self, id: Id) {
         self.registry.with_span(&id, |span| {
             self.observer.close(span);
         });
     }
 
-    fn clone_span(&self, id: span::Id) -> span::Id {
+    fn clone_span(&self, id: Id) -> Id {
         self.registry.clone_span(id)
     }
 
-    fn drop_span(&self, id: span::Id) {
+    fn drop_span(&self, id: Id) {
         self.registry.drop_span(id)
     }
 }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,8 +1,4 @@
-use tokio_trace::{
-    span,
-    subscriber::{FollowsError, RecordError, Subscriber},
-    Id, Meta,
-};
+use tokio_trace::{span, subscriber::Subscriber, Id, Meta};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -111,11 +107,11 @@ where
         _span: &Id,
         _name: &tokio_trace::field::Key,
         _value: ::std::fmt::Arguments,
-    ) -> Result<(), RecordError> {
+    ) {
         unimplemented!()
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         self.registry.add_follows_from(span, follows)
     }
 

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -84,7 +84,7 @@ pub trait FilterExt: Filter {
     ///     .with_registry(tokio_trace_subscriber::registry::increasing_counter())
     ///     .with_filter(name_filter.and(mod_filter));
     ///
-    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    /// tokio_trace::Dispatch::new(subscriber).as_default(|| {
     ///     foo();
     ///     my_module::foo();
     ///     my_module::bar();

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -1,7 +1,7 @@
 //! Utilities and helpers for implementing and composing subscribers.
 
 extern crate tokio_trace;
-pub use tokio_trace::{Event, SpanId};
+pub use tokio_trace::{Event, Id};
 
 mod compose;
 pub use compose::Composed;

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -70,7 +70,7 @@ pub trait ObserveExt: Observe {
     ///     .with_observer(observer)
     ///     .with_registry(registry::increasing_counter());
     ///
-    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    /// tokio_trace::Dispatch::new(subscriber).as_default(|| {
     ///     // This span will be seen by both `foo` and `bar`.
     ///     span!("my great span").enter(|| {
     ///         // ...
@@ -119,7 +119,7 @@ pub trait ObserveExt: Observe {
     ///     .with_observer(observer)
     ///     .with_registry(registry::increasing_counter());
     ///
-    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    /// tokio_trace::Dispatch::new(subscriber).as_default(|| {
     ///     /// // This span will be logged.
     ///     span!("foo", enabled = &true) .enter(|| {
     ///         // do work;

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,4 @@
-use tokio_trace::{
-    span::{self, Attributes, Id, SpanAttributes},
-    subscriber::FollowsError,
-};
+use tokio_trace::span::{self, Attributes, Id, SpanAttributes};
 
 use std::{
     cmp,
@@ -60,8 +57,8 @@ pub trait RegisterSpan {
     /// if one or both of the given span IDs do not correspond to spans that the
     /// registry knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
-    /// follow from _b_), it should return a `FollowsError`.
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError>;
+    /// follow from _b_), it should do nothing.
+    fn add_follows_from(&self, span: &Id, follows: Id);
 
     /// Queries the registry for an iterator over the IDs of the spans that
     /// `span` follows from.
@@ -176,9 +173,8 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) {
         // unimplemented
-        Ok(())
     }
 
     fn prior_spans(&self, _span: &Id) -> Self::PriorSpans {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,6 @@
 use tokio_trace::{
-    field,
     span::{self, Attributes, Id, SpanAttributes},
-    subscriber::{FollowsError, RecordError},
+    subscriber::FollowsError,
 };
 
 use std::{
@@ -43,13 +42,6 @@ pub trait RegisterSpan {
     }
 
     fn new_id(&self, new_id: Attributes) -> Id;
-
-    fn record(
-        &self,
-        span: &Id,
-        name: &field::Key,
-        value: &dyn field::Value,
-    ) -> Result<(), RecordError>;
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -182,15 +174,6 @@ impl RegisterSpan for IncreasingCounter {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         id
-    }
-
-    fn record(
-        &self,
-        _span: &Id,
-        _name: &field::Key,
-        _value: &dyn field::Value,
-    ) -> Result<(), RecordError> {
-        unimplemented!("TODO: figure out")
     }
 
     fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -107,7 +107,7 @@ impl tower_service::Service<()> for NewSvc {
 fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let mut rt = Runtime::new().unwrap();
         let reactor = rt.executor();
 

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -95,7 +95,7 @@ impl tower_service::Service<()> for NewSvc {
         Ok(Async::Ready(()))
     }
 
-    fn call(&mut self, target: ()) -> Self::Future {
+    fn call(&mut self, _target: ()) -> Self::Future {
         future::ok(Svc)
     }
 }

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -119,8 +119,7 @@ fn main() {
             "serve",
             local_ip = field::debug(addr.ip()),
             local_port = addr.port() as u64
-        )
-        .enter(move || {
+        ).enter(move || {
             let new_svc = tokio_trace_tower_http::InstrumentedMakeService::new(NewSvc);
             let h2 = Server::new(new_svc, Default::default(), reactor.clone());
 
@@ -132,8 +131,7 @@ fn main() {
                         "conn",
                         remote_ip = field::debug(addr.ip()),
                         remote_port = addr.port() as u64
-                    )
-                    .enter(|| {
+                    ).enter(|| {
                         if let Err(e) = sock.set_nodelay(true) {
                             return Err(e);
                         }
@@ -144,21 +142,17 @@ fn main() {
                             .serve(sock)
                             .map_err(|e| {
                                 error!("error {:?}", e);
-                            })
-                            .and_then(|_| {
+                            }).and_then(|_| {
                                 debug!("response finished");
                                 future::ok(())
-                            })
-                            .in_current_span();
+                            }).in_current_span();
                         reactor.spawn(Box::new(serve));
 
                         Ok((h2, reactor))
                     })
-                })
-                .map_err(|e| {
+                }).map_err(|e| {
                     error!("serve error {:?}", e);
-                })
-                .map(|_| {})
+                }).map(|_| {})
                 .in_current_span();
 
             rt.spawn(serve);

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -8,7 +8,7 @@ extern crate tokio_trace_futures;
 use std::marker::PhantomData;
 
 use futures::{Future, Poll};
-use tokio_trace::field::Value;
+use tokio_trace::field;
 use tokio_trace_futures::{Instrument, Instrumented};
 use tower_service::{MakeService, Service};
 
@@ -109,10 +109,10 @@ where
                 "request",
                 // TODO: custom `Value` impls for `http` types would be nicer
                 // than just sticking these in `debug`s...
-                method = &Value::debug(request.method()),
-                version = &Value::debug(request.version()),
-                uri = &Value::debug(request.uri()),
-                headers = &Value::debug(request.headers())
+                method = &field::debug(request.method()),
+                version = &field::debug(request.version()),
+                uri = &field::debug(request.uri()),
+                headers = &field::debug(request.headers())
             ).enter(move || inner.call(request).in_current_span())
         })
     }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -28,8 +28,8 @@ where
     Request: fmt::Debug + Clone + Send + Sync + 'static,
 {
     type Response = T::Response;
-    type Future = Instrumented<T::Future>;
     type Error = T::Error;
+    type Future = Instrumented<T::Future>;
 
     fn poll_ready(&mut self) -> futures::Poll<(), Self::Error> {
         let span = &mut self.span;

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -5,7 +5,7 @@ extern crate futures;
 extern crate tokio_trace_futures;
 
 use std::fmt;
-use tokio_trace::field::Value;
+use tokio_trace::field;
 use tokio_trace_futures::{Instrument, Instrumented};
 use tower_service::Service;
 
@@ -42,7 +42,7 @@ where
         let inner = &mut self.inner;
         span.enter(|| {
             // TODO: custom `Value` impls for `http` types would be nice...
-            span!("request", request = &Value::debug(&req))
+            span!("request", request = &field::debug(&req))
                 .enter(move || inner.call(req).in_current_span())
         })
     }

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -35,7 +35,7 @@ fn bench_costly_field_no_subscriber(b: &mut Bencher) {
         (0..n).fold(0, |old, new| {
             span!(
                 "span",
-                foo = tokio_trace::Value::display(format!("bar {:?}", 2))
+                foo = tokio_trace::field::display(format!("bar {:?}", 2))
             );
             old ^ new
         })

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -1,4 +1,7 @@
 #![feature(test)]
+
+#[macro_use]
+extern crate tokio_trace;
 extern crate test;
 use test::Bencher;
 
@@ -120,17 +123,24 @@ fn span_with_fields(b: &mut Bencher) {
                 "span",
                 foo = "foo",
                 bar = "bar",
-                baz = 3u64,
-                quuux = tokio_trace::Value::debug(0.99)
+                baz = 3,
+                quuux = tokio_trace::field::debug(0.99)
             )
         })
     });
 }
 
-// TODO: bring this back
-// #[bench]
-// fn span_with_fields_add_data(b: &mut Bencher) {
-//     tokio_trace::Dispatch::new(Record(Mutex::new(None))).as_default(|| {
-//         b.iter(|| span!("span", foo = &"foo", bar = &"bar", baz = &3, quuux = &0.99))
-//     });
-// }
+#[bench]
+fn span_with_fields_record(b: &mut Bencher) {
+    tokio_trace::Dispatch::new(Record(Mutex::new(None))).as_default(|| {
+        b.iter(|| {
+            span!(
+                "span",
+                foo = "foo",
+                bar = "bar",
+                baz = 3,
+                quuux = tokio_trace::field::debug(0.99)
+            )
+        })
+    });
+}

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -109,7 +109,7 @@ const N_SPANS: usize = 100;
 
 #[bench]
 fn span_no_fields(b: &mut Bencher) {
-    tokio_trace::Dispatch::to(EnabledSubscriber).as_default(|| b.iter(|| span!("span")));
+    tokio_trace::Dispatch::new(EnabledSubscriber).as_default(|| b.iter(|| span!("span")));
 }
 
 #[bench]
@@ -120,13 +120,13 @@ fn span_repeatedly(b: &mut Bencher) {
     }
 
     let n = test::black_box(N_SPANS);
-    tokio_trace::Dispatch::to(EnabledSubscriber)
+    tokio_trace::Dispatch::new(EnabledSubscriber)
         .as_default(|| b.iter(|| (0..n).fold(mk_span(0), |span, i| mk_span(i as u64))));
 }
 
 #[bench]
 fn span_with_fields(b: &mut Bencher) {
-    tokio_trace::Dispatch::to(EnabledSubscriber).as_default(|| {
+    tokio_trace::Dispatch::new(EnabledSubscriber).as_default(|| {
         b.iter(|| {
             span!(
                 "span",
@@ -142,7 +142,7 @@ fn span_with_fields(b: &mut Bencher) {
 // TODO: bring this back
 // #[bench]
 // fn span_with_fields_add_data(b: &mut Bencher) {
-//     tokio_trace::Dispatch::to(AddAttributes(Mutex::new(None))).as_default(|| {
+//     tokio_trace::Dispatch::new(AddAttributes(Mutex::new(None))).as_default(|| {
 //         b.iter(|| span!("span", foo = &"foo", bar = &"bar", baz = &3, quuux = &0.99))
 //     });
 // }

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -6,7 +6,7 @@ extern crate test;
 use test::Bencher;
 
 use std::sync::Mutex;
-use tokio_trace::{field, span, subscriber, Id, Meta};
+use tokio_trace::{field, span, Id, Meta};
 
 /// A subscriber that is enabled but otherwise does nothing.
 struct EnabledSubscriber;
@@ -17,19 +17,12 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         Id::from_u64(0)
     }
 
-    fn record_fmt(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: ::std::fmt::Arguments,
-    ) -> Result<(), tokio_trace::subscriber::RecordError> {
+    fn record_fmt(&self, span: &Id, field: &field::Key, value: ::std::fmt::Arguments) {
         let _ = (span, field, value);
-        Ok(())
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         let _ = (span, follows);
-        Ok(())
     }
 
     fn enabled(&self, metadata: &Meta) -> bool {
@@ -59,23 +52,16 @@ impl tokio_trace::Subscriber for Record {
         Id::from_u64(0)
     }
 
-    fn new_id(&self, span: span::Attributes) -> Id {
+    fn new_id(&self, _span: span::Attributes) -> Id {
         Id::from_u64(0)
     }
 
-    fn record_fmt(
-        &self,
-        _span: &Id,
-        _field: &field::Key,
-        value: ::std::fmt::Arguments,
-    ) -> Result<(), tokio_trace::subscriber::RecordError> {
+    fn record_fmt(&self, _span: &Id, _field: &field::Key, value: ::std::fmt::Arguments) {
         let _ = ::std::fmt::format(value);
-        Ok(())
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         let _ = (span, follows);
-        Ok(())
     }
 
     fn enabled(&self, metadata: &Meta) -> bool {

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,11 +3,13 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{Level, Span};
+use tokio_trace::{Level, Span, Value};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
-    let subscriber = tokio_trace_log::TraceLogger::new();
+    let subscriber = tokio_trace_log::TraceLogger::builder()
+        .with_parent_fields(true)
+        .finish();
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let foo: u64 = 3;
@@ -15,7 +17,15 @@ fn main() {
 
         span!("my_great_span", foo = 4u64, baz = 5u64).enter(|| {
             Span::current().close();
+
             event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
+            span!("my other span", quux = "quuuux").enter(|| {
+                event!(
+                    Level::Debug,
+                    { depth = Value::display("very") },
+                    "hi from inside both my spans!"
+                );
+            })
         });
     });
 }

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -9,7 +9,7 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::new();
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let foo: u64 = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,7 +3,7 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{Level, Span, Value};
+use tokio_trace::{field, Level, Span};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
@@ -12,17 +12,17 @@ fn main() {
         .finish();
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
-        let foo: u64 = 3;
+        let foo = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 
-        span!("my_great_span", foo = 4u64, baz = 5u64).enter(|| {
+        span!("my_great_span", foo = 4, baz = 5).enter(|| {
             Span::current().close();
 
             event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
             span!("my other span", quux = "quuuux").enter(|| {
                 event!(
                     Level::Debug,
-                    { depth = Value::display("very") },
+                    { depth = field::display("very") },
                     "hi from inside both my spans!"
                 );
             })

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,8 +3,6 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{field, Span};
-
 fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::builder()

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -13,7 +13,7 @@ fn main() {
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let foo = 3;
-        event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
+        trace!({ foo = foo, bar = "bar" }, "hello! I'm gonna shave a yak.");
 
         span!("my_great_span", foo = 4, baz = 5).enter(|| {
             Span::current().close();

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -47,17 +47,11 @@ impl Subscriber for CounterSubscriber {
         Id::from_u64(id as u64)
     }
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) {
         // unimplemented
-        Ok(())
     }
 
-    fn record_i64(
-        &self,
-        _id: &Id,
-        field: &field::Key,
-        value: i64,
-    ) -> Result<(), ::subscriber::RecordError> {
+    fn record_i64(&self, _id: &Id, field: &field::Key, value: i64) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             if value > 0 {
@@ -66,20 +60,13 @@ impl Subscriber for CounterSubscriber {
                 counter.fetch_sub(value as usize, Ordering::Release);
             }
         };
-        Ok(())
     }
 
-    fn record_u64(
-        &self,
-        _id: &Id,
-        field: &field::Key,
-        value: u64,
-    ) -> Result<(), ::subscriber::RecordError> {
+    fn record_u64(&self, _id: &Id, field: &field::Key, value: u64) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             counter.fetch_add(value as usize, Ordering::Release);
         };
-        Ok(())
     }
 
     /// Adds a new field to an existing span observed by this `Subscriber`.
@@ -89,14 +76,7 @@ impl Subscriber for CounterSubscriber {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    fn record_fmt(
-        &self,
-        _id: &Id,
-        _field: &field::Key,
-        _value: ::std::fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        Ok(())
-    }
+    fn record_fmt(&self, _id: &Id, _field: &field::Key, _value: ::std::fmt::Arguments) {}
 
     fn enabled(&self, metadata: &Meta) -> bool {
         if !metadata.is_span() {

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -150,7 +150,7 @@ impl Counters {
 fn main() {
     let (counters, subscriber) = Counters::new();
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let mut foo: u64 = 2;
         span!("my_great_span", foo_count = &foo).enter(|| {
             foo += 1;

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -136,9 +136,9 @@ fn main() {
         let mut foo: u64 = 2;
         span!("my_great_span", foo_count = &foo).enter(|| {
             foo += 1;
-            event!(Level::Info, { yak_shaved = true, yak_count = 1i64 }, "hi from inside my span");
-            span!("my other span", foo_count = &foo, baz_count = &5u64).enter(|| {
-                event!(Level::Warn, { yak_shaved = false, yak_count = 2i64 }, "failed to shave yak");
+            event!(Level::Info, { yak_shaved = true, yak_count = 1 }, "hi from inside my span");
+            span!("my other span", foo_count = &foo, baz_count = 5).enter(|| {
+                event!(Level::Warn, { yak_shaved = false, yak_count = -1 }, "failed to shave yak");
             });
         });
     });

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -4,7 +4,7 @@ extern crate tokio_trace;
 use tokio_trace::{
     field, span,
     subscriber::{self, Subscriber},
-    Event, Level, Meta,
+    Id, Level, Meta,
 };
 
 use std::{
@@ -21,51 +21,6 @@ struct Counters(Arc<RwLock<HashMap<String, AtomicUsize>>>);
 struct CounterSubscriber {
     ids: AtomicUsize,
     counters: Counters,
-}
-
-impl<'a> field::Record for &'a Counters {
-    fn record_i64(
-        &mut self,
-        field: &field::Key,
-        value: i64,
-    ) -> Result<(), ::subscriber::RecordError> {
-        let registry = (*self).0.read().unwrap();
-        if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
-            if value > 0 {
-                counter.fetch_add(value as usize, Ordering::Release);
-            } else {
-                counter.fetch_sub(value as usize, Ordering::Release);
-            }
-        };
-        Ok(())
-    }
-
-    fn record_u64(
-        &mut self,
-        field: &field::Key,
-        value: u64,
-    ) -> Result<(), ::subscriber::RecordError> {
-        let registry = (*self).0.read().unwrap();
-        if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
-            counter.fetch_add(value as usize, Ordering::Release);
-        };
-        Ok(())
-    }
-
-    /// Adds a new field to an existing span observed by this `Subscriber`.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_fmt(
-        &mut self,
-        _field: &field::Key,
-        _value: ::std::fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        Ok(())
-    }
 }
 
 impl Subscriber for CounterSubscriber {
@@ -87,27 +42,60 @@ impl Subscriber for CounterSubscriber {
         interest
     }
 
-    fn new_span(&self, _new_span: span::Attributes) -> span::Id {
+    fn new_id(&self, _new_span: span::Attributes) -> Id {
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
-        span::Id::from_u64(id as u64)
+        Id::from_u64(id as u64)
     }
 
-    fn add_follows_from(
-        &self,
-        _span: &span::Id,
-        _follows: span::Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
         // unimplemented
         Ok(())
     }
 
-    fn record(
+    fn record_i64(
         &self,
-        _span: &span::Id,
-        key: &field::Key,
-        value: &dyn field::Value,
+        _id: &Id,
+        field: &field::Key,
+        value: i64,
     ) -> Result<(), ::subscriber::RecordError> {
-        value.record(key, &mut &self.counters)
+        let registry = self.counters.0.read().unwrap();
+        if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
+            if value > 0 {
+                counter.fetch_add(value as usize, Ordering::Release);
+            } else {
+                counter.fetch_sub(value as usize, Ordering::Release);
+            }
+        };
+        Ok(())
+    }
+
+    fn record_u64(
+        &self,
+        _id: &Id,
+        field: &field::Key,
+        value: u64,
+    ) -> Result<(), ::subscriber::RecordError> {
+        let registry = self.counters.0.read().unwrap();
+        if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
+            counter.fetch_add(value as usize, Ordering::Release);
+        };
+        Ok(())
+    }
+
+    /// Adds a new field to an existing span observed by this `Subscriber`.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_fmt(
+        &self,
+        _id: &Id,
+        _field: &field::Key,
+        _value: ::std::fmt::Arguments,
+    ) -> Result<(), ::subscriber::RecordError> {
+        Ok(())
     }
 
     fn enabled(&self, metadata: &Meta) -> bool {
@@ -119,15 +107,9 @@ impl Subscriber for CounterSubscriber {
             .any(|f| f.name().map(|name| name.contains("count")).unwrap_or(false))
     }
 
-    fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        for (key, value) in event.fields() {
-            value.record(&key, &mut &self.counters);
-        }
-    }
-
-    fn enter(&self, _span: span::Id) {}
-    fn exit(&self, _span: span::Id) {}
-    fn close(&self, _span: span::Id) {}
+    fn enter(&self, _span: Id) {}
+    fn exit(&self, _span: Id) {}
+    fn close(&self, _span: Id) {}
 }
 
 impl Counters {

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -21,7 +21,7 @@ use self::sloggish_subscriber::SloggishSubscriber;
 fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         span!("", version = &field::Value::display(5.0)).enter(|| {
             span!("server", host = "localhost", port = 8080u64).enter(|| {
                 event!(Level::Info, {}, "starting");

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -22,27 +22,27 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
-        span!("", version = &field::Value::display(5.0)).enter(|| {
-            span!("server", host = "localhost", port = 8080u64).enter(|| {
+        span!("", version = &field::display(5.0)).enter(|| {
+            span!("server", host = "localhost", port = 8080).enter(|| {
                 event!(Level::Info, {}, "starting");
                 event!(Level::Info, {}, "listening");
-                let mut peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381u64);
+                let mut peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381);
                 peer1.enter(|| {
                     event!(Level::Debug, {}, "connected");
-                    event!(Level::Debug, { length = 2u64 }, "message received");
+                    event!(Level::Debug, { length = 2 }, "message received");
                 });
-                let mut peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230u64);
+                let mut peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230);
                 peer2.enter(|| {
                     event!(Level::Debug, {}, "connected");
                 });
                 peer1.enter(|| {
                     event!(Level::Warn, { algo = "xor" }, "weak encryption requested");
-                    event!(Level::Debug, { length = 8u64 }, "response sent");
+                    event!(Level::Debug, { length = 8 }, "response sent");
                     event!(Level::Debug, {}, "disconnected");
                 });
                 peer2.enter(|| {
-                    event!(Level::Debug, { length = 5u64 }, "message received");
-                    event!(Level::Debug, { length = 8u64 }, "response sent");
+                    event!(Level::Debug, { length = 5 }, "message received");
+                    event!(Level::Debug, { length = 8 }, "response sent");
                     event!(Level::Debug, {}, "disconnected");
                 });
                 event!(Level::Error, {}, "internal error");

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -189,7 +189,7 @@ impl Subscriber for SloggishSubscriber {
         let stack = self.stack.lock().unwrap();
         if let Some(idx) = stack
             .iter()
-            .position(|id| event.parent.as_ref().map(|p| p == id).unwrap_or(false))
+            .position(|id| event.parent().as_ref().map(|p| p == id).unwrap_or(false))
         {
             self.print_indent(&mut stderr, idx + 1).unwrap();
         }
@@ -198,11 +198,11 @@ impl Subscriber for SloggishSubscriber {
             "{} ",
             humantime::format_rfc3339_seconds(SystemTime::now())
         ).unwrap();
-        self.print_meta(&mut stderr, event.meta).unwrap();
+        self.print_meta(&mut stderr, event.metadata()).unwrap();
         write!(
             &mut stderr,
             "{}",
-            Style::new().bold().paint(format!("{}", event.message))
+            Style::new().bold().paint(format!("{}", event.message()))
         ).unwrap();
         self.print_kvs(
             &mut stderr,

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -18,12 +18,12 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .done()
             .run();
-        let mut foo = Dispatch::to(subscriber1).as_default(|| {
+        let mut foo = Dispatch::new(subscriber1).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
             foo
         });
-        Dispatch::to(subscriber::mock().done().run())
+        Dispatch::new(subscriber::mock().done().run())
             .as_default(move || foo.enter(|| span!("bar").enter(|| {})))
     }
 
@@ -48,13 +48,13 @@ mod tests {
             .done()
             .run();
 
-        let mut foo = Dispatch::to(subscriber1).as_default(|| {
+        let mut foo = Dispatch::new(subscriber1).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
             foo
         });
-        let mut baz = Dispatch::to(subscriber2).as_default(|| span!("baz"));
-        Dispatch::to(subscriber::mock().run()).as_default(move || {
+        let mut baz = Dispatch::new(subscriber2).as_default(|| span!("baz"));
+        Dispatch::new(subscriber::mock().run()).as_default(move || {
             foo.enter(|| span!("bar").enter(|| {}));
             baz.enter(|| span!("quux").enter(|| {}))
         })

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,5 +1,7 @@
 pub use tokio_trace_core::field::*;
-use Meta;
+
+use std::fmt;
+use {subscriber::RecordError, Meta};
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
@@ -14,6 +16,172 @@ pub trait AsKey {
     /// If `metadata` defines a key corresponding to this field, then the key is
     /// returned. Otherwise, this function returns `None`.
     fn as_key<'a>(&self, metadata: &'a Meta<'a>) -> Option<Key<'a>>;
+}
+
+pub trait Record {
+    /// Record a signed 64-bit integer value.
+    ///
+    /// This defaults to calling `self.record_fmt()`; implementations wishing to
+    /// provide behaviour specific to signed integers may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    where
+        Q: AsKey;
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This defaults to calling `self.record_fmt()`; implementations wishing to
+    /// provide behaviour specific to unsigned integers may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    where
+        Q: AsKey;
+
+    /// Record a boolean value.
+    ///
+    /// This defaults to calling `self.record_fmt()`; implementations wishing to
+    /// provide behaviour specific to booleans may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    where
+        Q: AsKey;
+
+    /// Record a string value.
+    ///
+    /// This defaults to calling `self.record_str()`; implementations wishing to
+    /// provide behaviour specific to strings may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    where
+        Q: AsKey;
+
+    /// Record a set of pre-compiled format arguments.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_fmt<Q: ?Sized>(
+        &mut self,
+        field: &Q,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError>
+    where
+        Q: AsKey;
+}
+
+/// A field value of an erased type.
+///
+/// Implementors of `Value` may call the appropriate typed recording methods on
+/// the `Subscriber` passed to `record` in order to indicate how their data
+/// should be recorded.
+pub trait Value {
+    /// Records this value with the given `Subscriber`.
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), ::subscriber::RecordError>
+    where
+        Q: AsKey,
+        R: Record;
+}
+
+/// A `Value` which serializes as a string using `fmt::Display`.
+#[derive(Clone)]
+pub struct DisplayValue<T: fmt::Display>(T);
+
+/// A `Value` which serializes as a string using `fmt::Debug`.
+#[derive(Clone)]
+pub struct DebugValue<T: fmt::Debug>(T);
+
+/// Wraps a type implementing `fmt::Display` as a `Value` that can be
+/// recorded using its `Display` implementation.
+pub fn display<'a, T>(t: T) -> DisplayValue<T>
+where
+    T: fmt::Display,
+{
+    DisplayValue(t)
+}
+
+// ===== impl Value =====
+
+/// Wraps a type implementing `fmt::Debug` as a `Value` that can be
+/// recorded using its `Debug` implementation.
+pub fn debug<T>(t: T) -> DebugValue<T>
+where
+    T: fmt::Debug,
+{
+    DebugValue(t)
+}
+
+macro_rules! impl_values {
+    ( $( $record:ident( $( $whatever:tt)+ ) ),+ ) => {
+        $(
+            impl_value!{ $record( $( $whatever )+ ) }
+        )+
+    }
+}
+macro_rules! impl_value {
+    ( $record:ident( $( $value_ty:ty ),+ ) ) => {
+        $(
+            impl $crate::field::Value for $value_ty {
+                fn record<Q: ?Sized, R>(
+                    &self,
+                    key: &Q,
+                    recorder: &mut R,
+                ) -> Result<(), $crate::subscriber::RecordError>
+                where
+                    Q: $crate::field::AsKey,
+                    R: $crate::field::Record,
+                {
+                    recorder.$record(key, *self)
+                }
+            }
+        )+
+    };
+    ( $record:ident( $( $value_ty:ty ),+ as $as_ty:ty) ) => {
+        $(
+            impl Value for $value_ty {
+                fn record<Q: ?Sized, R>(
+                    &self,
+                    key: &Q,
+                    recorder: &mut R,
+                ) -> Result<(), $crate::subscriber::RecordError>
+                where
+                    Q: $crate::field::AsKey,
+                    R: $crate::field::Record,
+                {
+                    recorder.$record(key, *self as $as_ty)
+                }
+            }
+        )+
+    };
 }
 
 // ===== impl AsKey =====
@@ -36,5 +204,72 @@ impl AsKey for str {
     #[inline]
     fn as_key<'a>(&self, metadata: &'a Meta<'a>) -> Option<Key<'a>> {
         metadata.key_for(&self)
+    }
+}
+
+// ===== impl Value =====
+
+impl_values! {
+    record_u64(u64),
+    record_u64(usize, u32, u16 as u64),
+    record_i64(i64),
+    record_i64(isize, i32, i16, i8 as i64),
+    record_bool(bool)
+}
+
+impl Value for str {
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), ::subscriber::RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        recorder.record_str(key, &self)
+    }
+}
+
+impl<'a, T: ?Sized> Value for &'a T
+where
+    T: Value + 'a,
+{
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        (*self).record(key, recorder)
+    }
+}
+
+// ===== impl DisplayValue =====
+
+impl<T> Value for DisplayValue<T>
+where
+    T: fmt::Display,
+{
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        recorder.record_fmt(key, format_args!("{}", self.0))
+    }
+}
+
+// ===== impl DebugValue =====
+
+impl<T: fmt::Debug> Value for DebugValue<T>
+where
+    T: fmt::Debug,
+{
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        recorder.record_fmt(key, format_args!("{:?}", self.0))
     }
 }

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,7 +1,7 @@
 pub use tokio_trace_core::field::*;
 
 use std::fmt;
-use {subscriber::RecordError, Meta};
+use Meta;
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
@@ -24,13 +24,7 @@ pub trait Record {
     /// This defaults to calling `self.record_fmt()`; implementations wishing to
     /// provide behaviour specific to signed integers may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
         Q: AsKey;
 
@@ -39,13 +33,7 @@ pub trait Record {
     /// This defaults to calling `self.record_fmt()`; implementations wishing to
     /// provide behaviour specific to unsigned integers may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
         Q: AsKey;
 
@@ -54,13 +42,7 @@ pub trait Record {
     /// This defaults to calling `self.record_fmt()`; implementations wishing to
     /// provide behaviour specific to booleans may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
         Q: AsKey;
 
@@ -69,28 +51,12 @@ pub trait Record {
     /// This defaults to calling `self.record_str()`; implementations wishing to
     /// provide behaviour specific to strings may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
         Q: AsKey;
 
     /// Record a set of pre-compiled format arguments.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_fmt<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: fmt::Arguments,
-    ) -> Result<(), RecordError>
+    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments)
     where
         Q: AsKey;
 }
@@ -102,11 +68,7 @@ pub trait Record {
 /// should be recorded.
 pub trait Value {
     /// Records this value with the given `Subscriber`.
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    ) -> Result<(), ::subscriber::RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record;
@@ -155,7 +117,7 @@ macro_rules! impl_value {
                     &self,
                     key: &Q,
                     recorder: &mut R,
-                ) -> Result<(), $crate::subscriber::RecordError>
+                )
                 where
                     Q: $crate::field::AsKey,
                     R: $crate::field::Record,
@@ -172,7 +134,7 @@ macro_rules! impl_value {
                     &self,
                     key: &Q,
                     recorder: &mut R,
-                ) -> Result<(), $crate::subscriber::RecordError>
+                )
                 where
                     Q: $crate::field::AsKey,
                     R: $crate::field::Record,
@@ -218,11 +180,7 @@ impl_values! {
 }
 
 impl Value for str {
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    ) -> Result<(), ::subscriber::RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,
@@ -235,7 +193,7 @@ impl<'a, T: ?Sized> Value for &'a T
 where
     T: Value + 'a,
 {
-    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,
@@ -250,7 +208,7 @@ impl<T> Value for DisplayValue<T>
 where
     T: fmt::Display,
 {
-    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,
@@ -265,7 +223,7 @@ impl<T: fmt::Debug> Value for DebugValue<T>
 where
     T: fmt::Debug,
 {
-    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 pub use tokio_trace_core::field::*;
 use Meta;
 
@@ -15,50 +14,6 @@ pub trait AsKey {
     /// If `metadata` defines a key corresponding to this field, then the key is
     /// returned. Otherwise, this function returns `None`.
     fn as_key<'a>(&self, metadata: &'a Meta<'a>) -> Option<Key<'a>>;
-}
-
-pub struct DebugRecorder<'a, W: 'a> {
-    write: &'a mut W,
-    with_key: bool,
-}
-
-// ===== impl DebugRecorder =====
-
-impl<'a, W: 'a> DebugRecorder<'a, W> {
-    pub fn into_inner(self) -> &'a mut W {
-        self.write
-    }
-}
-
-impl<'a, W: fmt::Write + 'a> DebugRecorder<'a, W> {
-    pub fn new(write: &'a mut W) -> Self {
-        Self {
-            write,
-            with_key: false,
-        }
-    }
-
-    pub fn new_with_key(write: &'a mut W) -> Self {
-        Self {
-            write,
-            with_key: true,
-        }
-    }
-}
-
-impl<'a, W: fmt::Write + 'a> Record for DebugRecorder<'a, W> {
-    fn record_fmt(
-        &mut self,
-        key: &Key,
-        args: fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        if self.with_key {
-            self.write
-                .write_fmt(format_args!("{}=", key.name().unwrap_or("???")))?;
-        }
-        self.write.write_fmt(args)?;
-        Ok(())
-    }
 }
 
 // ===== impl AsKey =====

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -97,6 +97,7 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
+            #[allow(unused_imports)]
             use $crate::{callsite, callsite::Callsite, Span,  span::SpanExt, field::{Value, AsKey}};
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
@@ -114,7 +115,6 @@ macro_rules! span {
     };
     (@ record: $span:expr, $k:expr, $i:expr, $val:expr) => (
         $span.record($i, &$val)
-            .expect(concat!("adding value for field '", stringify!($k), "' failed"));
     );
     (@ record: $span:expr, $k:expr, $i:expr,) => (
         // skip
@@ -125,6 +125,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
+            #[allow(unused_imports)]
             use $crate::{callsite, Id, Subscriber, Event, span::SpanExt, field::{Value, AsKey}};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:
@@ -140,8 +141,7 @@ macro_rules! event {
                 event.message(
                     &keys.next().expect("event metadata should define a key for the message"),
                     format_args!( $($arg)+ )
-                )
-                .expect("adding value for event message failed");
+                );
                 $(
                     let key = keys.next()
                         .expect(concat!("metadata should define a key for '", stringify!($k), "'"));
@@ -154,8 +154,7 @@ macro_rules! event {
         event!(target: module_path!(), $lvl, { $($k $( = $val)* ),* }, $($arg)+)
     );
     (@ record: $ev:expr, $k:expr, $i:expr, $val:expr) => (
-        $ev.record($i, &$val)
-            .expect(concat!("adding value for field '", stringify!($k), "' failed"));
+        $ev.record($i, &$val);
     );
     (@ record: $ev:expr, $k:expr, $i:expr,) => (
         // skip

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -123,7 +123,7 @@ macro_rules! span {
 
 #[macro_export]
 macro_rules! event {
-    (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
+    (target: $target:expr, $lvl:expr, follows: [ $( $follows:expr),* ], { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
             use $crate::{callsite, SpanAttributes, SpanId, Subscriber, Event, field::Value};
             use $crate::callsite::Callsite;
@@ -133,17 +133,24 @@ macro_rules! event {
                 $target, $( $k ),*
             };
             let field_values: &[ &dyn Value ] = &[ $( &$val ),* ];
+            let follows_from: &[SpanId] = &[ $( $follows ),* ];
             Event::observe(
                 callsite,
                 &field_values[..],
-                &[],
+                &follows_from[..],
                 format_args!( $($arg)+ ),
             );
         }
     });
+    (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $lvl, follows: [],  { $($k = $val),* }, $($arg)+)
+    );
     ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $lvl, { $($k = $val),* }, $($arg)+)
-    )
+    );
+    ($lvl:expr, follows: [ $( $follows:expr),* ], { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
+        event!(target: module_path!(), $lvl, follows: [ $( $follows ),* ], { $($k = $val),* }, $($arg)+)
+    );
 }
 
 mod dispatcher;

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -97,7 +97,7 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
-            use $crate::{callsite, callsite::Callsite, Span};
+            use $crate::{callsite, callsite::Callsite, Span,  span::SpanExt, field::{Value, AsKey}};
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
             // not actually be used, but it doesn't make sense to repeat it.
@@ -125,7 +125,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{callsite, SpanAttributes, Id, Subscriber, Event, field::Value};
+            use $crate::{callsite, Id, Subscriber, Event, span::SpanExt, field::{Value, AsKey}};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:
                 $lvl,
@@ -170,11 +170,11 @@ pub mod subscriber;
 pub use self::{
     dispatcher::Dispatch,
     field::Value,
-    span::{Attributes, Id, Span, SpanAttributes},
+    span::{Attributes, Event, Id, Span, SpanAttributes},
     subscriber::Subscriber,
     tokio_trace_core::{
         callsite::{self, Callsite},
-        Event, Level, Meta, MetaKind,
+        Level, Meta, MetaKind,
     },
 };
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -214,26 +214,6 @@ macro_rules! error {
     );
 }
 
-#[macro_export]
-macro_rules! trace {
-    (target: $target:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::Info, { $($k = $val),* }, $($arg)+)
-    );
-    ({ $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Trace, { $($k = $val),* }, $($arg)+)
-    )
-}
-
-#[macro_export]
-macro_rules! error {
-    (target: $target:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::Error, { $($k = $val),* }, $($arg)+)
-    );
-    ({ $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Error, { $($k = $val),* }, $($arg)+)
-    )
-}
-
 mod dispatcher;
 pub mod field;
 pub mod span;

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -398,7 +398,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .run();
 
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             span!("foo").enter(|| {
                 let mut bar = span!("bar",);
                 let another_bar = bar.enter(|| {
@@ -425,7 +425,7 @@ mod tests {
         // `Subscriber::enabled`, so that the spans will be constructed. We
         // won't enter any spans in this test, so the subscriber won't actually
         // expect to see any spans.
-        Dispatch::to(subscriber::mock().run()).as_default(|| {
+        Dispatch::new(subscriber::mock().run()).as_default(|| {
             span!("foo").enter(|| {
                 let foo1 = Span::current();
                 let foo2 = Span::current();
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn handles_to_different_spans_are_not_equal() {
-        Dispatch::to(subscriber::mock().run()).as_default(|| {
+        Dispatch::new(subscriber::mock().run()).as_default(|| {
             // Even though these spans have the same name and fields, they will have
             // differing metadata, since they were created on different lines.
             let foo1 = span!("foo", bar = 1u64, baz = false);
@@ -456,7 +456,7 @@ mod tests {
             span!("foo", bar = 1u64, baz = false)
         }
 
-        Dispatch::to(subscriber::mock().run()).as_default(|| {
+        Dispatch::new(subscriber::mock().run()).as_default(|| {
             let foo1 = make_span();
             let foo2 = make_span();
 
@@ -474,8 +474,8 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done();
-        let subscriber1 = Dispatch::to(subscriber1.run());
-        let subscriber2 = Dispatch::to(subscriber::mock().run());
+        let subscriber1 = Dispatch::new(subscriber1.run());
+        let subscriber2 = Dispatch::new(subscriber::mock().run());
 
         let mut foo = subscriber1.as_default(|| {
             let mut foo = span!("foo");
@@ -496,7 +496,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done();
-        let subscriber1 = Dispatch::to(subscriber1.run());
+        let subscriber1 = Dispatch::new(subscriber1.run());
         let mut foo = subscriber1.as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
@@ -506,7 +506,7 @@ mod tests {
         // Even though we enter subscriber 2's context, the subscriber that
         // tagged the span should see the enter/exit.
         thread::spawn(move || {
-            Dispatch::to(subscriber::mock().run()).as_default(|| {
+            Dispatch::new(subscriber::mock().run()).as_default(|| {
                 foo.enter(|| {});
             })
         }).join()
@@ -521,7 +521,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
             span.enter(|| {});
             drop(span);
@@ -541,7 +541,7 @@ mod tests {
             .close(span::mock().named(Some("bar")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
 
@@ -562,7 +562,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
 
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn span_doesnt_close_if_it_never_opened() {
         let subscriber = subscriber::mock().done().run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let span = span!("foo");
             drop(span);
         })
@@ -596,13 +596,13 @@ mod tests {
                 .close(span::mock().named(Some("foo")))
                 .done()
                 .run();
-            Dispatch::to(subscriber).as_default(|| span!("foo").into_shared().enter(|| {}))
+            Dispatch::new(subscriber).as_default(|| span!("foo").into_shared().enter(|| {}))
         }
 
         #[test]
         fn span_doesnt_close_if_it_never_opened() {
             let subscriber = subscriber::mock().done().run();
-            Dispatch::to(subscriber).as_default(|| {
+            Dispatch::new(subscriber).as_default(|| {
                 let span = span!("foo").into_shared();
                 drop(span);
             })
@@ -634,7 +634,7 @@ mod tests {
                 .done()
                 .run();
 
-            Dispatch::to(subscriber).as_default(|| {
+            Dispatch::new(subscriber).as_default(|| {
                 let barrier1 = Arc::new(Barrier::new(2));
                 let barrier2 = Arc::new(Barrier::new(2));
                 // Make copies of the barriers for thread 2 to wait on.
@@ -688,7 +688,7 @@ mod tests {
                 .done()
                 .run();
 
-            Dispatch::to(subscriber).as_default(|| {
+            Dispatch::new(subscriber).as_default(|| {
                 span!("foo").enter(|| {
                     let bar = span!("bar").into_shared();
                     bar.clone().enter(|| {

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -30,7 +30,7 @@ mod tests {
                 _ => false,
             }).run();
 
-        Dispatch::to(subscriber).as_default(move || {
+        Dispatch::new(subscriber).as_default(move || {
             // Enter "alice" and then "bob". The dispatcher expects to see "bob" but
             // not "alice."
             let mut alice = span!("alice");
@@ -94,7 +94,7 @@ mod tests {
                     _ => false,
                 }).run();
             // barrier1.wait();
-            let subscriber = Dispatch::to(subscriber);
+            let subscriber = Dispatch::new(subscriber);
             subscriber.as_default(do_test);
             barrier1.wait();
             subscriber.as_default(do_test)
@@ -116,7 +116,7 @@ mod tests {
                     Some("foo") => true,
                     _ => false,
                 }).run();
-            let subscriber = Dispatch::to(subscriber);
+            let subscriber = Dispatch::new(subscriber);
             subscriber.as_default(do_test);
             barrier.wait();
             subscriber.as_default(do_test)
@@ -158,7 +158,7 @@ mod tests {
                 }
             }).run();
 
-        Dispatch::to(subscriber).as_default(move || {
+        Dispatch::new(subscriber).as_default(move || {
             // Enter "charlie" and then "dave". The dispatcher expects to see "dave" but
             // not "charlie."
             let mut charlie = span!("charlie");
@@ -228,7 +228,7 @@ mod tests {
                 _ => false,
             }).run();
 
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             // Call the function once. The filter should be re-evaluated.
             assert!(my_great_function());
             assert_eq!(count.load(Ordering::Relaxed), 1);


### PR DESCRIPTION
Partially addresses #39. I can created macros for other levels, but I personally think the primary levels that we should support are trace/info and error.