### PR TITLE
Make subscriber errors forwards-compatible

### DIFF
--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -454,13 +454,7 @@ impl Enter {
     /// returns `Ok(())` if the other span was added as a precedent of this
     /// span, or an error if this was not possible.
     pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
-        match self.subscriber.add_follows_from(&self.id, from) {
-            Ok(()) => Ok(()),
-            Err(FollowsError::NoSpan(ref id)) if id == &self.id => {
-                panic!("span {:?} should exist to add a preceeding span", self.id)
-            }
-            Err(e) => Err(e),
-        }
+        self.subscriber.add_follows_from(&self.id, from)
     }
 
     /// Returns the span's ID.

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -428,12 +428,12 @@ impl Enter {
     /// function returns an [`RecordError`](::subscriber::RecordError).
     pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
         if !self.meta.contains_key(field) {
-            return Err(RecordError::NoField);
+            return Err(RecordError::no_field());
         }
 
         match self.subscriber.record(&self.id, field, value) {
             Ok(()) => Ok(()),
-            Err(RecordError::NoSpan) => panic!("span should still exist!"),
+            Err(ref e) if e.is_no_span() => panic!("span should still exist!"),
             Err(e) => Err(e),
         }
     }

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -1,7 +1,7 @@
 //! Subscribers collect and record trace data.
 use {field, span, Event, Meta, SpanId};
 
-use std::fmt;
+use std::{error::Error, fmt};
 
 /// Trait representing the functions required to collect trace data.
 ///
@@ -224,16 +224,19 @@ enum InterestKind {
 }
 
 /// Errors which may prevent a value from being successfully added to a span.
-// TODO: before releasing core 0.1 this needs to be made private, to avoid
-// future breaking changes.
 #[derive(Debug)]
-pub enum RecordError {
+pub struct RecordError {
+    kind: RecordErrorKind,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum RecordErrorKind {
     /// The span with the given ID does not exist.
-    NoSpan,
+    NoSpan(SpanId),
     /// The span exists, but does not have the specified field.
     NoField,
     /// The named field already has a value.
-    FieldAlreadyExists,
+    AlreadyExists,
     /// An error occurred recording the field.
     Record,
 }
@@ -302,11 +305,90 @@ impl Interest {
 }
 
 // ===== impl RecordError =====
-// TODO: impl Error, etc
+
+impl RecordError {
+    /// Returns an error indicating that no span exists for the given `id`.
+    pub fn no_span(id: SpanId) -> Self {
+        Self {
+            kind: RecordErrorKind::NoSpan(id),
+        }
+    }
+
+    /// Returns an error indicating that the span exists, but does not have the
+    /// specified field.
+    pub fn no_field() -> Self {
+        Self {
+            kind: RecordErrorKind::NoField,
+        }
+    }
+
+    /// Return an error indicating that the named field already has a value.
+    pub fn already_exists() -> Self {
+        Self {
+            kind: RecordErrorKind::AlreadyExists,
+        }
+    }
+
+    /// Returns an error indicating that an error occurred recording the field.
+    pub fn record() -> Self {
+        Self {
+            kind: RecordErrorKind::Record,
+        }
+    }
+
+    /// Returns `true` if this error was due to no span existing for the
+    /// specified field.
+    pub fn is_no_span(&self) -> bool {
+        match self.kind {
+            RecordErrorKind::NoSpan(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this error was due to no field existing with the
+    /// specified name.
+    pub fn is_no_field(&self) -> bool {
+        match self.kind {
+            RecordErrorKind::NoField => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this error was due to the named field already
+    /// existing.
+    pub fn is_already_exists(&self) -> bool {
+        match self.kind {
+            RecordErrorKind::AlreadyExists => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this error was due to an error occurring while
+    /// recording the field.
+    pub fn is_record(&self) -> bool {
+        match self.kind {
+            RecordErrorKind::Record => true,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for RecordError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            RecordErrorKind::NoSpan(ref id) => write!(f, "no span exists with id {:?}", id),
+            RecordErrorKind::NoField => f.pad("no such field exists"),
+            RecordErrorKind::AlreadyExists => f.pad("field already has a value"),
+            RecordErrorKind::Record => f.pad("an error occurred recording the field"),
+        }
+    }
+}
+
+impl Error for RecordError {}
 
 impl From<fmt::Error> for RecordError {
     fn from(_e: fmt::Error) -> Self {
-        RecordError::Record
+        RecordError::record()
     }
 }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -438,7 +438,6 @@ impl fmt::Display for FollowsError {
     }
 }
 
-
 #[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::*;
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -249,7 +249,7 @@ impl Subscriber for TraceLogger {
             span.record(key, val)?;
             Ok(())
         } else {
-            Err(subscriber::RecordError::NoSpan)
+            Err(subscriber::RecordError::no_span(span.clone()))
         }
     }
 

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -155,7 +155,9 @@ impl Subscriber for SloggishSubscriber {
         value: &dyn tokio_trace::field::Value,
     ) -> Result<(), subscriber::RecordError> {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
-        let span = spans.get_mut(span).ok_or(subscriber::RecordError::NoSpan)?;
+        let span = spans
+            .get_mut(span)
+            .ok_or_else(|| subscriber::RecordError::no_span(span.clone()))?;
         span.record(name, value)?;
         Ok(())
     }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -313,7 +313,7 @@ impl Shared {
         if let Some(ref inner) = self.inner {
             let field = field
                 .as_key(inner.metadata())
-                .ok_or(subscriber::RecordError::NoField)?;
+                .ok_or_else(subscriber::RecordError::no_field)?;
             inner.record(&field, value)
         } else {
             Ok(())
@@ -355,7 +355,9 @@ impl SpanExt for Span {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or(subscriber::RecordError::NoField)?;
+            let key = field
+                .as_key(meta)
+                .ok_or_else(subscriber::RecordError::no_field)?;
             self.record(&key, value)
         } else {
             Ok(())


### PR DESCRIPTION
This branch rewrites the `RecordError` and `FollowsError` types so that
the publicly-exposed type is a struct, rather than an enum. Consumers of
the API may still test what type of error occurred with a set of
`is_{error kind}` methods, but new error kinds may now be added without
causing a breaking change, as the struct cannot be matched against.

This is required for #73.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>