### PR TITLE
Remove unnecessary second lifetime from `Event`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -183,7 +183,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         self.subscriber.observe_event(event)
     }
 
@@ -231,7 +231,7 @@ impl Subscriber for NoSubscriber {
         false
     }
 
-    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, _event: &'a Event<'a>) {
         // Do nothing.
     }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -146,11 +146,8 @@ pub trait Subscriber {
     /// When an `Event` takes place, this function is called to notify the
     /// subscriber of that event.
     ///
-    /// Note that this function is generic over a pair of lifetimes because the
-    /// `Event` type is. See the documentation for [`Event`] for details.
-    ///
     /// [`Event`]: ../struct.Event.html
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
+    fn observe_event<'a>(&self, event: &'a Event<'a>);
 
     /// Records that a [`Span`] has been entered.
     ///
@@ -340,7 +337,7 @@ mod test_support {
             id
         }
 
-        fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {
+        fn observe_event<'a>(&self, _event: &'a Event<'a>) {
             match self.expected.lock().unwrap().pop_front() {
                 None => {}
                 Some(Expect::Event(_)) => unimplemented!(),

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -209,7 +209,7 @@ impl Subscriber for TraceLogger {
         Ok(())
     }
 
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         let meta = event.meta.as_log();
         let logger = log::logger();
         if logger.enabled(&meta) {
@@ -261,7 +261,7 @@ impl Subscriber for TraceLogger {
 }
 
 impl tokio_trace_subscriber::Observe for TraceLogger {
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         <Self as Subscriber>::observe_event(&self, event)
     }
 

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -120,7 +120,7 @@ where
         self.registry.add_follows_from(span, follows)
     }
 
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         self.observer.observe_event(event)
     }
 

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -10,7 +10,7 @@ use tokio_trace::{Event, Meta};
 /// Implementations of this trait describe the logic needed to process envent
 /// and span notifications, but don't implement span registration.
 pub trait Observe {
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>);
+    fn observe_event<'a>(&self, event: &'a Event<'a>);
     fn enter<'a>(&self, span: &SpanRef<'a>);
     fn exit<'a>(&self, span: &SpanRef<'a>);
     fn close<'a>(&self, span: &SpanRef<'a>);
@@ -45,7 +45,7 @@ pub trait ObserveExt: Observe {
     ///
     /// impl Observe for Foo {
     ///     // ...
-    /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+    /// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
     /// # fn enter(&self, _: &SpanRef) {}
     /// # fn exit(&self, _: &SpanRef) {}
     /// # fn close(&self, _: &SpanRef) {}
@@ -54,7 +54,7 @@ pub trait ObserveExt: Observe {
     ///
     /// impl Observe for Bar {
     ///     // ...
-    /// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+    /// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
     /// # fn enter(&self, _: &SpanRef) {}
     /// # fn exit(&self, _: &SpanRef) {}
     /// # fn close(&self, _: &SpanRef) {}
@@ -177,7 +177,7 @@ pub struct NoObserver;
 ///
 /// impl Observe for Foo {
 ///     // ...
-/// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+/// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
 /// # fn enter(&self, _: &SpanRef) {}
 /// # fn exit(&self, _: &SpanRef) {}
 /// # fn close(&self, _: &SpanRef) {}
@@ -186,7 +186,7 @@ pub struct NoObserver;
 ///
 /// impl Observe for Bar {
 ///     // ...
-/// # fn observe_event<'event, 'meta: 'event>(&self, _: &'event Event<'event, 'meta>) {}
+/// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
 /// # fn enter(&self, _: &SpanRef) {}
 /// # fn exit(&self, _: &SpanRef) {}
 /// # fn close(&self, _: &SpanRef) {}
@@ -254,7 +254,7 @@ where
     F: Filter,
 {
     #[inline]
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         self.inner.observe_event(event)
     }
 
@@ -300,7 +300,7 @@ where
     A: Observe,
     B: Observe,
 {
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         self.a.observe_event(event);
         self.b.observe_event(event);
     }
@@ -345,7 +345,7 @@ where
     A: Observe,
     B: Observe,
 {
-    fn observe_event<'event, 'meta: 'event>(&self, event: &'event Event<'event, 'meta>) {
+    fn observe_event<'a>(&self, event: &'a Event<'a>) {
         match self {
             Either::A(a) => a.observe_event(event),
             Either::B(b) => b.observe_event(event),
@@ -395,7 +395,7 @@ where
 }
 
 impl Observe for NoObserver {
-    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {}
+    fn observe_event<'a>(&self, _event: &'a Event<'a>) {}
 
     fn enter<'a>(&self, _span: &SpanRef<'a>) {}
 

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -72,7 +72,7 @@ impl Subscriber for CounterSubscriber {
         false
     }
 
-    fn observe_event<'event, 'meta: 'event>(&self, _event: &'event Event<'event, 'meta>) {}
+    fn observe_event<'a>(&self, _event: &'a Event<'a>) {}
 
     fn enter(&self, _span: span::Id) {}
     fn exit(&self, _span: span::Id) {}

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -136,10 +136,7 @@ impl Subscriber for SloggishSubscriber {
     }
 
     #[inline]
-    fn observe_event<'a>(
-        &self,
-        event: &'a tokio_trace::Event<'a>,
-    ) {
+    fn observe_event<'a>(&self, event: &'a tokio_trace::Event<'a>) {
         let mut stderr = self.stderr.lock();
 
         let stack = self.stack.lock().unwrap();

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -136,9 +136,9 @@ impl Subscriber for SloggishSubscriber {
     }
 
     #[inline]
-    fn observe_event<'event, 'meta: 'event>(
+    fn observe_event<'a>(
         &self,
-        event: &'event tokio_trace::Event<'event, 'meta>,
+        event: &'a tokio_trace::Event<'a>,
     ) {
         let mut stderr = self.stderr.lock();
 


### PR DESCRIPTION
Closes #78.

This branch removes the second lifetime parameter for an `Event`'s
metadata. That lifetime parameter may have been necessary at one point
but it doesn't appear to be now, and it just complicates things
needlessly.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>