### PR TITLE
Don't get the dispatcher when the cached interest is NEVER

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -21,10 +21,8 @@ struct Registry {
 
 /// Trait implemented by callsites.
 pub trait Callsite: Sync {
-    /// Returns `true` if the callsite is enabled for the given [dispatcher].
-    ///
-    /// [dispatcher]: ::Dispatch
-    fn is_enabled(&self, dispatch: &Dispatch) -> bool;
+    /// Returns the callsite's current Interest.
+    fn interest(&self) -> Interest;
 
     /// Adds the [`Interest`] returned by [registering] the callsite with a
     /// [dispatcher].

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -113,7 +113,7 @@ pub use self::{
     dispatcher::Dispatch,
     field::{AsValue, IntoValue, Key, Value},
     span::{Attributes as SpanAttributes, Id as SpanId, Span},
-    subscriber::{Subscriber, Interest},
+    subscriber::{Interest, Subscriber},
 };
 use field::BorrowedValue;
 

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -113,7 +113,7 @@ pub use self::{
     dispatcher::Dispatch,
     field::{AsValue, IntoValue, Key, Value},
     span::{Attributes as SpanAttributes, Id as SpanId, Span},
-    subscriber::Subscriber,
+    subscriber::{Subscriber, Interest},
 };
 use field::BorrowedValue;
 
@@ -341,12 +341,17 @@ impl<'a> Event<'a> {
         follows_from: &[SpanId],
         message: fmt::Arguments<'a>,
     ) {
+        let interest = callsite.interest();
+        if interest == Interest::NEVER {
+            return;
+        }
         let dispatch = Dispatch::current();
-        if callsite.is_enabled(&dispatch) {
+        let meta = callsite.metadata();
+        if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
             dispatch.observe_event(&Event {
                 parent: SpanId::current(),
                 follows_from,
-                meta: callsite.metadata(),
+                meta,
                 field_values,
                 message,
             });

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -10,7 +10,7 @@ use std::{
 use {
     callsite::Callsite,
     field::{IntoValue, Key, OwnedValue},
-    subscriber::{AddValueError, FollowsError, Subscriber, Interest},
+    subscriber::{AddValueError, FollowsError, Interest, Subscriber},
     DebugFields, Dispatch, Meta, StaticMeta,
 };
 

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -10,7 +10,7 @@ use std::{
 use {
     callsite::Callsite,
     field::{IntoValue, Key, OwnedValue},
-    subscriber::{AddValueError, FollowsError, Subscriber},
+    subscriber::{AddValueError, FollowsError, Subscriber, Interest},
     DebugFields, Dispatch, Meta, StaticMeta,
 };
 
@@ -138,25 +138,31 @@ impl Span {
     where
         F: FnOnce(&mut Span),
     {
-        let dispatch = Dispatch::current();
-        if callsite.is_enabled(&dispatch) {
-            let meta = callsite.metadata();
-            let parent = Id::current();
-            let data = Attributes::new(parent.clone(), meta);
-            let id = dispatch.new_span(data);
-            let inner = Some(Enter::new(id, dispatch, parent, meta));
-            let mut span = Self {
-                inner,
-                is_closed: false,
-            };
-            if_enabled(&mut span);
-            span
-        } else {
-            Span {
+        let interest = callsite.interest();
+        if interest == Interest::NEVER {
+            return Span {
                 inner: None,
                 is_closed: false,
-            }
+            };
         }
+        let dispatch = Dispatch::current();
+        let meta = callsite.metadata();
+        if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
+            return Span {
+                inner: None,
+                is_closed: false,
+            };
+        }
+        let parent = Id::current();
+        let attrs = Attributes::new(parent.clone(), meta);
+        let id = dispatch.new_span(attrs);
+        let inner = Some(Enter::new(id, dispatch, parent, meta));
+        let mut span = Self {
+            inner,
+            is_closed: false,
+        };
+        if_enabled(&mut span);
+        span
     }
 
     /// Returns a reference to the span that this thread is currently

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -37,8 +37,8 @@ use tokio_trace_subscriber::SpanRef;
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
     struct LogCallsite<'a>(tokio_trace::Meta<'a>);
     impl<'a> tokio_trace::Callsite for LogCallsite<'a> {
-        fn is_enabled(&self, dispatch: &tokio_trace::Dispatch) -> bool {
-            dispatch.enabled(&self.0)
+        fn interest(&self) -> tokio_trace::subscriber::Interest {
+            tokio_trace::subscriber::Interest::SOMETIMES
         }
 
         fn add_interest(&self, _interest: tokio_trace::subscriber::Interest) {

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -14,6 +14,7 @@ tokio-trace-core = { path = "../tokio-trace-core" }
 ansi_term = "0.11"
 humantime = "1.1.1"
 env_logger = "0.5"
+log = "0.4"
 tokio-trace-log = { path = "../tokio-trace-log" }
 tokio-trace-core = { path = "../tokio-trace-core", features = ["test-support"] }
 futures = "0.1"

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -1,6 +1,8 @@
 #![feature(test)]
 #[macro_use]
 extern crate tokio_trace;
+#[macro_use]
+extern crate log;
 extern crate test;
 use test::Bencher;
 
@@ -10,6 +12,17 @@ fn bench_span_no_subscriber(b: &mut Bencher) {
     b.iter(|| {
         (0..n).fold(0, |old, new| {
             span!("span");
+            old ^ new
+        })
+    });
+}
+
+#[bench]
+fn bench_log_no_logger(b: &mut Bencher) {
+    let n = test::black_box(1);
+    b.iter(|| {
+        (0..n).fold(0, |old, new| {
+            log!(log::Level::Info, "log");
             old ^ new
         })
     });

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -96,8 +96,7 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
-            use $crate::{callsite, Dispatch, Span};
-            use $crate::callsite::Callsite;
+            use $crate::{callsite, callsite::Callsite, Span};
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
             // not actually be used, but it doesn't make sense to repeat it.
@@ -125,7 +124,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{callsite, Dispatch, SpanData, SpanId, Subscriber, Event, field::AsValue};
+            use $crate::{callsite, SpanData, SpanId, Subscriber, Event, field::AsValue};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:
                 $lvl,


### PR DESCRIPTION
Currently, the `Callsite::is_enabled` function requires a reference to a
dispatcher. This is used to filter the callsite when the cached interest
is `Interest::SOMETIMES`. However, it means we must always get the
current dispatcher, even when the interest is `NEVER`.

This branch replaces `Callsite::is_enabled` with a `Callsite::interest`
function that just returns the cached interest. This no longer requires
a reference to a dispatcher. The `Span::new` and `Event::observe`
functions have been rewritten to only get the dispatcher if the interest
is `ALWAYS` or `SOMETIMES`.

This results in a major performance improvement in the case where a span
is disabled, putting our performance within the same order of magnitude
as the `log` crate's performance when there's no logger.

Benchmark results  (`bench_span_no_subscriber`) is the most relevant:

```
     Running target/release/deps/no_subscriber-6fb6999bbb120c50

running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           5 ns/iter (+/- 1)
test bench_log_no_logger              ... bench:           1 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           5 ns/iter (+/- 2)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-c1100adcfb21cd44

running 4 tests
test span_no_fields            ... bench:          68 ns/iter (+/- 10)
test span_repeatedly           ... bench:       7,877 ns/iter (+/- 1,093)
test span_with_fields          ... bench:          86 ns/iter (+/- 9)
test span_with_fields_add_data ... bench:         770 ns/iter (+/- 104)
```

vs. master:

```
     Running target/release/deps/no_subscriber-9f5296229e2944c8

running 4 tests
test bench_1_atomic_load              ... bench:           1 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:          42 ns/iter (+/- 7)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:          39 ns/iter (+/- 7)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out

     Running target/release/deps/subscriber-a13cd106471c1486

running 4 tests
test span_no_fields            ... bench:          77 ns/iter (+/- 14)
test span_repeatedly           ... bench:       9,305 ns/iter (+/- 2,155)
test span_with_fields          ... bench:          92 ns/iter (+/- 16)
test span_with_fields_add_data ... bench:         814 ns/iter (+/- 136)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out

```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>