### PR TITLE
Remove futures dependency from core crate

### DIFF
--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -14,3 +14,4 @@ ansi_term = "0.11"
 humantime = "1.1.1"
 env_logger = "0.5"
 tokio-trace-log = { path = "../tokio-trace-log" }
+futures = "0.1"

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -8,7 +8,6 @@ default = []
 test-support =  []
 
 [dependencies]
-futures = "0.1"
 
 [dev-dependencies]
 ansi_term = "0.11"

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -103,7 +103,6 @@
 //! [`enabled`]: subscriber/trait.Subscriber.html#tymethod.enabled
 //! [metadata]: struct.Meta.html
 #![warn(missing_docs)]
-extern crate futures;
 
 use std::{fmt, slice};
 


### PR DESCRIPTION
This was supposed to be removed in #33 but I must've missed it.

Closes #56.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>