### PR TITLE
Inline the hottest callsite filtering functions

### DIFF
--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -134,6 +134,7 @@ impl Span {
     /// [current span]: ::span::Span::current
     /// [field values]: ::span::Span::add_value
     /// [`follows_from` annotations]: ::span::Span::follows_from
+    #[inline]
     pub fn new<F>(callsite: &'static dyn Callsite, if_enabled: F) -> Span
     where
         F: FnOnce(&mut Span),

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -281,6 +281,7 @@ impl Interest {
     pub const ALWAYS: Interest = Interest(InterestKind::Always);
 
     /// Constructs a new `Interest` from a `usize`.
+    #[inline]
     pub fn from_usize(u: usize) -> Option<Self> {
         match u {
             0 => Some(Interest::NEVER),

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -37,6 +37,7 @@ macro_rules! callsite {
         static REGISTRATION: Once = Once::new();
         struct MyCallsite;
         impl callsite::Callsite for MyCallsite {
+            #[inline]
             fn interest(&self) -> Interest {
                 Interest::from_usize(INTEREST.load(Ordering::Relaxed))
                     .unwrap_or(Interest::SOMETIMES)


### PR DESCRIPTION
Inlining the small functions called in the callsite filtering path seems
to improve the performance of disabled spans enough that the overhead is
now about on par with the `log` crate.

Benchmarks for this branch:

```
     Running target/release/deps/no_subscriber-9e181e53a6cbc952

running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           1 ns/iter (+/- 0)
test bench_log_no_logger              ... bench:           1 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           1 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-8c367dadfb217e91

running 4 tests
test span_no_fields            ... bench:          65 ns/iter (+/- 14)
test span_repeatedly           ... bench:       8,238 ns/iter (+/- 1,489)
test span_with_fields          ... bench:          78 ns/iter (+/- 16)
test span_with_fields_add_data ... bench:         824 ns/iter (+/- 317)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```

vs. master:

```
     Running target/release/deps/no_subscriber-6fb6999bbb120c50

running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           5 ns/iter (+/- 1)
test bench_log_no_logger              ... bench:           1 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           5 ns/iter (+/- 2)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-c1100adcfb21cd44

running 4 tests
test span_no_fields            ... bench:          68 ns/iter (+/- 10)
test span_repeatedly           ... bench:       7,877 ns/iter (+/- 1,093)
test span_with_fields          ... bench:          86 ns/iter (+/- 9)
test span_with_fields_add_data ... bench:         770 ns/iter (+/- 104)
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>