### PR TITLE
Give callsite caches a slightly nicer API

### DIFF
--- a/tokio-trace/src/callsite.rs
+++ b/tokio-trace/src/callsite.rs
@@ -2,37 +2,31 @@ use std::cell::Cell;
 use ::{
     Dispatch,
     Meta,
+    Subscriber,
 };
 
-/// Caches callsite-specific data.
-pub struct Callsite<'a> {
-    last_filtered_by: Cell<usize>,
-    filtered: Cell<Filtered>,
-    meta: &'a Meta<'a>,
+#[doc(hidden)]
+pub struct Cache<'a> {
+    // TODO: these fields _should_ be private, but they have to be public so
+    // that callsite caches can be constructed by a macro. When const fns are
+    // stable, the callsite cache can just have a `const fn` constructor
+    // instead.
+    #[doc(hidden)]
+    pub last_filtered_by: Cell<usize>,
+    #[doc(hidden)]
+    pub cached_filter: Cell<Option<bool>>,
+    #[doc(hidden)]
+    pub meta: &'a Meta<'a>,
 }
 
-enum Filtered {
-    Unknown,
-    Enabled,
-    Disabled,
-}
-
-impl<'a> Callsite<'a> {
-    pub const fn new(meta: &'a Meta<'a>) -> Self {
-        Self {
-            last_filtered_by: Cell::new(0),
-            filtered: Cell::new(Filtered::Unknown),
-            meta,
-        }
-    }
-
+impl<'a> Cache<'a> {
     #[inline]
-    pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
+    pub fn is_invalid(&self, dispatch: &Dispatch) -> bool {
         let id = dispatch.id();
 
         // If the callsite was last filtered by a different subscriber, assume
         // the filter is no longer valid.
-        if self.last_filtered_by.get() != id {
+        if self.cached_filter.get().is_none() || self.last_filtered_by.get() != id {
             // Update the stamp on the call site so this subscriber is now the
             // last to filter it.
             self.last_filtered_by.set(id);
@@ -40,7 +34,22 @@ impl<'a> Callsite<'a> {
         }
 
         // Otherwise, just ask the subscriber what it thinks.
-        dispatch.should_invalidate_filter(&self.meta)
+        dispatch.should_invalidate_filter(self.metadata())
+    }
+
+    #[inline]
+    pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
+        if self.is_invalid(dispatch) {
+            let enabled = dispatch.enabled(self.metadata());
+            self.cached_filter.set(Some(enabled));
+            enabled
+        } else if let Some(cached) = self.cached_filter.get() {
+            cached
+        } else {
+            let enabled = dispatch.enabled(self.metadata());
+            self.cached_filter.set(Some(enabled));
+            enabled
+        }
     }
 
     #[inline]

--- a/tokio-trace/src/callsite.rs
+++ b/tokio-trace/src/callsite.rs
@@ -1,0 +1,50 @@
+use std::cell::Cell;
+use ::{
+    Dispatch,
+    Meta,
+};
+
+/// Caches callsite-specific data.
+pub struct Callsite<'a> {
+    last_filtered_by: Cell<usize>,
+    filtered: Cell<Filtered>,
+    meta: &'a Meta<'a>,
+}
+
+enum Filtered {
+    Unknown,
+    Enabled,
+    Disabled,
+}
+
+impl<'a> Callsite<'a> {
+    pub const fn new(meta: &'a Meta<'a>) -> Self {
+        Self {
+            last_filtered_by: Cell::new(0),
+            filtered: Cell::new(Filtered::Unknown),
+            meta,
+        }
+    }
+
+    #[inline]
+    pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
+        let id = dispatch.id();
+
+        // If the callsite was last filtered by a different subscriber, assume
+        // the filter is no longer valid.
+        if self.last_filtered_by.get() != id {
+            // Update the stamp on the call site so this subscriber is now the
+            // last to filter it.
+            self.last_filtered_by.set(id);
+            return true;
+        }
+
+        // Otherwise, just ask the subscriber what it thinks.
+        dispatch.should_invalidate_filter(&self.meta)
+    }
+
+    #[inline]
+    pub fn metadata(&self) -> &'a Meta<'a> {
+        self.meta
+    }
+}

--- a/tokio-trace/src/callsite.rs
+++ b/tokio-trace/src/callsite.rs
@@ -1,9 +1,5 @@
 use std::cell::Cell;
-use ::{
-    Dispatch,
-    Meta,
-    Subscriber,
-};
+use {Dispatch, Meta, Subscriber};
 
 #[doc(hidden)]
 pub struct Cache<'a> {

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -81,18 +81,9 @@ impl Dispatch {
     }
 
     #[doc(hidden)]
-    pub fn validate_cache(&self, filtered_by: &RefCell<usize>, meta: &Meta) -> bool {
-        // If the callsite was last filtered by a different subscriber, assume
-        // the filter is no longer valid.
-        if *filtered_by.borrow() != self.id {
-            // Update the stamp on the call site so this subscriber is now the
-            // last to filter it.
-            *filtered_by.borrow_mut() = self.id;
-            return true;
-        }
-
-        // Otherwise, just ask the subscriber what it thinks.
-        self.subscriber.should_invalidate_filter(meta)
+    #[inline]
+    pub fn id(&self) -> usize {
+        self.id
     }
 }
 


### PR DESCRIPTION
This branch refactors the callsite caching code to use a `struct` to
bundle together the caches, and struct methods rather than macros to
interact with the cache. This puts us on the path to eventually
exporting a public API for the callsite cache to the other crates.

This doesn't have a significant impact on the existing benchmarks:
```
     Running target/release/deps/no_subscriber-9424dd66075149b8

running 3 tests
test bench_1_atomic_load         ... bench:           0 ns/iter (+/- 0)
test bench_no_span_no_subscriber ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber    ... bench:          31 ns/iter (+/- 0)
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>