### PR TITLE
Rename `Dispatch::to` to `Dispatch::new`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -43,7 +43,7 @@ impl Dispatch {
     }
 
     /// Returns a `Dispatch` to the given [`Subscriber`](::Subscriber).
-    pub fn to<S>(subscriber: S) -> Self
+    pub fn new<S>(subscriber: S) -> Self
     // TODO: Add some kind of `UnsyncDispatch`?
     where
         S: Subscriber + Send + Sync + 'static,

--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -123,7 +123,7 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
     tokio_trace_env_logger::try_init().expect("init log adapter");
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let addr: ::std::net::SocketAddr = ([127, 0, 0, 1], 3000).into();
         span!("server", local = &Value::debug(addr)).enter(|| {
             let server = tokio::net::TcpListener::bind(&addr)

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -26,7 +26,7 @@ pub trait WithSubscriber: Sized {
     {
         WithDispatch {
             inner: self,
-            dispatch: Dispatch::to(subscriber),
+            dispatch: Dispatch::new(subscriber),
         }
     }
 }
@@ -156,7 +156,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
                 .wait()
@@ -191,7 +191,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             MyFuture { polls: 0 }
                 .instrument(span!("foo"))
                 .wait()
@@ -212,7 +212,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             stream::iter_ok::<_, ()>(&[1, 2, 3])
                 .instrument(span!("foo"))
                 .for_each(|_| future::ok(()))

--- a/tokio-trace-macros/examples/basic.rs
+++ b/tokio-trace-macros/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::new();
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let num: u64 = 1;
 
         let mut span = span!("Getting rec from another function.", number_of_recs = &num);

--- a/tokio-trace-subscriber/src/filter.rs
+++ b/tokio-trace-subscriber/src/filter.rs
@@ -84,7 +84,7 @@ pub trait FilterExt: Filter {
     ///     .with_registry(tokio_trace_subscriber::registry::increasing_counter())
     ///     .with_filter(name_filter.and(mod_filter));
     ///
-    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    /// tokio_trace::Dispatch::new(subscriber).as_default(|| {
     ///     foo();
     ///     my_module::foo();
     ///     my_module::bar();

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -70,7 +70,7 @@ pub trait ObserveExt: Observe {
     ///     .with_observer(observer)
     ///     .with_registry(registry::increasing_counter());
     ///
-    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    /// tokio_trace::Dispatch::new(subscriber).as_default(|| {
     ///     // This span will be seen by both `foo` and `bar`.
     ///     span!("my great span").enter(|| {
     ///         // ...
@@ -119,7 +119,7 @@ pub trait ObserveExt: Observe {
     ///     .with_observer(observer)
     ///     .with_registry(registry::increasing_counter());
     ///
-    /// tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    /// tokio_trace::Dispatch::new(subscriber).as_default(|| {
     ///     /// // This span will be logged.
     ///     span!("foo", enabled = &true) .enter(|| {
     ///         // do work;

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -107,7 +107,7 @@ impl tower_service::Service<()> for NewSvc {
 fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let mut rt = Runtime::new().unwrap();
         let reactor = rt.executor();
 

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -109,7 +109,7 @@ const N_SPANS: usize = 100;
 
 #[bench]
 fn span_no_fields(b: &mut Bencher) {
-    tokio_trace::Dispatch::to(EnabledSubscriber).as_default(|| b.iter(|| span!("span")));
+    tokio_trace::Dispatch::new(EnabledSubscriber).as_default(|| b.iter(|| span!("span")));
 }
 
 #[bench]
@@ -120,13 +120,13 @@ fn span_repeatedly(b: &mut Bencher) {
     }
 
     let n = test::black_box(N_SPANS);
-    tokio_trace::Dispatch::to(EnabledSubscriber)
+    tokio_trace::Dispatch::new(EnabledSubscriber)
         .as_default(|| b.iter(|| (0..n).fold(mk_span(0), |span, i| mk_span(i as u64))));
 }
 
 #[bench]
 fn span_with_fields(b: &mut Bencher) {
-    tokio_trace::Dispatch::to(EnabledSubscriber).as_default(|| {
+    tokio_trace::Dispatch::new(EnabledSubscriber).as_default(|| {
         b.iter(|| {
             span!(
                 "span",
@@ -142,7 +142,7 @@ fn span_with_fields(b: &mut Bencher) {
 // TODO: bring this back
 // #[bench]
 // fn span_with_fields_add_data(b: &mut Bencher) {
-//     tokio_trace::Dispatch::to(AddAttributes(Mutex::new(None))).as_default(|| {
+//     tokio_trace::Dispatch::new(AddAttributes(Mutex::new(None))).as_default(|| {
 //         b.iter(|| span!("span", foo = &"foo", bar = &"bar", baz = &3, quuux = &0.99))
 //     });
 // }

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -9,7 +9,7 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::new();
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let foo: u64 = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -150,7 +150,7 @@ impl Counters {
 fn main() {
     let (counters, subscriber) = Counters::new();
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let mut foo: u64 = 2;
         span!("my_great_span", foo_count = &foo).enter(|| {
             foo += 1;

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -21,7 +21,7 @@ use self::sloggish_subscriber::SloggishSubscriber;
 fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
-    tokio_trace::Dispatch::to(subscriber).as_default(|| {
+    tokio_trace::Dispatch::new(subscriber).as_default(|| {
         span!("", version = &field::Value::display(5.0)).enter(|| {
             span!("server", host = "localhost", port = 8080u64).enter(|| {
                 event!(Level::Info, {}, "starting");

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -18,12 +18,12 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .done()
             .run();
-        let mut foo = Dispatch::to(subscriber1).as_default(|| {
+        let mut foo = Dispatch::new(subscriber1).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
             foo
         });
-        Dispatch::to(subscriber::mock().done().run())
+        Dispatch::new(subscriber::mock().done().run())
             .as_default(move || foo.enter(|| span!("bar").enter(|| {})))
     }
 
@@ -48,13 +48,13 @@ mod tests {
             .done()
             .run();
 
-        let mut foo = Dispatch::to(subscriber1).as_default(|| {
+        let mut foo = Dispatch::new(subscriber1).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
             foo
         });
-        let mut baz = Dispatch::to(subscriber2).as_default(|| span!("baz"));
-        Dispatch::to(subscriber::mock().run()).as_default(move || {
+        let mut baz = Dispatch::new(subscriber2).as_default(|| span!("baz"));
+        Dispatch::new(subscriber::mock().run()).as_default(move || {
             foo.enter(|| span!("bar").enter(|| {}));
             baz.enter(|| span!("quux").enter(|| {}))
         })

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -398,7 +398,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .run();
 
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             span!("foo").enter(|| {
                 let mut bar = span!("bar",);
                 let another_bar = bar.enter(|| {
@@ -425,7 +425,7 @@ mod tests {
         // `Subscriber::enabled`, so that the spans will be constructed. We
         // won't enter any spans in this test, so the subscriber won't actually
         // expect to see any spans.
-        Dispatch::to(subscriber::mock().run()).as_default(|| {
+        Dispatch::new(subscriber::mock().run()).as_default(|| {
             span!("foo").enter(|| {
                 let foo1 = Span::current();
                 let foo2 = Span::current();
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn handles_to_different_spans_are_not_equal() {
-        Dispatch::to(subscriber::mock().run()).as_default(|| {
+        Dispatch::new(subscriber::mock().run()).as_default(|| {
             // Even though these spans have the same name and fields, they will have
             // differing metadata, since they were created on different lines.
             let foo1 = span!("foo", bar = 1u64, baz = false);
@@ -456,7 +456,7 @@ mod tests {
             span!("foo", bar = 1u64, baz = false)
         }
 
-        Dispatch::to(subscriber::mock().run()).as_default(|| {
+        Dispatch::new(subscriber::mock().run()).as_default(|| {
             let foo1 = make_span();
             let foo2 = make_span();
 
@@ -474,8 +474,8 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done();
-        let subscriber1 = Dispatch::to(subscriber1.run());
-        let subscriber2 = Dispatch::to(subscriber::mock().run());
+        let subscriber1 = Dispatch::new(subscriber1.run());
+        let subscriber2 = Dispatch::new(subscriber::mock().run());
 
         let mut foo = subscriber1.as_default(|| {
             let mut foo = span!("foo");
@@ -496,7 +496,7 @@ mod tests {
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done();
-        let subscriber1 = Dispatch::to(subscriber1.run());
+        let subscriber1 = Dispatch::new(subscriber1.run());
         let mut foo = subscriber1.as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
@@ -506,7 +506,7 @@ mod tests {
         // Even though we enter subscriber 2's context, the subscriber that
         // tagged the span should see the enter/exit.
         thread::spawn(move || {
-            Dispatch::to(subscriber::mock().run()).as_default(|| {
+            Dispatch::new(subscriber::mock().run()).as_default(|| {
                 foo.enter(|| {});
             })
         }).join()
@@ -521,7 +521,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
             span.enter(|| {});
             drop(span);
@@ -541,7 +541,7 @@ mod tests {
             .close(span::mock().named(Some("bar")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
 
@@ -562,7 +562,7 @@ mod tests {
             .close(span::mock().named(Some("foo")))
             .done()
             .run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
 
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn span_doesnt_close_if_it_never_opened() {
         let subscriber = subscriber::mock().done().run();
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             let span = span!("foo");
             drop(span);
         })
@@ -596,13 +596,13 @@ mod tests {
                 .close(span::mock().named(Some("foo")))
                 .done()
                 .run();
-            Dispatch::to(subscriber).as_default(|| span!("foo").into_shared().enter(|| {}))
+            Dispatch::new(subscriber).as_default(|| span!("foo").into_shared().enter(|| {}))
         }
 
         #[test]
         fn span_doesnt_close_if_it_never_opened() {
             let subscriber = subscriber::mock().done().run();
-            Dispatch::to(subscriber).as_default(|| {
+            Dispatch::new(subscriber).as_default(|| {
                 let span = span!("foo").into_shared();
                 drop(span);
             })
@@ -634,7 +634,7 @@ mod tests {
                 .done()
                 .run();
 
-            Dispatch::to(subscriber).as_default(|| {
+            Dispatch::new(subscriber).as_default(|| {
                 let barrier1 = Arc::new(Barrier::new(2));
                 let barrier2 = Arc::new(Barrier::new(2));
                 // Make copies of the barriers for thread 2 to wait on.
@@ -688,7 +688,7 @@ mod tests {
                 .done()
                 .run();
 
-            Dispatch::to(subscriber).as_default(|| {
+            Dispatch::new(subscriber).as_default(|| {
                 span!("foo").enter(|| {
                     let bar = span!("bar").into_shared();
                     bar.clone().enter(|| {

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -30,7 +30,7 @@ mod tests {
                 _ => false,
             }).run();
 
-        Dispatch::to(subscriber).as_default(move || {
+        Dispatch::new(subscriber).as_default(move || {
             // Enter "alice" and then "bob". The dispatcher expects to see "bob" but
             // not "alice."
             let mut alice = span!("alice");
@@ -94,7 +94,7 @@ mod tests {
                     _ => false,
                 }).run();
             // barrier1.wait();
-            let subscriber = Dispatch::to(subscriber);
+            let subscriber = Dispatch::new(subscriber);
             subscriber.as_default(do_test);
             barrier1.wait();
             subscriber.as_default(do_test)
@@ -116,7 +116,7 @@ mod tests {
                     Some("foo") => true,
                     _ => false,
                 }).run();
-            let subscriber = Dispatch::to(subscriber);
+            let subscriber = Dispatch::new(subscriber);
             subscriber.as_default(do_test);
             barrier.wait();
             subscriber.as_default(do_test)
@@ -158,7 +158,7 @@ mod tests {
                 }
             }).run();
 
-        Dispatch::to(subscriber).as_default(move || {
+        Dispatch::new(subscriber).as_default(move || {
             // Enter "charlie" and then "dave". The dispatcher expects to see "dave" but
             // not "charlie."
             let mut charlie = span!("charlie");
@@ -228,7 +228,7 @@ mod tests {
                 _ => false,
             }).run();
 
-        Dispatch::to(subscriber).as_default(|| {
+        Dispatch::new(subscriber).as_default(|| {
             // Call the function once. The filter should be re-evaluated.
             assert!(my_great_function());
             assert_eq!(count.load(Ordering::Relaxed), 1);


### PR DESCRIPTION
@carllerche suggested that this naming was unclear, so I've
renamed the constructor to follow the conventional naming
scheme.

This is in service of #72

Signed-off-by: Eliza Weisman <eliza@buoyant.io>