### PR TITLE
Rename `prior_span` back to `follows_from`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -121,12 +121,12 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_prior_span(
+    fn add_follows_from(
         &self,
         span: &span::Id,
         follows: span::Id,
-    ) -> Result<(), subscriber::PriorError> {
-        self.subscriber.add_prior_span(span, follows)
+    ) -> Result<(), subscriber::FollowsError> {
+        self.subscriber.add_follows_from(span, follows)
     }
 
     #[inline]
@@ -166,11 +166,11 @@ impl Subscriber for NoSubscriber {
         Ok(())
     }
 
-    fn add_prior_span(
+    fn add_follows_from(
         &self,
         _span: &span::Id,
         _follows: span::Id,
-    ) -> Result<(), subscriber::PriorError> {
+    ) -> Result<(), subscriber::FollowsError> {
         Ok(())
     }
 

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -10,7 +10,7 @@ use std::{
     },
 };
 use {
-    subscriber::{AddValueError, PriorError, Subscriber},
+    subscriber::{AddValueError, FollowsError, Subscriber},
     value::{IntoValue, OwnedValue},
     DebugFields, Dispatch, StaticMeta,
 };
@@ -222,13 +222,13 @@ impl Span {
     /// If this span is disabled, this function will do nothing. Otherwise, it
     /// returns `Ok(())` if the other span was added as a precedent of this
     /// span, or an error if this was not possible.
-    pub fn follows<I: AsId>(&self, from: I) -> Result<(), PriorError> {
+    pub fn follows_from<I: AsId>(&self, from: I) -> Result<(), FollowsError> {
         if let Some(ref inner) = self.inner {
-            let from_id = from.as_id().ok_or(PriorError::NoPreceedingId)?;
+            let from_id = from.as_id().ok_or(FollowsError::NoPreceedingId)?;
             let inner = &inner.inner;
-            match inner.subscriber.add_prior_span(&inner.id, from_id) {
+            match inner.subscriber.add_follows_from(&inner.id, from_id) {
                 Ok(()) => Ok(()),
-                Err(PriorError::NoSpan(ref id)) if id == &inner.id => {
+                Err(FollowsError::NoSpan(ref id)) if id == &inner.id => {
                     panic!("span {:?} should exist to add a preceeding span", inner.id)
                 }
                 Err(e) => Err(e),

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -89,10 +89,10 @@ pub trait Subscriber {
     /// if one or both of the given span IDs do not correspond to spans that the
     /// subscriber knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
-    /// follow from _b_), it should return a [`PriorError`].
+    /// follow from _b_), it should return a [`FollowsError`].
     ///
-    /// [`PriorError`]: PriorError
-    fn add_prior_span(&self, span: &span::Id, follows: span::Id) -> Result<(), PriorError>;
+    /// [`FollowsError`]: FollowsError
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsError>;
 
     // === Filtering methods ==================================================
 
@@ -197,9 +197,9 @@ pub enum AddValueError {
 // TODO: before releasing core 0.1 this needs to be made private, to avoid
 // future breaking changes.
 #[derive(Clone, Debug)]
-pub enum PriorError {
+pub enum FollowsError {
     /// The span with the given ID does not exist.
-    /// TODO: can this error type be generalized between `PriorError` and
+    /// TODO: can this error type be generalized between `FollowsError` and
     /// `AddValueError`?
     NoSpan(SpanId),
     /// The span that this span follows from does not exist (it has no ID).
@@ -302,7 +302,7 @@ mod test_support {
             Ok(())
         }
 
-        fn add_prior_span(&self, _span: &span::Id, _follows: span::Id) -> Result<(), PriorError> {
+        fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), FollowsError> {
             // TODO: it should be possible to expect spans to follow from other spans
             Ok(())
         }

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -302,7 +302,11 @@ mod test_support {
             Ok(())
         }
 
-        fn add_follows_from(&self, _span: &span::Id, _follows: span::Id) -> Result<(), FollowsError> {
+        fn add_follows_from(
+            &self,
+            _span: &span::Id,
+            _follows: span::Id,
+        ) -> Result<(), FollowsError> {
             // TODO: it should be possible to expect spans to follow from other spans
             Ok(())
         }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -194,11 +194,11 @@ impl Subscriber for TraceLogger {
         Ok(())
     }
 
-    fn add_prior_span(
+    fn add_follows_from(
         &self,
         span: &span::Id,
         follows: span::Id,
-    ) -> Result<(), subscriber::PriorError> {
+    ) -> Result<(), subscriber::FollowsError> {
         // TODO: this should eventually track the relationship?
         log::logger().log(
             &log::Record::builder()

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     span,
-    subscriber::{AddValueError, PriorError, Subscriber},
+    subscriber::{AddValueError, FollowsError, Subscriber},
     Event, IntoValue, Meta, SpanData,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
@@ -116,8 +116,8 @@ where
         self.registry.add_value(span, name, value)
     }
 
-    fn add_prior_span(&self, span: &span::Id, follows: span::Id) -> Result<(), PriorError> {
-        self.registry.add_prior_span(span, follows)
+    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsError> {
+        self.registry.add_follows_from(span, follows)
     }
 
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     span::{Data, Id, State},
-    subscriber::{AddValueError, PriorError},
+    subscriber::{AddValueError, FollowsError},
     value::{IntoValue, OwnedValue},
 };
 
@@ -64,8 +64,8 @@ pub trait RegisterSpan {
     /// if one or both of the given span IDs do not correspond to spans that the
     /// registry knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
-    /// follow from _b_), it should return a `PriorError`.
-    fn add_prior_span(&self, span: &Id, follows: Id) -> Result<(), PriorError>;
+    /// follow from _b_), it should return a `FollowsError`.
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError>;
 
     /// Queries the registry for an iterator over the IDs of the spans that
     /// `span` follows from.
@@ -152,7 +152,7 @@ impl RegisterSpan for IncreasingCounter {
         span.add_value(name, value)
     }
 
-    fn add_prior_span(&self, _span: &Id, _follows: Id) -> Result<(), PriorError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -52,11 +52,11 @@ impl Subscriber for CounterSubscriber {
             .add_value(name, value)
     }
 
-    fn add_prior_span(
+    fn add_follows_from(
         &self,
         _span: &span::Id,
         _follows: span::Id,
-    ) -> Result<(), subscriber::PriorError> {
+    ) -> Result<(), subscriber::FollowsError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -126,11 +126,11 @@ impl Subscriber for SloggishSubscriber {
         span.add_value(name, value)
     }
 
-    fn add_prior_span(
+    fn add_follows_from(
         &self,
         _span: &tokio_trace::SpanId,
         _follows: tokio_trace::SpanId,
-    ) -> Result<(), subscriber::PriorError> {
+    ) -> Result<(), subscriber::FollowsError> {
         // unimplemented
         Ok(())
     }


### PR DESCRIPTION
This branch changes the `prior_span` naming back to `follows_from`. This
naming better implies causality.

Closes #59 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>