### PR TITLE
Reduce current dispatcher Arc clones

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -8,7 +8,6 @@ use {
 
 use std::{
     cell::RefCell,
-    default::Default,
     fmt,
     sync::{Arc, Weak},
 };
@@ -33,18 +32,15 @@ impl Dispatch {
         }
     }
 
-    /// Returns the subscriber that a new [`Span`] or [`Event`] would dispatch
-    /// to.
-    ///
-    /// This returns a `Dispatch` to the [`Subscriber`] that created the
-    /// current [`Span`], or the thread's default subscriber if no
-    /// span is currently executing.
-    ///
-    /// [`Span`]: ::span::Span
-    /// [`Subscriber`]: ::Subscriber
-    /// [`Event`]: ::Event
-    pub(crate) fn current() -> Dispatch {
-        Span::current().dispatch().cloned().unwrap_or_default()
+    pub(crate) fn with_current<T, F>(f: F) -> T
+    where
+        F: FnOnce(&Dispatch) -> T
+    {
+        if let Some(c) = Span::current().dispatch() {
+            f(c)
+        } else {
+            CURRENT_DISPATCH.with(|current| f(&*current.borrow()))
+        }
     }
 
     /// Returns a `Dispatch` to the given [`Subscriber`](::Subscriber).
@@ -87,12 +83,6 @@ impl Dispatch {
 impl fmt::Debug for Dispatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("Dispatch(...)")
-    }
-}
-
-impl Default for Dispatch {
-    fn default() -> Self {
-        CURRENT_DISPATCH.with(|current| current.borrow().clone())
     }
 }
 

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -34,7 +34,7 @@ impl Dispatch {
 
     pub(crate) fn with_current<T, F>(f: F) -> T
     where
-        F: FnOnce(&Dispatch) -> T
+        F: FnOnce(&Dispatch) -> T,
     {
         if let Some(c) = Span::current().dispatch() {
             f(c)

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -357,7 +357,6 @@ impl<'a> Event<'a> {
                 });
             }
         })
-
     }
 
     /// Returns an iterator over the names of all the fields on this `Event`.

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -345,17 +345,19 @@ impl<'a> Event<'a> {
         if interest == Interest::NEVER {
             return;
         }
-        let dispatch = Dispatch::current();
-        let meta = callsite.metadata();
-        if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
-            dispatch.observe_event(&Event {
-                parent: SpanId::current(),
-                follows_from,
-                meta,
-                field_values,
-                message,
-            });
-        }
+        Dispatch::with_current(|dispatch| {
+            let meta = callsite.metadata();
+            if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
+                dispatch.observe_event(&Event {
+                    parent: SpanId::current(),
+                    follows_from,
+                    meta,
+                    field_values,
+                    message,
+                });
+            }
+        })
+
     }
 
     /// Returns an iterator over the names of all the fields on this `Event`.


### PR DESCRIPTION
Closes #84.

This branch replaces `Dispatch::current` with a function that runs a
closure on the current dispatcher using `CURRENT_DISPATCH.with(...)`,
and only clones the dispatcher when it's necessary to do so to construct
a new enabled span. 

On my machine, this change has relatively little performance impact, but
on platforms where an arc bump is more costly, this is likely a significant
performance improvement:

```
running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           1 ns/iter (+/- 0)
test bench_log_no_logger              ... bench:           1 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           1 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-8c367dadfb217e91

running 4 tests
test span_no_fields            ... bench:          82 ns/iter (+/- 12)
test span_repeatedly           ... bench:       8,616 ns/iter (+/- 1,209)
test span_with_fields          ... bench:          98 ns/iter (+/- 22)
test span_with_fields_add_data ... bench:         783 ns/iter (+/- 123)
```

vs. master:

```
     Running target/release/deps/no_subscriber-9e181e53a6cbc952

running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           1 ns/iter (+/- 0)
test bench_log_no_logger              ... bench:           1 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           1 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-8c367dadfb217e91

running 4 tests
test span_no_fields            ... bench:          68 ns/iter (+/- 10)
test span_repeatedly           ... bench:       7,603 ns/iter (+/- 923)
test span_with_fields          ... bench:          86 ns/iter (+/- 23)
test span_with_fields_add_data ... bench:         805 ns/iter (+/- 110)
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>