### PR TITLE
Make callsite cache invalidation much faster

### DIFF
--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -1,0 +1,30 @@
+#![feature(test)]
+#[macro_use]
+extern crate tokio_trace;
+extern crate test;
+use test::Bencher;
+
+#[bench]
+fn bench_span_no_subscriber(b: &mut Bencher) {
+    let n = test::black_box(1);
+    b.iter(|| {
+        (0..n).fold(0, |old, new| {
+            span!("span");
+            old ^ new
+        })
+    });
+}
+
+#[bench]
+fn bench_no_span_no_subscriber(b: &mut Bencher) {
+    let n = test::black_box(1);
+    b.iter(|| (0..n).fold(0, |new, old| old ^ new));
+}
+
+#[bench]
+fn bench_1_atomic_load(b: &mut Bencher) {
+    let n = test::black_box(1);
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let foo = AtomicUsize::new(1);
+    b.iter(|| (0..n).fold(0, |new, old| foo.load(Ordering::Relaxed) ^ new));
+}

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -23,8 +23,9 @@ fn bench_no_span_no_subscriber(b: &mut Bencher) {
 
 #[bench]
 fn bench_1_atomic_load(b: &mut Bencher) {
+    // This is just included as a baseline.
     let n = test::black_box(1);
     use std::sync::atomic::{AtomicUsize, Ordering};
     let foo = AtomicUsize::new(1);
-    b.iter(|| (0..n).fold(0, |new, old| foo.load(Ordering::Relaxed) ^ new));
+    b.iter(|| (0..n).fold(0, |new, _old| foo.load(Ordering::Relaxed) ^ new));
 }

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -82,7 +82,6 @@ impl Dispatch {
 
     #[doc(hidden)]
     pub fn validate_cache(&self, filtered_by: &RefCell<usize>, meta: &Meta) -> bool {
-
         // If the callsite was last filtered by a different subscriber, assume
         // the filter is no longer valid.
         if *filtered_by.borrow() != self.id {

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -81,15 +81,14 @@ impl Dispatch {
     }
 
     #[doc(hidden)]
-    pub fn validate_cache(&self, filtered_by: &AtomicUsize, meta: &Meta) -> bool {
-        let last_id = filtered_by.load(Ordering::Acquire);
+    pub fn validate_cache(&self, filtered_by: &RefCell<usize>, meta: &Meta) -> bool {
 
         // If the callsite was last filtered by a different subscriber, assume
         // the filter is no longer valid.
-        if last_id != self.id {
+        if *filtered_by.borrow() != self.id {
             // Update the stamp on the call site so this subscriber is now the
             // last to filter it.
-            filtered_by.compare_and_swap(last_id, self.id, Ordering::Release);
+            *filtered_by.borrow_mut() = self.id;
             return true;
         }
 

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -8,7 +8,10 @@ use std::{
     cell::RefCell,
     default::Default,
     fmt,
-    sync::{Arc, atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering}},
+    sync::{
+        atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
+        Arc,
+    },
 };
 
 thread_local! {
@@ -27,7 +30,7 @@ impl Dispatch {
     pub fn none() -> Self {
         Dispatch {
             subscriber: Arc::new(NoSubscriber),
-            gen: 0
+            gen: 0,
         }
     }
 
@@ -103,9 +106,7 @@ impl fmt::Debug for Dispatch {
 
 impl Default for Dispatch {
     fn default() -> Self {
-        CURRENT_DISPATCH.with(|current| {
-            current.borrow().clone()
-        })
+        CURRENT_DISPATCH.with(|current| current.borrow().clone())
     }
 }
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -146,10 +146,11 @@ macro_rules! meta {
 macro_rules! cached_filter {
     ($meta:expr, $dispatcher:expr) => {{
         use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+        static FILTERED_BY: AtomicUsize = ATOMIC_USIZE_INIT;
         static FILTERED: AtomicUsize = ATOMIC_USIZE_INIT;
         const ENABLED: usize = 1;
         const DISABLED: usize = 2;
-        if $dispatcher.should_invalidate_filter($meta) {
+        if $dispatcher.validate_cache(&FILTERED_BY, $meta) {
             let enabled = $dispatcher.enabled(&META);
             if enabled {
                 FILTERED.store(ENABLED, Ordering::Relaxed);

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -145,38 +145,46 @@ macro_rules! meta {
 #[macro_export]
 macro_rules! cached_filter {
     ($meta:expr, $dispatcher:expr) => {{
-        use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
-        // TODO: maybe we should bundle all this callsite-specific data together
-        // into a struct or something...
-        static FILTERED_BY: AtomicUsize = ATOMIC_USIZE_INIT;
-        static FILTERED: AtomicUsize = ATOMIC_USIZE_INIT;
-        const ENABLED: usize = 1;
-        const DISABLED: usize = 2;
-        if $dispatcher.validate_cache(&FILTERED_BY, $meta) {
+        use std::cell::RefCell;
+        thread_local! {
+            // TODO: maybe we should bundle all this callsite-specific data together
+            // into a struct or something...
+            static FILTERED_BY: RefCell<usize> = RefCell::new(0);
+            static FILTERED: RefCell<u8> = RefCell::new(0);
+        }
+
+        // TODO: since this is now stored in a RefCell rather than as an atomic, we
+        // can just use an enum rather than a number...
+        const ENABLED: u8 = 1;
+        const DISABLED: u8 = 2;
+        if FILTERED_BY.with(|filtered_by| $dispatcher.validate_cache(filtered_by, $meta)) {
             let enabled = $dispatcher.enabled(&META);
-            if enabled {
-                FILTERED.store(ENABLED, Ordering::Relaxed);
-            } else {
-                FILTERED.store(DISABLED, Ordering::Relaxed);
-            }
+            FILTERED.with(|filtered| {
+                *filtered.borrow_mut() = if enabled {
+                    ENABLED
+                } else {
+                    DISABLED
+                };
+            });
             enabled
         } else {
-            match FILTERED.load(Ordering::Relaxed) {
-                // If there's a cached result, use that.
-                ENABLED => true,
-                DISABLED => false,
-                // Otherwise, this span has not yet been filtered, so call
-                // `enabled` now and store the result.
-                _ => {
-                    let enabled = $dispatcher.enabled(&META);
-                    if enabled {
-                        FILTERED.store(ENABLED, Ordering::Relaxed);
-                    } else {
-                        FILTERED.store(DISABLED, Ordering::Relaxed);
-                    }
-                    enabled
+            FILTERED.with(|filtered| {
+                match *filtered.borrow() {
+                    // If there's a cached result, use that.
+                    ENABLED => return true,
+                    DISABLED => return false,
+                    // Otherwise, this span has not yet been filtered, so call
+                    // `enabled` now and store the result.
+                    _=> { }
                 }
-            }
+                let enabled = $dispatcher.enabled(&META);
+                *filtered.borrow_mut() = if enabled {
+                    ENABLED
+                } else {
+                    DISABLED
+                };
+                enabled
+            })
         }
     }};
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -160,11 +160,7 @@ macro_rules! cached_filter {
         if FILTERED_BY.with(|filtered_by| $dispatcher.validate_cache(filtered_by, $meta)) {
             let enabled = $dispatcher.enabled(&META);
             FILTERED.with(|filtered| {
-                *filtered.borrow_mut() = if enabled {
-                    ENABLED
-                } else {
-                    DISABLED
-                };
+                *filtered.borrow_mut() = if enabled { ENABLED } else { DISABLED };
             });
             enabled
         } else {
@@ -175,14 +171,10 @@ macro_rules! cached_filter {
                     DISABLED => return false,
                     // Otherwise, this span has not yet been filtered, so call
                     // `enabled` now and store the result.
-                    _=> { }
+                    _ => {}
                 }
                 let enabled = $dispatcher.enabled(&META);
-                *filtered.borrow_mut() = if enabled {
-                    ENABLED
-                } else {
-                    DISABLED
-                };
+                *filtered.borrow_mut() = if enabled { ENABLED } else { DISABLED };
                 enabled
             })
         }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -146,6 +146,8 @@ macro_rules! meta {
 macro_rules! cached_filter {
     ($meta:expr, $dispatcher:expr) => {{
         use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+        // TODO: maybe we should bundle all this callsite-specific data together
+        // into a struct or something...
         static FILTERED_BY: AtomicUsize = ATOMIC_USIZE_INIT;
         static FILTERED: AtomicUsize = ATOMIC_USIZE_INIT;
         const ENABLED: usize = 1;


### PR DESCRIPTION
When a call site caches a filter evaluation for a particular piece of
metadata, the cached filter result will need to be evaluated if the
subscriber context changes. These subscribers may have different filters
which may return different results for the same metadata, so we must not
use the cached result from one subscriber when the current subscriber
has changed.

Currently, this invalidation is implemented by having the dispatcher
track a set of the hashes of all the callsites it has filtered since the
last subscriber switch. This has serious performance implementations.

This branch changes the approach to have the call-site store an ID of
the last subscriber that filtered it, and assigning a unique ID to every
new dispatcher that's created. By comparing the ID of the current
dispatcher with that of the last one to filter the subscriber, we can
determine if the cached filter invocation is still valid.

I've also written a quick benchmark to assess the overhead of creating a
span when there isn't currently a subscriber, compared to not creating a
span at all.

Here's the benchmark results before this change:
```
     Running target/release/deps/no_subscriber-4d55a6a1581e9283

running 3 tests
test bench_1_atomic_load         ... bench:           0 ns/iter (+/- 0)
test bench_no_span_no_subscriber ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber    ... bench:         113 ns/iter (+/- 17)
```

And after:
```
     Running target/release/deps/no_subscriber-4d55a6a1581e9283

running 3 tests
test bench_1_atomic_load         ... bench:           0 ns/iter (+/- 0)
test bench_no_span_no_subscriber ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber    ... bench:          31 ns/iter (+/- 3)
```

This is part of the work towards  #61.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>