### PR TITLE
Improve span/event construction APIs

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -43,7 +43,7 @@ impl Dispatch {
     /// [`Span`]: ::span::Span
     /// [`Subscriber`]: ::Subscriber
     /// [`Event`]: ::Event
-    pub fn current() -> Dispatch {
+    pub(crate) fn current() -> Dispatch {
         Span::current().dispatch().cloned().unwrap_or_default()
     }
 

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -398,7 +398,7 @@ impl<'a> Event<'a> {
     /// [`Callsite`]: ::callsite::Callsite
     pub fn observe(
         callsite: &'a dyn callsite::Callsite,
-        field_values: &[ &dyn field::AsValue ],
+        field_values: &[&dyn field::AsValue],
         follows_from: &[SpanId],
         message: fmt::Arguments<'a>,
     ) {

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -384,6 +384,35 @@ impl<'a> PartialEq for Meta<'a> {
 // ===== impl Event =====
 
 impl<'a> Event<'a> {
+    /// Notifies the currently active [`Subscriber`] of an `Event` at the given
+    /// [`Callsite`].
+    ///
+    /// If the given callsite is enabled, a  new `Event` will be constructed
+    /// with the provided `field_values` and `message`, following from the
+    /// provided span IDs. The subscriber will then observe that event.
+    ///
+    /// If the callsite is not enabled, this function does nothing.
+    ///
+    /// [`Subscriber`]: ::subscriber::Subscriber
+    /// [`Callsite`]: ::callsite::Callsite
+    pub fn observe(
+        callsite: &'a dyn callsite::Callsite,
+        field_values: &[ &dyn field::AsValue ],
+        follows_from: &[SpanId],
+        message: fmt::Arguments<'a>,
+    ) {
+        let dispatch = Dispatch::current();
+        if callsite.is_enabled(&dispatch) {
+            dispatch.observe_event(&Event {
+                parent: SpanId::current(),
+                follows_from,
+                meta: callsite.metadata(),
+                field_values,
+                message,
+            });
+        }
+    }
+
     /// Returns an iterator over the names of all the fields on this `Event`.
     pub fn field_names(&self) -> slice::Iter<&'a str> {
         self.meta.field_names.iter()

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -178,6 +178,7 @@ pub mod span;
 pub mod subscriber;
 
 pub use self::{
+    callsite::Callsite,
     dispatcher::Dispatch,
     field::{AsValue, IntoValue, Key, Value},
     span::{Data as SpanData, Id as SpanId, Span},

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -67,17 +67,13 @@ macro_rules! event {
                 target:
                 $target, $( $k ),*
             };
-            let dispatch = Dispatch::current();
-            if callsite.is_enabled(&dispatch) {
-                let field_values: &[ &dyn AsValue ] = &[ $( &$val ),* ];
-                dispatch.observe_event(&Event {
-                    parent: SpanId::current(),
-                    follows_from: &[],
-                    meta: callsite.metadata(),
-                    field_values: &field_values[..],
-                    message: format_args!( $($arg)+ ),
-                });
-            }
+            let field_values: &[ &dyn AsValue ] = &[ $( &$val ),* ];
+            Event::observe(
+                callsite,
+                &field_values[..],
+                &[],
+                format_args!( $($arg)+ ),
+            );
         }
     });
     ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -34,34 +34,24 @@ macro_rules! span {
             use $crate::{callsite, Dispatch, Span};
             use $crate::callsite::Callsite;
             let callsite = callsite! { span: $name, $( $k ),* };
-            let dispatch = Dispatch::current();
-            if callsite.is_enabled(&dispatch) {
-                let meta = callsite.metadata();
-                let span = Span::new(dispatch.clone(), meta);
-                // Depending on how many fields are generated, this may or may
-                // not actually be used, but it doesn't make sense to repeat it.
-                #[allow(unused_variables, unused_mut, unused_imports)] {
-                    use $crate::Subscriber;
-                    let id = span.id().expect("span must have an ID if enabled");
-                    let mut keys = meta.fields();
-                    $(
-                        let key = keys.next()
-                            .expect(concat!("metadata should define a key for '", stringify!($k), "'"));
-                        span!(@ add_value: &dispatch, &id, $k, &key, $($val)*);
-                    )*
-                }
-
-                span
-            } else {
-                Span::new_disabled()
-            }
+            // Depending on how many fields are generated, this may or may
+            // not actually be used, but it doesn't make sense to repeat it.
+            #[allow(unused_variables, unused_mut)]
+            Span::new(callsite, |span| {
+                let mut keys = callsite.metadata().fields();
+                $(
+                    let key = keys.next()
+                        .expect(concat!("metadata should define a key for '", stringify!($k), "'"));
+                    span!(@ add_value: span, $k, &key, $($val)*);
+                )*
+            })
         }
     };
-    (@ add_value: $dispatch:expr, $id:expr, $k:expr, $i:expr, $val:expr) => (
-        $dispatch.add_value($id, $i, $val)
+    (@ add_value: $span:expr, $k:expr, $i:expr, $val:expr) => (
+        $span.add_value($i, $val)
             .expect(concat!("adding value for field '", stringify!($k), "' failed"));
     );
-    (@ add_value: $dispatch:expr, $id:expr, $k:expr, $i:expr,) => (
+    (@ add_value: $span:expr, $k:expr, $i:expr,) => (
         // skip
     );
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -87,6 +87,7 @@ pub mod span;
 pub mod subscriber;
 
 pub use self::{
+    callsite::Callsite,
     dispatcher::Dispatch,
     field::{AsValue, IntoValue, Value},
     span::{Data as SpanData, Id as SpanId, Span},


### PR DESCRIPTION
This branch removes `Dispatch::current` from the public API.

As @carllerche pointed out to me, with some reworking of APIs, it's
possible to implement span and event creation without requiring a
dispatcher to be passed in. This means that we no longer have to observe
the current dispatcher.

Removing the current dispatcher means that we can prevent a lot of bad
behaviour that's otherwise exposed to users --- the current dispatcher
can no longer be "forced" to observe events or spans by calling its
notification methods manually.

The new `Span` and `Event` constructors are also (finally) in a state
that I'm actually comfortable stabilizing as public APIs, so I've
un-hidden them. This means that the `span!` and `event!` macros no
longer rely on `#[doc(hidden)]` public functions, with the exception of
the `Kind` type used to indicate the kind of a metadata. I'd like to
find a better solution for that as well. This also means that there's now
a supported method of creating spans and events without using the
macros.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>