### PR TITLE
Remove `span::Data` from `tokio-trace-core`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -103,7 +103,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn new_span(&self, span: span::Data) -> span::Id {
+    fn new_span(&self, span: span::Attributes) -> span::Id {
         self.subscriber.new_span(span)
     }
 
@@ -155,7 +155,7 @@ impl Subscriber for Dispatch {
 struct NoSubscriber;
 
 impl Subscriber for NoSubscriber {
-    fn new_span(&self, _span: span::Data) -> span::Id {
+    fn new_span(&self, _span: span::Attributes) -> span::Id {
         span::Id::from_u64(0)
     }
 

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -349,12 +349,14 @@ impl<'a> Key<'a> {
         Self { i, metadata }
     }
 
-    pub(crate) fn as_usize(&self) -> usize {
-        self.i
-    }
-
     pub(crate) fn metadata(&self) -> &Meta<'a> {
         self.metadata
+    }
+
+    /// Return a `usize` representing the index into an array whose indices are
+    /// ordered the same as the set of fields that generated this `key`.
+    pub fn as_usize(&self) -> usize {
+        self.i
     }
 
     /// Returns a string representing the name of the field, or `None` if the

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -112,7 +112,7 @@ pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
     field::{AsValue, IntoValue, Key, Value},
-    span::{Data as SpanData, Id as SpanId, Span},
+    span::{Attributes as SpanAttributes, Id as SpanId, Span},
     subscriber::Subscriber,
 };
 use field::BorrowedValue;

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -296,10 +296,7 @@ impl fmt::Debug for Span {
 
 impl Attributes {
     fn new(parent: Option<Id>, metadata: &'static StaticMeta) -> Self {
-        Attributes {
-            parent,
-            metadata,
-        }
+        Attributes { parent, metadata }
     }
 
     /// Returns the name of this span, or `None` if it is unnamed,

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -40,26 +40,16 @@ pub struct Span {
     is_closed: bool,
 }
 
-/// Representation of the data associated with a span.
-///
-/// This has the potential to outlive the span itself if it exists after the
-/// span completes executing --- such as if it is still being processed by a
-/// subscriber.
+/// A set of attributes describing a new `Span`.
 ///
 /// This may *not* be used to enter the span.
-pub struct Data {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attributes {
     /// The span ID of the parent span, or `None` if that span does not exist.
-    pub parent: Option<Id>,
+    parent: Option<Id>,
 
     /// Metadata describing this span.
-    pub static_meta: &'static StaticMeta,
-
-    /// The values of the fields attached to this span.
-    ///
-    /// These may be `None` if a field was defined but the value has yet to be
-    /// attached. The name of the field at each index is defined by
-    /// `self.static_meta.field_names[i]`.
-    pub field_values: Vec<Option<OwnedValue>>,
+    metadata: &'static Meta<'static>,
 }
 
 /// Identifies a span within the context of a process.
@@ -152,7 +142,7 @@ impl Span {
         if callsite.is_enabled(&dispatch) {
             let meta = callsite.metadata();
             let parent = Id::current();
-            let data = Data::new(parent.clone(), meta);
+            let data = Attributes::new(parent.clone(), meta);
             let id = dispatch.new_span(data);
             let inner = Some(Enter::new(id, dispatch, parent, meta));
             let mut span = Self {
@@ -302,26 +292,19 @@ impl fmt::Debug for Span {
     }
 }
 
-// ===== impl Data =====
+// ===== impl Attributes =====
 
-impl Data {
-    fn new(parent: Option<Id>, static_meta: &'static StaticMeta) -> Self {
-        // Preallocate enough `None`s to hold the unset state of every field
-        // name.
-        let field_values = iter::repeat(())
-            .map(|_| None)
-            .take(static_meta.field_names.len())
-            .collect();
-        Data {
+impl Attributes {
+    fn new(parent: Option<Id>, metadata: &'static StaticMeta) -> Self {
+        Attributes {
             parent,
-            static_meta,
-            field_values,
+            metadata,
         }
     }
 
     /// Returns the name of this span, or `None` if it is unnamed,
     pub fn name(&self) -> Option<&'static str> {
-        self.static_meta.name
+        self.metadata.name
     }
 
     /// Returns the `Id` of the parent of this span, if one exists.
@@ -330,13 +313,13 @@ impl Data {
     }
 
     /// Borrows this span's metadata.
-    pub fn meta(&self) -> &'static StaticMeta {
-        self.static_meta
+    pub fn metadata(&self) -> &'static StaticMeta {
+        self.metadata
     }
 
     /// Returns an iterator over the names of all the fields on this span.
     pub fn field_keys(&self) -> impl Iterator<Item = Key<'static>> {
-        self.static_meta.fields()
+        self.metadata.fields()
     }
 
     /// Returns a [`Key`](::field::Key) for the field with the given `name`, if
@@ -345,76 +328,14 @@ impl Data {
     where
         Q: Borrow<str>,
     {
-        self.static_meta.key_for(name)
+        self.metadata.key_for(name)
     }
 
     /// Returns true if a field named 'name' has been declared on this span,
     /// even if the field does not currently have a value.
     #[inline]
     pub fn has_field(&self, key: &Key) -> bool {
-        self.static_meta.contains_key(key)
-    }
-
-    /// Borrows the value of the field named `name`, if it exists. Otherwise,
-    /// returns `None`.
-    pub fn field(&self, key: &Key) -> Option<&OwnedValue> {
-        if !self.has_field(key) {
-            return None;
-        }
-
-        let i = key.as_usize();
-        self.field_values.get(i)?.as_ref()
-    }
-
-    /// Returns an iterator over all the field names and values on this span.
-    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (Key<'static>, &'a OwnedValue)> {
-        self.field_keys().filter_map(move |key| {
-            let val = self.field_values.get(key.as_usize())?.as_ref()?;
-            Some((key, val))
-        })
-    }
-
-    /// Edits the span data to add the given `value` to the field indexed by `key`.
-    ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`AddValueError`](::subscriber::AddValueError).
-    pub fn add_value(&mut self, key: &Key, value: &dyn IntoValue) -> Result<(), AddValueError> {
-        if !self.has_field(key) {
-            return Err(AddValueError::NoField);
-        }
-        let field = &mut self.field_values[key.as_usize()];
-        if field.is_some() {
-            Err(AddValueError::FieldAlreadyExists)
-        } else {
-            *field = Some(value.into_value());
-            Ok(())
-        }
-    }
-
-    /// Returns a struct that can be used to format all the fields on this
-    /// span with `fmt::Debug`.
-    pub fn debug_fields<'a>(&'a self) -> DebugFields<'a, 'static, Self, &'a OwnedValue> {
-        DebugFields(self)
-    }
-}
-
-impl<'a> IntoIterator for &'a Data {
-    type Item = (Key<'static>, &'a OwnedValue);
-    type IntoIter = Box<Iterator<Item = Self::Item> + 'a>; // TODO: unbox
-    fn into_iter(self) -> Self::IntoIter {
-        Box::new(self.fields())
-    }
-}
-
-impl fmt::Debug for Data {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Span")
-            .field("name", &self.name())
-            .field("parent", &self.parent)
-            .field("fields", &self.debug_fields())
-            .field("meta", &self.meta())
-            .finish()
+        self.metadata.contains_key(key)
     }
 }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -112,7 +112,7 @@ pub trait Subscriber {
     ///
     /// [span ID]: ::span::Id
     /// [`Span`]: ::span::Span
-    fn new_span(&self, span: span::Data) -> span::Id;
+    fn new_span(&self, span: span::Attributes) -> span::Id;
 
     /// Adds a new field to an existing span observed by this `Subscriber`.
     ///
@@ -305,7 +305,7 @@ mod test_support {
 
     use super::*;
     use span::{self, MockSpan};
-    use {field::Key, Event, IntoValue, Meta, SpanData, SpanId};
+    use {field::Key, Event, IntoValue, Meta, SpanAttributes, SpanId};
 
     use std::{
         collections::{HashMap, VecDeque},
@@ -329,7 +329,7 @@ mod test_support {
     }
 
     struct Running<F: Fn(&Meta) -> bool> {
-        spans: Mutex<HashMap<SpanId, SpanData>>,
+        spans: Mutex<HashMap<SpanId, SpanAttributes>>,
         expected: Mutex<VecDeque<Expect>>,
         ids: AtomicUsize,
         filter: F,
@@ -412,7 +412,7 @@ mod test_support {
             Ok(())
         }
 
-        fn new_span(&self, span: SpanData) -> span::Id {
+        fn new_span(&self, span: SpanAttributes) -> span::Id {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = span::Id::from_u64(id as u64);
             self.spans.lock().unwrap().insert(id.clone(), span);

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
     span,
     subscriber::{AddValueError, FollowsError, Subscriber},
-    Event, IntoValue, Meta, SpanData,
+    Event, IntoValue, Meta,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
@@ -98,8 +98,8 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_span(&self, new_span: SpanData) -> span::Id {
-        self.registry.new_span(new_span)
+    fn new_span(&self, new_span: span::Attributes) -> span::Id {
+        self.registry.new_span(span::Data::from_attributes(new_span))
     }
 
     fn add_value(

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -99,7 +99,8 @@ where
     }
 
     fn new_span(&self, new_span: span::Attributes) -> span::Id {
-        self.registry.new_span(span::Data::from_attributes(new_span))
+        self.registry
+            .new_span(span::Data::from_attributes(new_span))
     }
 
     fn add_value(

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -24,7 +24,7 @@ struct CounterSubscriber {
 }
 
 impl Subscriber for CounterSubscriber {
-    fn new_span(&self, new_span: span::Data) -> span::Id {
+    fn new_span(&self, new_span: span::Attributes) -> span::Id {
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
         for key in new_span.field_keys() {
             if let Some(name) = key.name() {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -111,10 +111,10 @@ impl Subscriber for SloggishSubscriber {
         true
     }
 
-    fn new_span(&self, span: tokio_trace::SpanData) -> tokio_trace::span::Id {
+    fn new_span(&self, span: tokio_trace::span::Attributes) -> tokio_trace::span::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         let id = tokio_trace::span::Id::from_u64(next);
-        self.spans.lock().unwrap().insert(id.clone(), span);
+        self.spans.lock().unwrap().insert(id.clone(), span.into());
         id
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -196,14 +196,19 @@
 //! [`Data`]: ::span::Data
 //! [shared span]: ::span::Shared
 //! [`IntoShared`]: ::span::IntoShared
-pub use tokio_trace_core::span::{Data, Id, Span};
+pub use tokio_trace_core::span::{Attributes, Id, Span};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};
 
-use std::sync::Arc;
+use std::{
+    fmt,
+    borrow::Borrow,
+    iter,
+    sync::Arc,
+};
 use tokio_trace_core::span::Enter;
-use {field, subscriber, IntoValue};
+use {field, subscriber, IntoValue, Meta};
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
 pub trait IntoShared {
@@ -255,6 +260,25 @@ impl IntoShared for Span {
 pub struct Shared {
     inner: Option<Arc<Enter>>,
 }
+
+/// Representation of the data associated with a span.
+///
+/// This has the potential to outlive the span itself if it exists after the
+/// span completes executing --- such as if it is still being processed by a
+/// subscriber.
+///
+/// This may *not* be used to enter the span.
+pub struct Data {
+    attributes: Attributes,
+
+    /// The values of the fields attached to this span.
+    ///
+    /// These may be `None` if a field was defined but the value has yet to be
+    /// attached. The name of the field at each index is defined by
+    /// `self.attributes.field_names[i]`.
+    field_values: Vec<Option<field::OwnedValue>>,
+}
+
 
 impl Shared {
     /// Returns a `Shared` span handle that can be cloned.
@@ -379,37 +403,151 @@ impl SpanExt for Span {
     }
 }
 
-impl ::sealed::Sealed for Data {}
+impl Data {
+    pub fn from_attributes(attributes: Attributes) -> Self {
+        Self {
+            attributes,
+            field_values: Vec::new(),
+        }
+    }
 
-impl SpanExt for Data {
-    fn add_value_for<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: &dyn IntoValue,
-    ) -> Result<(), subscriber::AddValueError>
+    /// Returns the name of this span, or `None` if it is unnamed,
+    pub fn name(&self) -> Option<&'static str> {
+        self.attributes.name()
+    }
+
+    /// Returns the `Id` of the parent of this span, if one exists.
+    pub fn parent(&self) -> Option<&Id> {
+        self.attributes.parent()
+    }
+
+    /// Borrows this span's metadata.
+    pub fn metadata(&self) -> &'static Meta<'static> {
+        self.attributes.metadata()
+    }
+
+    /// Returns an iterator over the names of all the fields on this span.
+    pub fn field_keys(&self) -> impl Iterator<Item = field::Key<'static>> {
+        self.metadata().fields()
+    }
+
+    /// Returns a [`Key`](::field::Key) for the field with the given `name`, if
+    /// one exists,
+    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Key<'static>>
+    where
+        Q: Borrow<str>,
+    {
+        self.attributes.key_for(name)
+    }
+
+    /// Returns true if a field named 'name' has been declared on this span,
+    /// even if the field does not currently have a value.
+    #[inline]
+    pub fn has_field<Q: ?Sized>(&self, field: &Q) -> bool
+    where
+        Q: field::AsKey,
+    {
+        if let Some(key) = field.as_key(self.metadata()) {
+            self.metadata().contains_key(&key)
+        } else {
+            false
+        }
+    }
+
+    /// Borrows the value of the field named `name`, if it exists. Otherwise,
+    /// returns `None`.
+    pub fn field_for<Q: ?Sized>(&self, field: &Q) -> Option<&field::OwnedValue>
     where
         Q: field::AsKey,
     {
         let key = field
-            .as_key(self.meta())
-            .ok_or(subscriber::AddValueError::NoField)?;
-        self.add_value(&key, value)
+            .as_key(self.metadata())?;
+        if !self.has_field(&key) {
+            return None;
+        }
+
+        let i = key.as_usize();
+        self.field_values.get(i)?.as_ref()
     }
 
-    fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
+    /// Returns an iterator over all the field names and values on this span.
+    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (field::Key<'static>, &'a field::OwnedValue)> {
+        self.field_keys().filter_map(move |key| {
+            let val = self.field_values.get(key.as_usize())?.as_ref()?;
+            Some((key, val))
+        })
+    }
+
+    /// Edits the span data to add the given `value` to the field indexed by `key`.
+    ///
+    /// `name` must name a field already defined by this span's metadata, and
+    /// the field must not already have a value. If this is not the case, this
+    /// function returns an [`AddValueError`](::subscriber::AddValueError).
+    ///
+    /// **Note**: This function will allocate to grow the vector used internally
+    /// to store the span's field values. Otherwise, if this function is not used,
+    /// the `Data` type will not allocate. Thus, this function should only be
+    /// called by subscribers who wish to allocate to persist field values;
+    /// otherwise, it need not be used.
+    pub fn add_value<Q: ?Sized>(&mut self, field: &Q, value: &dyn field::IntoValue) -> Result<(), ::subscriber::AddValueError>
     where
         Q: field::AsKey,
     {
-        field.as_key(self.meta()).is_some()
+        let meta = self.metadata();
+        let key = field
+            .as_key(meta)
+            .ok_or(::subscriber::AddValueError::NoField)?;
+        if !self.has_field(&key) {
+            return Err(::subscriber::AddValueError::NoField);
+        }
+        if self.field_values.is_empty() {
+            // If we're adding the first field, go ahead and reserve capacity to
+            // add all the fields.
+            let count = meta.field_names.len();
+            self.field_values.reserve(count);
+            self.field_values
+                .extend(iter::repeat(()).map(|_| None).take(count));
+        }
+        let field = &mut self.field_values[key.as_usize()];
+        if field.is_some() {
+            Err(::subscriber::AddValueError::FieldAlreadyExists)
+        } else {
+            *field = Some(value.into_value());
+            Ok(())
+        }
     }
 }
 
-impl DataExt for Data {
-    fn field_for<Q: ?Sized>(&self, field: &Q) -> Option<&field::OwnedValue>
-    where
-        Q: field::AsKey,
-    {
-        self.field(&field.as_key(self.meta())?)
+impl<'a> IntoIterator for &'a Data {
+    type Item = (field::Key<'static>, &'a field::OwnedValue);
+    type IntoIter = Box<Iterator<Item = Self::Item> + 'a>; // TODO: unbox
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.fields())
+    }
+}
+
+impl fmt::Debug for Data {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        struct DebugFields<'a>(&'a Data);
+        impl<'a> fmt::Debug for DebugFields<'a> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.debug_set().entries(self.0.into_iter()
+                    .map(|(k, v)| (k.name().unwrap_or("???"), v))).finish()
+            }
+        }
+
+        f.debug_struct("Data")
+            .field("name", &self.name())
+            .field("parent", &self.parent())
+            .field("fields", &DebugFields(self))
+            .field("metadata", &self.metadata())
+            .finish()
+    }
+}
+
+impl From<Attributes> for Data {
+    fn from(attributes: Attributes) -> Data {
+        Data::from_attributes(attributes)
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -201,12 +201,7 @@ pub use tokio_trace_core::span::{Attributes, Id, Span};
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};
 
-use std::{
-    fmt,
-    borrow::Borrow,
-    iter,
-    sync::Arc,
-};
+use std::{borrow::Borrow, fmt, iter, sync::Arc};
 use tokio_trace_core::span::Enter;
 use {field, subscriber, IntoValue, Meta};
 
@@ -278,7 +273,6 @@ pub struct Data {
     /// `self.attributes.field_names[i]`.
     field_values: Vec<Option<field::OwnedValue>>,
 }
-
 
 impl Shared {
     /// Returns a `Shared` span handle that can be cloned.
@@ -460,8 +454,7 @@ impl Data {
     where
         Q: field::AsKey,
     {
-        let key = field
-            .as_key(self.metadata())?;
+        let key = field.as_key(self.metadata())?;
         if !self.has_field(&key) {
             return None;
         }
@@ -471,7 +464,9 @@ impl Data {
     }
 
     /// Returns an iterator over all the field names and values on this span.
-    pub fn fields<'a>(&'a self) -> impl Iterator<Item = (field::Key<'static>, &'a field::OwnedValue)> {
+    pub fn fields<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = (field::Key<'static>, &'a field::OwnedValue)> {
         self.field_keys().filter_map(move |key| {
             let val = self.field_values.get(key.as_usize())?.as_ref()?;
             Some((key, val))
@@ -489,7 +484,11 @@ impl Data {
     /// the `Data` type will not allocate. Thus, this function should only be
     /// called by subscribers who wish to allocate to persist field values;
     /// otherwise, it need not be used.
-    pub fn add_value<Q: ?Sized>(&mut self, field: &Q, value: &dyn field::IntoValue) -> Result<(), ::subscriber::AddValueError>
+    pub fn add_value<Q: ?Sized>(
+        &mut self,
+        field: &Q,
+        value: &dyn field::IntoValue,
+    ) -> Result<(), ::subscriber::AddValueError>
     where
         Q: field::AsKey,
     {
@@ -531,8 +530,12 @@ impl fmt::Debug for Data {
         struct DebugFields<'a>(&'a Data);
         impl<'a> fmt::Debug for DebugFields<'a> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.debug_set().entries(self.0.into_iter()
-                    .map(|(k, v)| (k.name().unwrap_or("???"), v))).finish()
+                f.debug_set()
+                    .entries(
+                        self.0
+                            .into_iter()
+                            .map(|(k, v)| (k.name().unwrap_or("???"), v)),
+                    ).finish()
             }
         }
 


### PR DESCRIPTION
Closes #25 
Closes #87

This branch removes the `span::Data` type from `tokio-trace-core` and
replaces it with a new `span::Attributes` type, which does not track the
span's field values. 

Since the `Data` type might still be useful for subscriber
implementations, it is still provided in the `tokio-trace` crate, but is
no longer part of `core`.

This also includes the changes in PR #87, which  changes `Data` to only
allocate when `add_value` is called, rather than in `new`. It will now
only grow the vector the desired amount to store another value. Thus, if
a subscriber does not wish to allocate, the allocation will never take
place. When `add_data` is called and the vector is empty, we reserve
enough capacity to store all the fields, so we still only perform a
single allocation.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>