### PR TITLE
Remove pre-allocation from span::Data

### DIFF
--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -4,6 +4,7 @@ use std::{
     cell::RefCell,
     cmp, fmt,
     hash::{Hash, Hasher},
+    iter,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use {
@@ -382,10 +383,12 @@ impl Data {
         if !self.has_field(key) {
             return Err(AddValueError::NoField);
         }
-        let i = key.as_usize();
-        while self.field_values.len() < i + 1 {
-            // Extend to the given index.
-            self.field_values.push(None);
+        if self.field_values.is_empty() {
+            // If we're adding the first field, go ahead and reserve capacity to
+            // add all the fields.
+            let count = self.static_meta.field_names.len();
+            self.field_values.reserve(count);
+            self.field_values.extend(iter::repeat(()).map(|_| None).take(count));
         }
         let field = &mut self.field_values[key.as_usize()];
         if field.is_some() {

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -372,6 +372,12 @@ impl Data {
     /// `name` must name a field already defined by this span's metadata, and
     /// the field must not already have a value. If this is not the case, this
     /// function returns an [`AddValueError`](::subscriber::AddValueError).
+    ///
+    /// **Note**: This function will allocate to grow the vector used internally
+    /// to store the span's field values. Otherwise, if this function is not used,
+    /// the `Data` type will not allocate. Thus, this function should only be
+    /// called by subscribers who wish to allocate to persist field values;
+    /// otherwise, it need not be used.
     pub fn add_value(&mut self, key: &Key, value: &dyn IntoValue) -> Result<(), AddValueError> {
         if !self.has_field(key) {
             return Err(AddValueError::NoField);

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -388,7 +388,8 @@ impl Data {
             // add all the fields.
             let count = self.static_meta.field_names.len();
             self.field_values.reserve(count);
-            self.field_values.extend(iter::repeat(()).map(|_| None).take(count));
+            self.field_values
+                .extend(iter::repeat(()).map(|_| None).take(count));
         }
         let field = &mut self.field_values[key.as_usize()];
         if field.is_some() {


### PR DESCRIPTION
Currently, the `span::Data` type pre-allocates a vector of `None`s for
each field on a span when the `Data` is created. This is so that we can
set those indices into the vector to store the field at that index, when
adding field values to the span. However, if a subscriber chooses *not*
to store the `span::Data`, or not to add values to it in that
subscriber's implementation of `add_value`, it _still_ has to pay the
cost of this allocation. 

This branch changes `span::Data` to only allocate when `add_value` is
called, rather than in `new`. It will now only grow the vector the
desired amount to store another value. Thus, if a subscriber does not
wish to allocate, the allocation will never take place. When `add_data`
is called and the vector is empty, we reserve enough capacity to store
all the fields, so we still only perform a single allocation.

This improves the benchmarks which construct spans with fields but never
store the fields in the constructed `span::Data` significantly:

```
running 4 tests
test span_no_fields            ... bench:          75 ns/iter (+/- 11)
test span_repeatedly           ... bench:       8,572 ns/iter (+/- 1,110)
test span_with_fields          ... bench:          90 ns/iter (+/- 9)
test span_with_fields_add_data ... bench:         734 ns/iter (+/- 67)
```

vs master:

```
running 4 tests
test span_no_fields            ... bench:          80 ns/iter (+/- 12)
test span_repeatedly           ... bench:      16,311 ns/iter (+/- 4,239)
test span_with_fields          ... bench:         172 ns/iter (+/- 66)
test span_with_fields_add_data ... bench:         742 ns/iter (+/- 124)
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>