### PR TITLE
Rework span entry and exit APIs

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -140,13 +140,18 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn enter(&self, span: span::Id, state: span::State) {
-        self.subscriber.enter(span, state)
+    fn enter(&self, span: span::Id) {
+        self.subscriber.enter(span)
     }
 
     #[inline]
-    fn exit(&self, span: span::Id, state: span::State) {
-        self.subscriber.exit(span, state)
+    fn exit(&self, span: span::Id) {
+        self.subscriber.exit(span)
+    }
+
+    #[inline]
+    fn close(&self, span: span::Id) {
+        self.subscriber.close(span)
     }
 }
 
@@ -182,7 +187,9 @@ impl Subscriber for NoSubscriber {
         // Do nothing.
     }
 
-    fn enter(&self, _span: span::Id, _state: span::State) {}
+    fn enter(&self, _span: span::Id) {}
 
-    fn exit(&self, _span: span::Id, _state: span::State) {}
+    fn exit(&self, _span: span::Id) {}
+
+    fn close(&self, _span: span::Id) {}
 }

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -19,39 +19,6 @@
 //! represented by its children. Thus, a parent span always lasts for at least
 //! as long as the longest-executing span in its subtree.
 //!
-//! Furthermore, execution may enter and exit a span multiple times before that
-//! span is _completed_. Consider, for example, a future which has an associated
-//! span and enters that span every time it is polled:
-//! ```rust
-//! # extern crate tokio_trace_core as tokio_trace;
-//! # extern crate futures;
-//! # use futures::{Future, Poll, Async};
-//! struct MyFuture {
-//!    // data
-//!    span: tokio_trace::Span,
-//! }
-//!
-//! impl Future for MyFuture {
-//!     type Item = ();
-//!     type Error = ();
-//!
-//!     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//!         self.span.enter(|| {
-//!             // Do actual future work
-//! # Ok(Async::Ready(()))
-//!         })
-//!     }
-//! }
-//! ```
-//!
-//! If this future was spawned on an executor, it might yield one or more times
-//! before `poll` returns `Ok(Async::Ready)`. If the future were to yield, then
-//! the executor would move on to poll the next future, which may _also_ enter
-//! an associated span or series of spans. Therefore, it is valid for a span to
-//! be entered repeatedly before it completes. Only the time when that span or
-//! one of its children was the current span is considered to be time spent in
-//! that span.
-//!
 //! In addition, data may be associated with spans. A span may have _fields_ ---
 //! a set of key-value pairs describing the state of the program during that
 //! span; an optional name, and metadata describing the source code location

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -36,7 +36,7 @@
 //!     type Error = ();
 //!
 //!     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//!         self.span.clone().enter(|| {
+//!         self.span.enter(|| {
 //!             // Do actual future work
 //! # Ok(Async::Ready(()))
 //!         })

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -4,7 +4,7 @@ use std::{
     cmp, fmt,
     hash::{Hash, Hasher},
     iter, slice,
-    sync::atomic::{AtomicUsize, AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use {
     subscriber::{AddValueError, FollowsError, Subscriber},
@@ -159,7 +159,6 @@ impl Span {
             None => f(),
         }
     }
-
 
     /// Returns the `Id` of the parent of this span, if one exists.
     pub fn parent(&self) -> Option<Id> {
@@ -395,7 +394,7 @@ impl AsId for Id {
 
 impl Enter {
     fn new(id: Id, subscriber: Dispatch, parent: Option<Id>) -> Self {
-       Self {
+        Self {
             id,
             subscriber,
             parent,
@@ -425,12 +424,8 @@ impl Enter {
         self.handles.fetch_sub(1, Ordering::Release);
         self.has_entered.store(true, Ordering::Release);
         self.subscriber.enter(self.id());
-        let prior = CURRENT_SPAN.with(|current_span| {
-            current_span.replace(Some(self))
-        });
-        Entered {
-            prior,
-        }
+        let prior = CURRENT_SPAN.with(|current_span| current_span.replace(Some(self)));
+        Entered { prior }
     }
 
     fn close(&self) {
@@ -485,9 +480,8 @@ impl Drop for Enter {
                 _ if self.handle_count() <= 1 => {
                     self.subscriber.close(self.id());
                 }
-                _ => {},
+                _ => {}
             })
-
         }
     }
 }
@@ -495,7 +489,8 @@ impl Drop for Enter {
 impl Entered {
     fn exit(self) -> Option<Enter> {
         CURRENT_SPAN.with(|current_span| {
-            let inner = current_span.replace(self.prior)
+            let inner = current_span
+                .replace(self.prior)
                 .expect("cannot exit span that wasn't entered");
             inner.subscriber.exit(inner.id());
             if inner.should_close() {

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -196,6 +196,7 @@ impl Span {
     /// Signals that this span should close the next time it is exited, or when
     /// it is dropped.
     pub fn close(&mut self) {
+        self.is_closed = true;
         self.inner.take().as_ref().map(Enter::close);
     }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -364,7 +364,6 @@ mod test_support {
             let span = spans
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
-            println!("enter:\t{:?}", span.name());
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => panic!(
@@ -399,8 +398,6 @@ mod test_support {
             let span = spans
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
-
-            println!("exit:\t{:?}", span.name());
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => panic!(
@@ -435,7 +432,6 @@ mod test_support {
             let span = spans
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
-            println!("close:\t{:?}", span.name());
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => panic!(

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -270,8 +270,7 @@ mod test_support {
 
     impl<F: Fn(&Meta) -> bool> MockSubscriber<F> {
         pub fn enter(mut self, span: MockSpan) -> Self {
-            self.expected
-                .push_back(Expect::Enter(span));
+            self.expected.push_back(Expect::Enter(span));
             self
         }
 
@@ -357,8 +356,9 @@ mod test_support {
                     "expected to close span {:?} but got an event",
                     expected_span.name,
                 ),
-                Some(Expect::Nothing) =>
-                    panic!("expected nothing else to happen, but got an event"),
+                Some(Expect::Nothing) => {
+                    panic!("expected nothing else to happen, but got an event")
+                }
             }
         }
 
@@ -456,7 +456,7 @@ mod test_support {
                         assert_eq!(name, span.name());
                     }
                     // TODO: expect fields
-                },
+                }
                 Some(Expect::Nothing) => panic!(
                     "expected nothing else to happen, but closed span {:?}",
                     span.name(),

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -278,7 +278,7 @@ mod test_support {
         }
 
         pub fn close(mut self, span: MockSpan) -> Self {
-            self.expected.push_back(Expect::Exit(span));
+            self.expected.push_back(Expect::Close(span));
             self
         }
 
@@ -364,6 +364,7 @@ mod test_support {
             let span = spans
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
+            println!("enter:\t{:?}", span.name());
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => panic!(
@@ -398,6 +399,8 @@ mod test_support {
             let span = spans
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
+
+            println!("exit:\t{:?}", span.name());
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => panic!(
@@ -432,6 +435,7 @@ mod test_support {
             let span = spans
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
+            println!("close:\t{:?}", span.name());
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => panic!(
@@ -448,12 +452,12 @@ mod test_support {
                     expected_span.name,
                     span.name()
                 ),
-                Some(Expect::Close(expected_span)) => panic!(
+                Some(Expect::Close(expected_span)) => {
                     if let Some(name) = expected_span.name {
                         assert_eq!(name, span.name());
                     }
                     // TODO: expect fields
-                ),
+                },
                 Some(Expect::Nothing) => panic!(
                     "expected nothing else to happen, but closed span {:?}",
                     span.name(),

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -18,7 +18,8 @@ use {span, Event, IntoValue, Meta, SpanId};
 ///   spans.
 /// - Filtering spans and events, and determining when those filters must be
 ///   invalidated.
-/// - Observing spans as they are entered and exited, and events as they occur.
+/// - Observing spans as they are entered, exited, and closed, and events as
+///   they occur.
 ///
 /// When a span is entered or exited, the subscriber is provided only with the
 /// [`SpanId`] with which it tagged that span when it was created. This means
@@ -181,7 +182,9 @@ pub trait Subscriber {
     /// [`SpanId`] that identifies the closed span.
     ///
     /// Unlike `exit`, this method implies that the span will not be entered
-    /// again.
+    /// again. The subscriber is free to use that guarantee as it sees fit (such
+    /// as garbage-collecting any cached data related to that span, if
+    /// necessary).
     ///
     /// [`Span`]: ::span::Span
     /// [`SpanId`]: ::span::Id

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -243,6 +243,7 @@ mod test_support {
         Enter(MockSpan),
         Exit(MockSpan),
         Close(MockSpan),
+        Nothing,
     }
 
     struct Running<F: Fn(&Meta) -> bool> {
@@ -278,6 +279,11 @@ mod test_support {
 
         pub fn close(mut self, span: MockSpan) -> Self {
             self.expected.push_back(Expect::Exit(span));
+            self
+        }
+
+        pub fn done(mut self) -> Self {
+            self.expected.push_back(Expect::Nothing);
             self
         }
 
@@ -348,6 +354,8 @@ mod test_support {
                     "expected to close span {:?} but got an event",
                     expected_span.name,
                 ),
+                Some(Expect::Nothing) =>
+                    panic!("expected nothing else to happen, but got an event"),
             }
         }
 
@@ -377,6 +385,10 @@ mod test_support {
                     "expected to close span {:?}, but entered span {:?} instead",
                     expected_span.name,
                     span.name()
+                ),
+                Some(Expect::Nothing) => panic!(
+                    "expected nothing else to happen, but entered span {:?}",
+                    span.name(),
                 ),
             }
         }
@@ -408,6 +420,10 @@ mod test_support {
                     expected_span.name,
                     span.name()
                 ),
+                Some(Expect::Nothing) => panic!(
+                    "expected nothing else to happen, but exited span {:?}",
+                    span.name(),
+                ),
             }
         }
 
@@ -437,6 +453,10 @@ mod test_support {
                         assert_eq!(name, span.name());
                     }
                     // TODO: expect fields
+                ),
+                Some(Expect::Nothing) => panic!(
+                    "expected nothing else to happen, but closed span {:?}",
+                    span.name(),
                 ),
             }
         }

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -9,11 +9,17 @@ pub mod executor;
 
 // TODO: seal?
 pub trait Instrument: Sized {
+    // TODO: consider renaming to `in_span` for consistency w/
+    // `in_current_span`?
     fn instrument(self, span: Span) -> Instrumented<Self> {
         Instrumented {
             inner: self,
             span,
         }
+    }
+
+    fn in_current_span(self) -> Instrumented<Self> {
+        self.instrument(Span::current())
     }
 }
 

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate futures;
-#[cfg_attr(test, macro_use)]
 extern crate tokio_trace;
 
 use futures::{Async, Future, Poll, Sink, StartSend, Stream};

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -154,59 +154,15 @@ mod tests {
         }
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Done),
-            ).run();
+            .exit(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .done()
+            .run();
         Dispatch::to(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
-                .wait()
-                .unwrap();
-        })
-    }
-
-    #[test]
-    fn future_completion_leaves_reachable_spans_idle() {
-        struct MyFuture {
-            polls: usize,
-        }
-
-        impl Future for MyFuture {
-            type Item = ();
-            type Error = ();
-            fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-                self.polls += 1;
-                if self.polls == 2 {
-                    Ok(Async::Ready(()))
-                } else {
-                    task::current().notify();
-                    Ok(Async::NotReady)
-                }
-            }
-        }
-        let subscriber = subscriber::mock()
-            .enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).run();
-        Dispatch::to(subscriber).as_default(|| {
-            let foo = span!("foo");
-            MyFuture { polls: 0 }
-                .instrument(foo.clone())
                 .wait()
                 .unwrap();
         })
@@ -233,16 +189,12 @@ mod tests {
         }
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Done),
-            ).run();
+            .exit(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .done()
+            .run();
         Dispatch::to(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
@@ -255,26 +207,15 @@ mod tests {
     fn stream_enter_exit_is_reasonable() {
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Idle),
-            ).enter(span::mock().named(Some("foo")))
-            .exit(
-                span::mock()
-                    .named(Some("foo"))
-                    .with_state(span::State::Done),
-            ).run();
+            .exit(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .run();
         Dispatch::to(subscriber).as_default(|| {
             stream::iter_ok::<_, ()>(&[1, 2, 3])
                 .instrument(span!("foo"))

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -11,10 +11,7 @@ pub trait Instrument: Sized {
     // TODO: consider renaming to `in_span` for consistency w/
     // `in_current_span`?
     fn instrument(self, span: Span) -> Instrumented<Self> {
-        Instrumented {
-            inner: self,
-            span,
-        }
+        Instrumented { inner: self, span }
     }
 
     fn in_current_span(self) -> Instrumented<Self> {
@@ -98,7 +95,7 @@ impl<T: Sink> Sink for Instrumented<T> {
     }
 
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-                let span = &mut self.span;
+        let span = &mut self.span;
         let inner = &mut self.inner;
         span.enter(|| inner.poll_complete())
     }

--- a/tokio-trace-macros/examples/basic.rs
+++ b/tokio-trace-macros/examples/basic.rs
@@ -14,7 +14,7 @@ fn main() {
     tokio_trace::Dispatch::to(subscriber).as_default(|| {
         let num = 1;
 
-        let span = span!("Getting rec from another function.", number_of_recs = &num);
+        let mut span = span!("Getting rec from another function.", number_of_recs = &num);
         span.enter(|| {
             let band = suggest_band();
             event!(Level::Info, { band_recommendation = &band }, "Got a rec.");

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -124,15 +124,21 @@ where
         self.observer.observe_event(event)
     }
 
-    fn enter(&self, id: span::Id, state: span::State) {
-        self.registry.with_span(&id, state, |span| {
+    fn enter(&self, id: span::Id) {
+        self.registry.with_span(&id, |span| {
             self.observer.enter(span);
         });
     }
 
-    fn exit(&self, id: span::Id, state: span::State) {
-        self.registry.with_span(&id, state, |span| {
+    fn exit(&self, id: span::Id) {
+        self.registry.with_span(&id, |span| {
             self.observer.exit(span);
+        });
+    }
+
+    fn close(&self, id: span::Id) {
+        self.registry.with_span(&id, |span| {
+            self.observer.close(span);
         });
     }
 }

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -48,6 +48,7 @@ pub trait ObserveExt: Observe {
     /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
     /// # fn enter(&self, _: &SpanRef) {}
     /// # fn exit(&self, _: &SpanRef) {}
+    /// # fn close(&self, _: &SpanRef) {}
     /// # fn filter(&self) -> &dyn Filter { &NoFilter}
     /// }
     ///
@@ -56,6 +57,7 @@ pub trait ObserveExt: Observe {
     /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
     /// # fn enter(&self, _: &SpanRef) {}
     /// # fn exit(&self, _: &SpanRef) {}
+    /// # fn close(&self, _: &SpanRef) {}
     /// # fn filter(&self) -> &dyn Filter { &NoFilter}
     /// }
     ///
@@ -178,6 +180,7 @@ pub struct NoObserver;
 /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
 /// # fn enter(&self, _: &SpanRef) {}
 /// # fn exit(&self, _: &SpanRef) {}
+/// # fn close(&self, _: &SpanRef) {}
 /// # fn filter(&self) -> &dyn Filter { &NoFilter}
 /// }
 ///
@@ -186,6 +189,7 @@ pub struct NoObserver;
 /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
 /// # fn enter(&self, _: &SpanRef) {}
 /// # fn exit(&self, _: &SpanRef) {}
+/// # fn close(&self, _: &SpanRef) {}
 /// # fn filter(&self) -> &dyn Filter { &NoFilter}
 /// }
 ///

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -13,6 +13,7 @@ pub trait Observe {
     fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
     fn enter<'a>(&self, span: &SpanRef<'a>);
     fn exit<'a>(&self, span: &SpanRef<'a>);
+    fn close<'a>(&self, span: &SpanRef<'a>);
 
     fn filter(&self) -> &dyn Filter {
         &filter::NoFilter
@@ -263,6 +264,11 @@ where
         self.inner.exit(span)
     }
 
+    #[inline]
+    fn close<'a>(&self, span: &SpanRef<'a>) {
+        self.inner.close(span)
+    }
+
     fn filter(&self) -> &dyn Filter {
         self
     }
@@ -303,6 +309,11 @@ where
     fn exit<'a>(&self, span: &SpanRef<'a>) {
         self.a.exit(span);
         self.b.exit(span);
+    }
+
+    fn close<'a>(&self, span: &SpanRef<'a>) {
+        self.a.close(span);
+        self.b.close(span);
     }
 
     fn filter(&self) -> &dyn Filter {
@@ -350,6 +361,13 @@ where
             Either::B(b) => b.exit(span),
         }
     }
+
+    fn close<'a>(&self, span: &SpanRef<'a>) {
+        match self {
+            Either::A(a) => a.close(span),
+            Either::B(b) => b.close(span),
+        }
+    }
 }
 
 impl<A, B> Filter for Either<A, B>
@@ -378,6 +396,8 @@ impl Observe for NoObserver {
     fn enter<'a>(&self, _span: &SpanRef<'a>) {}
 
     fn exit<'a>(&self, _span: &SpanRef<'a>) {}
+
+    fn close<'a>(&self, _span: &SpanRef<'a>) {}
 
     fn filter(&self) -> &dyn Filter {
         self

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -113,8 +113,7 @@ fn main() {
         let addr = "[::1]:8888".parse().unwrap();
         let bind = TcpListener::bind(&addr).expect("bind");
 
-        let server_span = span!("serve", local_ip = &addr.ip(), local_port = &addr.port());
-        server_span.clone().enter(move || {
+        span!("serve", local_ip = &addr.ip(), local_port = &addr.port()).enter(move || {
             let new_svc = tokio_trace_tower_http::InstrumentedNewService::new(NewSvc);
             let h2 = Server::new(new_svc, Default::default(), reactor.clone());
 
@@ -122,9 +121,7 @@ fn main() {
                 .incoming()
                 .fold((h2, reactor), |(h2, reactor), sock| {
                     let addr = sock.peer_addr().expect("can't get addr");
-                    let conn_span =
-                        span!("conn", remote_ip = &addr.ip(), remote_port = &addr.port());
-                    conn_span.clone().enter(|| {
+                    span!("conn", remote_ip = &addr.ip(), remote_port = &addr.port()).enter(|| {
                         if let Err(e) = sock.set_nodelay(true) {
                             return Err(e);
                         }
@@ -137,14 +134,14 @@ fn main() {
                             .and_then(|_| {
                                 event!(Level::Debug, {}, "response finished");
                                 future::ok(())
-                            }).instrument(conn_span);
+                            }).in_current_span();
                         reactor.spawn(Box::new(serve));
 
                         Ok((h2, reactor))
                     })
                 }).map_err(|e| event!(Level::Error, {}, "serve error {:?}", e))
                 .map(|_| {})
-                .instrument(server_span.clone());
+                .in_current_span();
 
             rt.spawn(serve);
             rt.shutdown_on_idle().wait().unwrap();

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -102,8 +102,7 @@ where
                 version = &request.version(),
                 uri = request.uri(),
                 headers = request.headers()
-            )
-                .enter(move || inner.call(request).in_current_span())
+            ).enter(move || inner.call(request).in_current_span())
         })
     }
 }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -40,9 +40,7 @@ where
         let span = &mut self.span;
         let inner = &mut self.inner;
         span.enter(|| {
-            span!("request", request = &req).enter(move || {
-                inner.call(req).in_current_span()
-            })
+            span!("request", request = &req).enter(move || inner.call(req).in_current_span())
         })
     }
 }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -6,7 +6,6 @@ extern crate tokio_trace_futures;
 
 use std::fmt;
 use tokio_trace_futures::{Instrument, Instrumented};
-use tokio_trace::Span;
 use tower_service::Service;
 
 // TODO: Can this still be `Clone` (some kind of SharedSpan type?)

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -6,9 +6,11 @@ extern crate tokio_trace_futures;
 
 use std::fmt;
 use tokio_trace_futures::{Instrument, Instrumented};
+use tokio_trace::Span;
 use tower_service::Service;
 
-#[derive(Clone, Debug)]
+// TODO: Can this still be `Clone` (some kind of SharedSpan type?)
+#[derive(Debug)]
 pub struct InstrumentedService<T> {
     inner: T,
     span: tokio_trace::Span,
@@ -30,19 +32,18 @@ where
     type Error = T::Error;
 
     fn poll_ready(&mut self) -> futures::Poll<(), Self::Error> {
-        let span = self.span.clone();
+        let span = &mut self.span;
         let inner = &mut self.inner;
         span.enter(|| inner.poll_ready())
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
-        let span = self.span.clone();
+        let span = &mut self.span;
         let inner = &mut self.inner;
         span.enter(|| {
-            let request_span = span!("request", request = &req);
-            request_span
-                .clone()
-                .enter(move || inner.call(req).instrument(request_span))
+            span!("request", request = &req).enter(move || {
+                inner.call(req).instrument(Span::current())
+            })
         })
     }
 }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -42,7 +42,7 @@ where
         let inner = &mut self.inner;
         span.enter(|| {
             span!("request", request = &req).enter(move || {
-                inner.call(req).instrument(Span::current())
+                inner.call(req).in_current_span()
             })
         })
     }

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -13,8 +13,7 @@ fn main() {
         let foo = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 
-        let span = span!("my_great_span", foo = &4, baz = &5);
-        span.enter(|| {
+        span!("my_great_span", foo = &4, baz = &5).enter(|| {
             event!(
                 Level::Info,
                 { yak_shaved = &true },

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -74,12 +74,10 @@ impl Subscriber for CounterSubscriber {
 
     fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {}
 
-    fn enter(&self, _span: span::Id, _state: span::State) {}
+    fn enter(&self, _span: span::Id) {}
+    fn exit(&self, _span: span::Id) {}
 
-    fn exit(&self, span: span::Id, state: span::State) {
-        if state != span::State::Done {
-            return;
-        }
+    fn close(&self, span: span::Id) {
         if let Some(span) = self.spans.read().unwrap().get(&span) {
             let registry = self.counters.0.read().unwrap();
             for (counter, value) in span.fields().into_iter().filter_map(|(k, v)| {

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -26,13 +26,13 @@ fn main() {
             span!("server", host = &"localhost", port = &8080).enter(|| {
                 event!(Level::Info, {}, "starting");
                 event!(Level::Info, {}, "listening");
-                let peer1 = span!("conn", peer_addr = &"82.9.9.9", port = &42381);
-                peer1.clone().enter(|| {
+                let mut peer1 = span!("conn", peer_addr = &"82.9.9.9", port = &42381);
+                peer1.enter(|| {
                     event!(Level::Debug, {}, "connected");
                     event!(Level::Debug, { length = 2 }, "message received");
                 });
-                let peer2 = span!("conn", peer_addr = &"8.8.8.8", port = &18230);
-                peer2.clone().enter(|| {
+                let mut peer2 = span!("conn", peer_addr = &"8.8.8.8", port = &18230);
+                peer2.enter(|| {
                     event!(Level::Debug, {}, "connected");
                 });
                 peer1.enter(|| {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -165,7 +165,7 @@ impl Subscriber for SloggishSubscriber {
     }
 
     #[inline]
-    fn enter(&self, span: tokio_trace::span::Id, _state: tokio_trace::span::State) {
+    fn enter(&self, span: tokio_trace::span::Id) {
         let mut stderr = self.stderr.lock();
         let mut stack = self.stack.lock().unwrap();
         let spans = self.spans.lock().unwrap();
@@ -196,5 +196,11 @@ impl Subscriber for SloggishSubscriber {
     }
 
     #[inline]
-    fn exit(&self, _span: tokio_trace::span::Id, _state: tokio_trace::span::State) {}
+    fn exit(&self, _span: tokio_trace::span::Id) {}
+
+    #[inline]
+    fn close(&self, _span: tokio_trace::span::Id) {
+        // TODO: it's *probably* safe to remove the span from the cache
+        // now...but that doesn't really matter for this example.
+    }
 }

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -3,10 +3,7 @@ pub use tokio_trace_core::dispatcher::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use {
-        span,
-        subscriber,
-    };
+    use {span, subscriber};
 
     #[test]
     fn dispatcher_is_sticky() {

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -4,7 +4,7 @@ pub use tokio_trace_core::dispatcher::*;
 mod tests {
     use super::*;
     use {
-        span::{self, State},
+        span,
         subscriber,
     };
 
@@ -14,18 +14,19 @@ mod tests {
         // dispatcher, even across dispatcher context switches.
         let subscriber1 = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
-            .exit(span::mock().named(Some("foo")).with_state(State::Idle))
+            .exit(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("bar")))
-            .exit(span::mock().named(Some("bar")).with_state(State::Done))
-            .exit(span::mock().named(Some("foo")).with_state(State::Done))
+            .exit(span::mock().named(Some("bar")))
+            .exit(span::mock().named(Some("foo")))
+            .done()
             .run();
-        let foo = Dispatch::to(subscriber1).as_default(|| {
-            let foo = span!("foo");
-            foo.clone().enter(|| {});
+        let mut foo = Dispatch::to(subscriber1).as_default(|| {
+            let mut foo = span!("foo");
+            foo.enter(|| {});
             foo
         });
-        Dispatch::to(subscriber::mock().run())
+        Dispatch::to(subscriber::mock().done().run())
             .as_default(move || foo.enter(|| span!("bar").enter(|| {})))
     }
 
@@ -35,25 +36,27 @@ mod tests {
         // dispatcher.
         let subscriber1 = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
-            .exit(span::mock().named(Some("foo")).with_state(State::Idle))
+            .exit(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("bar")))
-            .exit(span::mock().named(Some("bar")).with_state(State::Done))
-            .exit(span::mock().named(Some("foo")).with_state(State::Done))
+            .exit(span::mock().named(Some("bar")))
+            .exit(span::mock().named(Some("foo")))
+            .done()
             .run();
         let subscriber2 = subscriber::mock()
             .enter(span::mock().named(Some("baz")))
             .enter(span::mock().named(Some("quux")))
-            .exit(span::mock().named(Some("quux")).with_state(State::Done))
-            .exit(span::mock().named(Some("baz")).with_state(State::Done))
+            .exit(span::mock().named(Some("quux")))
+            .exit(span::mock().named(Some("baz")))
+            .done()
             .run();
 
-        let foo = Dispatch::to(subscriber1).as_default(|| {
-            let foo = span!("foo");
-            foo.clone().enter(|| {});
+        let mut foo = Dispatch::to(subscriber1).as_default(|| {
+            let mut foo = span!("foo");
+            foo.enter(|| {});
             foo
         });
-        let baz = Dispatch::to(subscriber2).as_default(|| span!("baz"));
+        let mut baz = Dispatch::to(subscriber2).as_default(|| span!("baz"));
         Dispatch::to(subscriber::mock().run()).as_default(move || {
             foo.enter(|| span!("bar").enter(|| {}));
             baz.enter(|| span!("quux").enter(|| {}))

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -9,7 +9,7 @@ extern crate tokio_trace_core;
 /// # #[macro_use]
 /// # extern crate tokio_trace;
 /// # fn main() {
-/// let span = span!("my span");
+/// let mut span = span!("my span");
 /// span.enter(|| {
 ///     // do work inside the span...
 /// });

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -16,7 +16,7 @@
 //! # #[macro_use] extern crate tokio_trace;
 //! # fn main() {
 //! let my_var = 5;
-//! let my_span = span!("my_span", my_var = &my_var);
+//! let mut my_span = span!("my_span", my_var = &my_var);
 //!
 //! my_span.enter(|| {
 //!     // perform some work in the context of `my_span`...
@@ -122,7 +122,7 @@ mod tests {
             .run();
 
         Dispatch::to(subscriber).as_default(|| {
-            span!("foo",).enter(|| {
+            span!("foo").enter(|| {
                 let mut bar = span!("bar",);
                 bar.enter(|| {
                     // do nothing. exiting "bar" should leave it idle, since it can

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -141,7 +141,7 @@
 //! [`Data`]: ::span::Data
 pub use tokio_trace_core::span::*;
 pub use tokio_trace_core::Span; // TODO: auto-close
-// use tokio_trace_core::span::Span as Inner;
+                                // use tokio_trace_core::span::Span as Inner;
 
 // #[derive(Clone, Debug)]
 // pub struct Span {
@@ -360,9 +360,7 @@ mod tests {
             .run();
         Dispatch::to(subscriber).as_default(|| {
             let mut span = span!("foo");
-            span.enter(|| {
-
-            });
+            span.enter(|| {});
             drop(span);
         })
     }
@@ -382,7 +380,7 @@ mod tests {
             .run();
         Dispatch::to(subscriber).as_default(|| {
             let mut foo = span!("foo");
-            foo.enter(|| {  });
+            foo.enter(|| {});
 
             span!("bar").enter(|| {
                 // Since `foo` is not executing, it should close immediately.
@@ -403,7 +401,7 @@ mod tests {
             .run();
         Dispatch::to(subscriber).as_default(|| {
             let mut foo = span!("foo");
-            foo.enter(|| {  });
+            foo.enter(|| {});
 
             foo.close();
 
@@ -412,15 +410,12 @@ mod tests {
                 // exit.
             });
             assert!(foo.is_closed());
-
         })
     }
 
     #[test]
     fn span_doesnt_close_if_it_never_opened() {
-        let subscriber = subscriber::mock()
-            .done()
-            .run();
+        let subscriber = subscriber::mock().done().run();
         Dispatch::to(subscriber).as_default(|| {
             let span = span!("foo");
             drop(span);

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -88,6 +88,13 @@
 //! [`State`]: ::span::State
 //! [`Data`]: ::span::Data
 pub use tokio_trace_core::span::*;
+pub use tokio_trace_core::Span; // TODO: auto-close
+// use tokio_trace_core::span::Span as Inner;
+
+// #[derive(Clone, Debug)]
+// pub struct Span {
+
+// }
 
 #[cfg(test)]
 mod tests {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -286,7 +286,7 @@ mod tests {
         .unwrap();
     }
 
-        #[test]
+    #[test]
     fn span_closes_on_drop() {
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -285,4 +285,32 @@ mod tests {
         }).join()
         .unwrap();
     }
+
+        #[test]
+    fn span_closes_on_drop() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .done()
+            .run();
+        Dispatch::to(subscriber).as_default(|| {
+            let mut span = span!("foo");
+            span.enter(|| {
+
+            });
+            drop(span);
+        })
+    }
+
+    #[test]
+    fn span_doesnt_close_if_it_never_opened() {
+        let subscriber = subscriber::mock()
+            .done()
+            .run();
+        Dispatch::to(subscriber).as_default(|| {
+            let mut span = span!("foo");
+            drop(span);
+        })
+    }
 }

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -42,24 +42,25 @@ mod tests {
         Dispatch::to(subscriber).as_default(move || {
             // Enter "foo" and then "bar". The dispatcher expects to see "bar" but
             // not "foo."
-            let foo = span!("foo");
-            let bar = foo.clone().enter(|| {
-                let bar = span!("bar");
-                bar.clone().enter(|| bar)
+            let mut foo = span!("foo");
+            let mut bar = foo.enter(|| {
+                let mut bar = span!("bar");
+                bar.enter(||());
+                bar
             });
 
             // The filter should have seen each span a single time.
             assert_eq!(foo_count.load(Ordering::Relaxed), 1);
             assert_eq!(bar_count.load(Ordering::Relaxed), 1);
 
-            foo.clone().enter(|| bar.clone().enter(|| {}));
+            foo.enter(|| bar.enter(|| {}));
 
             // The subscriber should see "bar" again, but the filter should not have
             // been called.
             assert_eq!(foo_count.load(Ordering::Relaxed), 1);
             assert_eq!(bar_count.load(Ordering::Relaxed), 1);
 
-            bar.clone().enter(|| {});
+            bar.enter(|| {});
             assert_eq!(foo_count.load(Ordering::Relaxed), 1);
             assert_eq!(bar_count.load(Ordering::Relaxed), 1);
         });
@@ -127,16 +128,17 @@ mod tests {
         let subscriber2 = Dispatch::to(subscriber2);
 
         let do_test = move |n: usize| {
-            let foo = span!("foo");
-            let bar = foo.clone().enter(|| {
-                let bar = span!("bar");
-                bar.clone().enter(|| bar)
+            let mut foo = span!("foo");
+            let mut bar = foo.enter(|| {
+                let mut bar = span!("bar");
+                bar.enter(|| ());
+                bar
             });
 
             assert_eq!(foo_count.load(Ordering::Relaxed), n);
             assert_eq!(bar_count.load(Ordering::Relaxed), n);
 
-            foo.clone().enter(|| bar.clone().enter(|| {}));
+            foo.enter(|| bar.enter(|| {}));
 
             assert_eq!(foo_count.load(Ordering::Relaxed), n);
             assert_eq!(bar_count.load(Ordering::Relaxed), n);
@@ -156,15 +158,16 @@ mod tests {
     #[test]
     fn filters_evaluated_across_threads() {
         fn do_test() -> Span {
-            let foo = span!("foo");
-            let bar = foo.clone().enter(|| {
-                let bar = span!("bar");
-                bar.clone().enter(|| bar)
+            let mut foo = span!("foo");
+            let mut bar = foo.enter(|| {
+                let mut bar = span!("bar");
+                bar.enter(|| ());
+                bar
             });
 
-            foo.enter(|| bar.clone().enter(|| {}));
+            foo.enter(|| bar.enter(|| {}));
 
-            bar.clone()
+            bar
         }
 
         let barrier = Arc::new(Barrier::new(2));
@@ -218,10 +221,10 @@ mod tests {
         // the threads have completed, but the spans should still notify their
         // parent subscribers.
 
-        let bar = thread1.join().unwrap();
+        let mut bar = thread1.join().unwrap();
         bar.enter(|| {});
 
-        let bar = thread2.join().unwrap();
+        let mut bar = thread2.join().unwrap();
         bar.enter(|| {});
     }
 
@@ -256,17 +259,18 @@ mod tests {
         Dispatch::to(subscriber).as_default(move || {
             // Enter "foo" and then "bar". The dispatcher expects to see "bar" but
             // not "foo."
-            let foo = span!("foo");
-            let bar = foo.clone().enter(|| {
-                let bar = span!("bar");
-                bar.clone().enter(|| bar)
+            let mut foo = span!("foo");
+            let mut bar = foo.enter(|| {
+                let mut bar = span!("bar");
+                bar.enter(|| {});
+                bar
             });
 
             // The filter should have seen each span a single time.
             assert_eq!(foo_count.load(Ordering::Relaxed), 1);
             assert_eq!(bar_count.load(Ordering::Relaxed), 1);
 
-            foo.clone().enter(|| bar.clone().enter(|| {}));
+            foo.enter(|| bar.enter(|| {}));
 
             // The subscriber should see "bar" again, but the filter should not have
             // been called.
@@ -275,8 +279,8 @@ mod tests {
 
             // A different span with the same name has a different call site, so it
             // should cause the filter to be reapplied.
-            let foo2 = span!("foo");
-            foo.clone().enter(|| {});
+            let mut foo2 = span!("foo");
+            foo.enter(|| {});
             assert_eq!(foo_count.load(Ordering::Relaxed), 2);
             assert_eq!(bar_count.load(Ordering::Relaxed), 1);
 

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -45,7 +45,7 @@ mod tests {
             let mut foo = span!("foo");
             let mut bar = foo.enter(|| {
                 let mut bar = span!("bar");
-                bar.enter(||());
+                bar.enter(|| ());
                 bar
             });
 


### PR DESCRIPTION
This branch represents a significant rewrite of the span type and its
API. The primary goal of this change is that constructing an enabled
span should not cause an allocation (see #25), and a single `Span`
handle should be able to be entered multiple times (see #28).

This change necessitated several API changes:
- `Spans` are now entered by mutable reference, rather than by consuming
  the span,
- `Span` no longer implements `Clone`,
- Removed the `span::State` type, and removed it from all `Subscriber` 
  methods.
- `Subscriber`s are now notified of span closure by a new 
  `Subscriber::close(span id)` method.
- Dropping a `Span` handle will still cause a the span to be closed
  the next time it exits, if no other handles exist. However, spans may
  now be asked to close explicitly with the new `Span::close` method.

I've updated the documentation and dependent crates to track these API 
changes, as well as adding new tests.

Additionally, I have another branch (#71) which re-implements the previous
(`Clone`-based) span API as a new type, `span::Shared`, in the
`tokio-trace` crate. The `Shared` span handle is constructed from a
`core::Span` handle, so users who need to share multiple entering
handles to a span, or enter a span from more than one thread, can now
explicitly opt in to the allocation overhead.

Closes #65. 
Closes #57. 
Closes #28.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>