### PR TITLE
Attempt to encapsulate the callsite cache's thread-locality

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -3,19 +3,20 @@ use {Dispatch, Meta, Subscriber};
 
 #[doc(hidden)]
 pub struct Cache<'a> {
-    // TODO: these fields _should_ be private, but they have to be public so
-    // that callsite caches can be constructed by a macro. When const fns are
-    // stable, the callsite cache can just have a `const fn` constructor
-    // instead.
-    #[doc(hidden)]
-    pub last_filtered_by: Cell<usize>,
-    #[doc(hidden)]
-    pub cached_filter: Cell<Option<bool>>,
-    #[doc(hidden)]
-    pub meta: &'a Meta<'a>,
+    last_filtered_by: Cell<usize>,
+    cached_filter: Cell<Option<bool>>,
+    meta: &'a Meta<'a>,
 }
 
 impl<'a> Cache<'a> {
+    pub fn new(meta: &'a Meta<'a>) -> Self {
+        Self {
+            last_filtered_by: Cell::new(0),
+            cached_filter: Cell::new(None),
+            meta,
+        }
+    }
+
     #[inline]
     pub fn is_invalid(&self, dispatch: &Dispatch) -> bool {
         let id = dispatch.id();

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -1,11 +1,49 @@
-use std::cell::Cell;
-use {Dispatch, Meta, Subscriber};
+use std::{
+    cell::Cell,
+    thread::LocalKey,
+};
+use {Dispatch, Meta, Subscriber, Span};
+
+#[derive(Debug)]
+pub struct Callsite(&'static LocalKey<Cache<'static>>);
 
 #[doc(hidden)]
 pub struct Cache<'a> {
     last_filtered_by: Cell<usize>,
     cached_filter: Cell<Option<bool>>,
     meta: &'a Meta<'a>,
+}
+
+impl Callsite {
+    #[doc(hidden)]
+    pub fn new(cache: &'static LocalKey<Cache<'static>>) -> Self {
+        Callsite(cache)
+    }
+
+    #[inline]
+    pub fn new_span(&self, dispatch: Dispatch) -> Span {
+        self.0.with(|cache| {
+            if cache.is_enabled(&dispatch) {
+                Span::new(dispatch, cache.metadata())
+            } else {
+                Span::new_disabled()
+            }
+        })
+    }
+
+    #[inline]
+    pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
+        self.0.with(|cache| {
+            cache.is_enabled(dispatch)
+        })
+    }
+
+    #[inline]
+    pub fn metadata(&self) -> &'static Meta<'static> {
+        self.0.with(|cache| {
+            cache.meta
+        })
+    }
 }
 
 impl<'a> Cache<'a> {

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -1,8 +1,5 @@
-use std::{
-    cell::Cell,
-    thread::LocalKey,
-};
-use {Dispatch, Meta, Subscriber, Span};
+use std::{cell::Cell, thread::LocalKey};
+use {Dispatch, Meta, Span, Subscriber};
 
 #[derive(Debug)]
 pub struct Callsite(&'static LocalKey<Cache<'static>>);
@@ -33,16 +30,12 @@ impl Callsite {
 
     #[inline]
     pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
-        self.0.with(|cache| {
-            cache.is_enabled(dispatch)
-        })
+        self.0.with(|cache| cache.is_enabled(dispatch))
     }
 
     #[inline]
     pub fn metadata(&self) -> &'static Meta<'static> {
-        self.0.with(|cache| {
-            cache.meta
-        })
+        self.0.with(|cache| cache.meta)
     }
 }
 

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -106,21 +106,6 @@
 
 use std::{fmt, slice};
 
-// Cache the result of testing if a span or event with the given metadata is
-// enabled by the current subscriber, so the filter doesn't have to be
-// reapplied if we have already called `enabled`.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! callsite {
-    ($meta:expr) => {
-        $crate::callsite::Cache {
-            last_filtered_by: ::std::cell::Cell::new(0),
-            cached_filter: ::std::cell::Cell::new(None),
-            meta: $meta,
-        }
-    };
-}
-
 /// Describes the level of verbosity of a `Span` or `Event`.
 #[repr(usize)]
 #[derive(Copy, Eq, Debug, Hash)]

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -1,44 +1,5 @@
 extern crate tokio_trace_core;
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! callsite {
-    (span: $name:expr, $( $field_name:ident ),*) => ({
-        $crate::Meta {
-            name: Some($name),
-            target: module_path!(),
-            level: $crate::Level::Trace,
-            module_path: Some(module_path!()),
-            file: Some(file!()),
-            line: Some(line!()),
-            field_names: &[ $(stringify!($field_name)),* ],
-            kind: $crate::Kind::Span,
-        }
-    });
-    (event: $lvl:expr, $( $field_name:ident ),*) =>
-        (callsite!(event: $lvl, target: module_path!(), $( $field_name ),* ));
-    (event: $lvl:expr, target: $target:expr, $( $field_name:ident ),*) => ({
-        $crate::Meta {
-            name: None,
-            target: $target,
-            level: $lvl,
-            module_path: Some(module_path!()),
-            file: Some(file!()),
-            line: Some(line!()),
-            field_names: &[ $(stringify!($field_name)),* ],
-            kind: $crate::Kind::Event,
-        }
-    });
-    (@ $meta:expr ) => ({
-        use $crate::{callsite, Meta};
-        static META: Meta = $meta;
-        thread_local! {
-            static CACHE: callsite::Cache = callsite::Cache::new(&META);
-        }
-        callsite::Callsite::new(&CACHE)
-    })
-}
-
 /// Constructs a new span.
 ///
 /// # Examples
@@ -70,20 +31,9 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
-            use $crate::{callsite, Span, Dispatch, Meta};
-            static META: Meta<'static> = meta! { span: $name, $( $k ),* };
-            thread_local! {
-                // TODO: if callsite caches become an API, can we better
-                // encapsulate the thread-local-iness of them? Do we want to?
-                static CALLSITE: callsite::Cache<'static> = callsite::Cache::new(&META);
-            }
-            let dispatcher = Dispatch::current();
-            // TODO: should span construction just become a method on callsites?
-            let span = if CALLSITE.with(|c| c.is_enabled(&dispatcher)) {
-                Span::new(dispatcher, &META)
-            } else {
-                Span::new_disabled()
-            };
+            use $crate::{callsite, Dispatch};
+            let callsite = callsite! { span: $name, $( $k ),* };
+            let span = callsite.new_span(Dispatch::current());
             $(
                 span.add_value(stringify!($k), $( $val )* )
                     .expect(concat!("adding value for field ", stringify!($k), " failed"));
@@ -97,22 +47,19 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{callsite, Dispatch, Meta, SpanData, SpanId, Subscriber, Event, value::AsValue};
-            static META: Meta<'static> = meta! { event:
+            use $crate::{callsite, Dispatch, SpanData, SpanId, Subscriber, Event, value::AsValue};
+            let callsite = callsite! { event:
                 $lvl,
                 target:
                 $target, $( $k ),*
             };
-            thread_local! {
-                static CALLSITE: callsite::Cache<'static> = callsite::Cache::new(&META);
-            }
             let dispatcher = Dispatch::current();
-            if CALLSITE.with(|c| c.is_enabled(&dispatcher)) {
+            if callsite.is_enabled(&dispatcher) {
                 let field_values: &[ &dyn AsValue ] = &[ $( &$val ),* ];
                 dispatcher.observe_event(&Event {
                     parent: SpanId::current(),
                     follows_from: &[],
-                    meta: &META,
+                    meta: callsite.metadata(),
                     field_values: &field_values[..],
                     message: format_args!( $($arg)+ ),
                 });

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -67,7 +67,7 @@ macro_rules! span {
             thread_local! {
                 // TODO: if callsite caches become an API, can we better
                 // encapsulate the thread-local-iness of them? Do we want to?
-                static CALLSITE: callsite::Cache<'static> = callsite!(&META);
+                static CALLSITE: callsite::Cache<'static> = callsite::Cache::new(&META);
             }
             let dispatcher = Dispatch::current();
             // TODO: should span construction just become a method on callsites?
@@ -96,7 +96,7 @@ macro_rules! event {
                 $target, $( $k ),*
             };
             thread_local! {
-                static CALLSITE: callsite::Cache<'static> = callsite!(&META);
+                static CALLSITE: callsite::Cache<'static> = callsite::Cache::new(&META);
             }
             let dispatcher = Dispatch::current();
             if CALLSITE.with(|c| c.is_enabled(&dispatcher)) {


### PR DESCRIPTION
This branch is an attempt to hide more of the implementation details
behind the callsite cache, so that it can become part of a public API. 

Unfortunately, the `Cache` type still needs to be `#[doc(hidden)] pub`,
as it still needs to be constructed in a macro so that the appropriate
number of thread-locals are generated (per-callsite, not globally within
the `new` function), but the fields can now be private, and the `span!`
and `event!` macros are now written against an API that doesn't expose
the thread-local behind the cache. So, this is a step in the right
direction, I hope.

Also, callsites can now construct `Span`s. Hopefully this will allow us
to avoid exposing the "is the span disabled" logic, while also providing
a way to construct spans other than using the span macro.

For future work, I'd like callsites to know how to construct events as
well (so we can get rid of the pub fields on events).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>