### PR TITLE
Add `Dispatcher::if_enabled` function

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -2,13 +2,13 @@ use std::{cell::Cell, thread::LocalKey};
 use {Dispatch, Meta, Span, Subscriber};
 
 #[derive(Debug)]
-pub struct Callsite(&'static LocalKey<Cache<'static>>);
+pub struct Callsite(pub(crate) &'static LocalKey<Cache<'static>>);
 
 #[doc(hidden)]
 pub struct Cache<'a> {
-    last_filtered_by: Cell<usize>,
-    cached_filter: Cell<Option<bool>>,
-    meta: &'a Meta<'a>,
+    pub(crate) last_filtered_by: Cell<usize>,
+    pub(crate) cached_filter: Cell<Option<bool>>,
+    pub(crate) meta: &'a Meta<'a>,
 }
 
 impl Callsite {
@@ -18,23 +18,7 @@ impl Callsite {
     }
 
     #[inline]
-    pub fn new_span(&self, dispatch: Dispatch) -> Span {
-        self.0.with(|cache| {
-            if cache.is_enabled(&dispatch) {
-                Span::new(dispatch, cache.metadata())
-            } else {
-                Span::new_disabled()
-            }
-        })
-    }
-
-    #[inline]
-    pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
-        self.0.with(|cache| cache.is_enabled(dispatch))
-    }
-
-    #[inline]
-    pub fn metadata(&self) -> &'static Meta<'static> {
+    pub(crate) fn metadata(&self) -> &'static Meta<'static> {
         self.0.with(|cache| cache.meta)
     }
 }
@@ -45,38 +29,6 @@ impl<'a> Cache<'a> {
             last_filtered_by: Cell::new(0),
             cached_filter: Cell::new(None),
             meta,
-        }
-    }
-
-    #[inline]
-    pub fn is_invalid(&self, dispatch: &Dispatch) -> bool {
-        let id = dispatch.id();
-
-        // If the callsite was last filtered by a different subscriber, assume
-        // the filter is no longer valid.
-        if self.cached_filter.get().is_none() || self.last_filtered_by.get() != id {
-            // Update the stamp on the call site so this subscriber is now the
-            // last to filter it.
-            self.last_filtered_by.set(id);
-            return true;
-        }
-
-        // Otherwise, just ask the subscriber what it thinks.
-        dispatch.should_invalidate_filter(self.metadata())
-    }
-
-    #[inline]
-    pub fn is_enabled(&self, dispatch: &Dispatch) -> bool {
-        if self.is_invalid(dispatch) {
-            let enabled = dispatch.enabled(self.metadata());
-            self.cached_filter.set(Some(enabled));
-            enabled
-        } else if let Some(cached) = self.cached_filter.get() {
-            cached
-        } else {
-            let enabled = dispatch.enabled(self.metadata());
-            self.cached_filter.set(Some(enabled));
-            enabled
         }
     }
 

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -81,42 +81,51 @@ impl Dispatch {
         })
     }
 
+    #[inline]
     pub fn if_enabled<F, T>(self, callsite: &callsite::Callsite, f: F) -> Option<T>
     where
         F: FnOnce(Dispatch, &'static Meta<'static>) -> T,
     {
-        if callsite.0.with(|cache| self.is_enabled(cache)) {
-            Some(f(self, callsite.metadata()))
-        } else {
-            None
-        }
-    }
-
-    fn is_invalid(&self, cache: &callsite::Cache<'static>) -> bool {
-        // If the callsite was last filtered by a different subscriber, assume
-        // the filter is no longer valid.
-        if cache.cached_filter.get().is_none() || cache.last_filtered_by.get() != self.id {
-            // Update the stamp on the call site so this subscriber is now the
-            // last to filter it.
-            cache.last_filtered_by.set(self.id);
-            return true;
+        if self.is_enabled(callsite) {
+            return Some(f(self, callsite.metadata()));
         }
 
-        // Otherwise, just ask the subscriber what it thinks.
-        self.subscriber.should_invalidate_filter(&cache.meta)
+        None
     }
 
-    fn is_enabled(&self, cache: &callsite::Cache<'static>) -> bool {
-        if self.is_invalid(cache) {
-            let enabled = self.subscriber.enabled(&cache.meta);
-            cache.cached_filter.set(Some(enabled));
-            enabled
-        } else if let Some(cached) = cache.cached_filter.get() {
+    #[inline]
+    fn is_invalid(&self, callsite: &callsite::Callsite) -> bool {
+        callsite.0.with(|cache| {
+            // If the callsite was last filtered by a different subscriber, assume
+            // the filter is no longer valid.
+            if cache.cached_filter.get().is_none() || cache.last_filtered_by.get() != self.id {
+                // Update the stamp on the call site so this subscriber is now the
+                // last to filter it.
+                cache.last_filtered_by.set(self.id);
+                return true;
+            }
+
+            // Otherwise, just ask the subscriber what it thinks.
+            self.subscriber.should_invalidate_filter(&cache.meta)
+        })
+    }
+
+    #[inline]
+    fn is_enabled(&self, callsite: &callsite::Callsite) -> bool {
+        if self.is_invalid(callsite) {
+            callsite.0.with(|cache| {
+                let enabled = self.subscriber.enabled(&cache.meta);
+                cache.cached_filter.set(Some(enabled));
+                enabled
+            })
+        } else if let Some(cached) = callsite.0.with(|cache| { cache.cached_filter.get() }) {
             cached
         } else {
-            let enabled = self.subscriber.enabled(&cache.meta);
-            cache.cached_filter.set(Some(enabled));
-            enabled
+            callsite.0.with(|cache| {
+                let enabled = self.subscriber.enabled(&cache.meta);
+                cache.cached_filter.set(Some(enabled));
+                enabled
+            })
         }
     }
 }

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -81,6 +81,11 @@ impl Dispatch {
         })
     }
 
+    /// Performs an operation if a callsite is enabled.
+    ///
+    /// If the given callsite is enabled for this subscriber, this function
+    /// calls the given closure with the dispatcher and the callsite's metadata,
+    /// and returns the result. Otherwise, it returns `None`.
     #[inline]
     pub fn if_enabled<F, T>(self, callsite: &callsite::Callsite, f: F) -> Option<T>
     where
@@ -118,7 +123,7 @@ impl Dispatch {
                 cache.cached_filter.set(Some(enabled));
                 enabled
             })
-        } else if let Some(cached) = callsite.0.with(|cache| { cache.cached_filter.get() }) {
+        } else if let Some(cached) = callsite.0.with(|cache| cache.cached_filter.get()) {
             cached
         } else {
             callsite.0.with(|cache| {

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -16,6 +16,18 @@ fn bench_span_no_subscriber(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_costly_field_no_subscriber(b: &mut Bencher) {
+    let n = test::black_box(1);
+    b.iter(|| {
+        (0..n).fold(0, |old, new| {
+            span!("span", foo = &format!("bar {:?}", 2));
+            old ^ new
+        })
+    });
+}
+
+
+#[bench]
 fn bench_no_span_no_subscriber(b: &mut Bencher) {
     let n = test::black_box(1);
     b.iter(|| (0..n).fold(0, |new, old| old ^ new));

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -26,7 +26,6 @@ fn bench_costly_field_no_subscriber(b: &mut Bencher) {
     });
 }
 
-
 #[bench]
 fn bench_no_span_no_subscriber(b: &mut Bencher) {
     let n = test::black_box(1);


### PR DESCRIPTION
This branch changes the interface between the callsite cache and the
dispatcher, adding a `Dispatcher::if_enabled` method which, given a
closure and a callsite, executes the closure if the callsite is enabled
on that dispatcher. This function is publicly exposed and documented,
and can be used as the basis for span and event construction in the
`span!` and `event!` macros.

The motivation behind this is twofold:

First, the `span!` macro currently calls `add_value` on the for each
value, regardless of whether or not the span is enabled. If the span is
disabled, adding the value is a no-op, but since the macro takes the
value as an expression, that expression still has to be evaluated before
passing it to `add_value`. Thus, values which are expensive to produce
still incur a cost. I added a benchmark for adding a field with a value
which requires formatting a string to a disabled span. On master,
there's a significant performance difference between that benchmark and
the benchmark for a disabled span with no value:
```
test bench_costly_field_no_subscriber ... bench:         133 ns/iter (+/- 21)
test bench_span_no_subscriber         ... bench:          62 ns/iter (+/- 7)
```

The other motivation is that currently, the interface between the
dispatcher and the callsite cache involve several `#[doc(hidden)] pub`
methods. Although these aren't public APIs and should not be relied on,
it's still _possible_ to call them, so changing them can still break
downstream users. It would be nice to minimize the number of
`#[doc(hidden)]` items. The new approach allows more of the interface
between the dispatcher and callsite caches to be `pub(crate)` instead
--- the dispatcher's ID is never exposed publically, and although the
cache itself is still `#[doc(hidden)] pub`, it has no public methods
besides its' constructor, making it functionally opaque to users. 

After making this change, the cost of creating a disabled span with and
without a costly field is approximately the same:
```
test bench_costly_field_no_subscriber ... bench:          38 ns/iter (+/- 10)
test bench_span_no_subscriber         ... bench:          40 ns/iter (+/- 5)
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>