### PR TITLE
Add `clone_span` and `drop_span` hooks to `Subscriber`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -139,6 +139,16 @@ impl Subscriber for Dispatch {
     fn close(&self, span: span::Id) {
         self.subscriber.close(span)
     }
+
+    #[inline]
+    fn clone_span(&self, id: span::Id) -> span::Id {
+        self.subscriber.clone_span(id)
+    }
+
+    #[inline]
+    fn drop_span(&self, id: span::Id) {
+        self.subscriber.drop_span(id)
+    }
 }
 
 struct NoSubscriber;

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -494,8 +494,9 @@ impl Enter {
     }
 
     fn duplicate(&self) -> Self {
+        let id = self.subscriber.clone_span(self.id.clone());
         Self {
-            id: self.id.clone(),
+            id,
             subscriber: self.subscriber.clone(),
             parent: self.parent.clone(),
             wants_close: AtomicBool::from(self.wants_close()),
@@ -547,6 +548,7 @@ impl Hash for Enter {
 
 impl Drop for Enter {
     fn drop(&mut self) {
+        self.subscriber.drop_span(self.id.clone());
         // If this handle wants to be closed, try to close it --- either by
         // closing it now if it is idle, or telling the current span to close
         // when it exits, if it is the current span.

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -738,7 +738,6 @@ mod test_support {
                     "expected nothing else to happen, but exited span {:?}",
                     span.name(),
                 ),
-
             }
         }
 
@@ -768,7 +767,7 @@ mod test_support {
                         assert_eq!(name, span.name());
                     }
                     // TODO: expect fields
-                },
+                }
                 Some(Expect::CloneSpan(expected_span)) => panic!(
                     "expected to clone span {:?}, but closed span {:?} instead",
                     expected_span.name,
@@ -790,7 +789,14 @@ mod test_support {
             println!("clone_span: {:?}", id);
             let mut expected = self.expected.lock().unwrap();
             let was_expected = if let Some(Expect::CloneSpan(ref span)) = expected.front() {
-                assert_eq!(self.spans.lock().unwrap().get(&id).map(SpanAttributes::name), span.name);
+                assert_eq!(
+                    self.spans
+                        .lock()
+                        .unwrap()
+                        .get(&id)
+                        .map(SpanAttributes::name),
+                    span.name
+                );
                 true
             } else {
                 false
@@ -808,7 +814,14 @@ mod test_support {
                     // Don't assert if this function was called while panicking,
                     // as failing the assertion can cause a double panic.
                     if !::std::thread::panicking() {
-                        assert_eq!(self.spans.lock().unwrap().get(&id).map(SpanAttributes::name), span.name);
+                        assert_eq!(
+                            self.spans
+                                .lock()
+                                .unwrap()
+                                .get(&id)
+                                .map(SpanAttributes::name),
+                            span.name
+                        );
                     }
                     true
                 } else {

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -236,6 +236,11 @@ pub trait Subscriber {
     /// guaranteed that if this function has been called once more than the
     /// number of times `clone_span` was called with the same `id`, then no more
     /// `Span`s using that `id` exist.
+    ///
+    /// **Note**: since this function is called when spans are dropped,
+    /// implementations should ensure that they are unwind-safe. Panicking from
+    /// inside of a `drop_span` function may cause a double panic, if the span
+    /// was dropped due to a thread unwinding.
     fn drop_span(&self, id: span::Id) {
         let _ = id;
     }

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -210,6 +210,35 @@ pub trait Subscriber {
     /// [`Span`]: ::span::Span
     /// [`SpanId`]: ::span::Id
     fn close(&self, span: span::Id);
+
+    /// Notifies the subscriber that a [`Span`] handle with the given [`Id`] has
+    /// been cloned.
+    ///
+    /// This function is guaranteed to only be called with span IDs that were
+    /// returned by this subscriber's `new_span` function.
+    ///
+    /// Note that typically this is just the identity function, passing through
+    /// the identifier. For more unsafe situations, however, if `id` is itself a
+    /// pointer of some kind this can be used as a hook to "clone" the pointer,
+    /// depending on what that means for the specified pointer.
+    fn clone_span(&self, id: span::Id) -> span::Id {
+        id
+    }
+
+    /// Notifies the subscriber that a [`Span`] handle with the given [`Id`] has
+    /// been dropped.
+    ///
+    /// This function is guaranteed to only be called with span IDs that were
+    /// returned by this subscriber's `new_span` function.
+    ///
+    /// This function provides a hook for schemes which encode pointers in this
+    /// `id` argument to deallocate resources associated with the pointer. It's
+    /// guaranteed that if this function has been called once more than the
+    /// number of times `clone_span` was called with the same `id`, then no more
+    /// `Span`s using that `id` exist.
+    fn drop_span(&self, id: span::Id) {
+        let _ = id;
+    }
 }
 
 /// Indicates a `Subscriber`'s interest in a particular callsite.

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -136,4 +136,12 @@ where
             self.observer.close(span);
         });
     }
+
+    fn clone_span(&self, id: span::Id) -> span::Id {
+        self.registry.clone_span(id)
+    }
+
+    fn drop_span(&self, id: span::Id) {
+        self.registry.drop_span(id)
+    }
 }

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -75,7 +75,39 @@ pub trait RegisterSpan {
     where
         F: for<'a> Fn(&'a SpanRef<'a>);
 
-    // TODO: Should the registry also be informed of span closure?
+    /// Notifies the subscriber that a [`Span`] handle with the given [`Id`] has
+    /// been cloned.
+    ///
+    /// This function is guaranteed to only be called with span IDs that were
+    /// returned by this subscriber's `new_span` function.
+    ///
+    /// Note that typically this is just the identity function, passing through
+    /// the identifier. For more unsafe situations, however, if `id` is itself a
+    /// pointer of some kind this can be used as a hook to "clone" the pointer,
+    /// depending on what that means for the specified pointer.
+    fn clone_span(&self, id: span::Id) -> span::Id {
+        id
+    }
+
+    /// Notifies the subscriber that a [`Span`] handle with the given [`Id`] has
+    /// been dropped.
+    ///
+    /// This function is guaranteed to only be called with span IDs that were
+    /// returned by this subscriber's `new_span` function.
+    ///
+    /// This function provides a hook for schemes which encode pointers in this
+    /// `id` argument to deallocate resources associated with the pointer. It's
+    /// guaranteed that if this function has been called once more than the
+    /// number of times `clone_span` was called with the same `id`, then no more
+    /// `Span`s using that `id` exist.
+    ///
+    /// **Note**: since this function is called when spans are dropped,
+    /// implementations should ensure that they are unwind-safe. Panicking from
+    /// inside of a `drop_span` function may cause a double panic, if the span
+    /// was dropped due to a thread unwinding.
+    fn drop_span(&self, id: span::Id) {
+        let _ = id;
+    }
 }
 
 #[derive(Debug)]

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -419,6 +419,7 @@ mod tests {
         });
     }
 
+
     #[test]
     fn handles_to_the_same_span_are_equal() {
         // Create a mock subscriber that will return `true` on calls to
@@ -529,6 +530,79 @@ mod tests {
     }
 
     #[test]
+    fn dropping_a_span_calls_drop_span() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .drop_span(span::mock().named(Some("foo")))
+            .done()
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            let mut span = span!("foo");
+            span.enter(|| {});
+            drop(span);
+        })
+    }
+
+    #[test]
+    fn span_current_calls_clone_span() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .clone_span(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            let mut span = span!("foo");
+            let span2 = span.enter(|| { Span::current() });
+        })
+    }
+
+    #[test]
+    fn drop_span_when_exiting_dispatchers_context() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .clone_span(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .drop_span(span::mock().named(Some("foo")))
+            .drop_span(span::mock().named(Some("foo")))
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            let mut span = span!("foo");
+            let span2 = span.enter(|| { Span::current() });
+            drop(span);
+        })
+    }
+
+    #[test]
+    fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
+        let subscriber1 = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .clone_span(span::mock().named(Some("foo")))
+            .drop_span(span::mock().named(Some("foo")))
+            .drop_span(span::mock().named(Some("foo")))
+            .done();
+        let subscriber1 = Dispatch::new(subscriber1.run());
+        let subscriber2 = Dispatch::new(subscriber::mock().done().run());
+
+        let mut foo = subscriber1.as_default(|| {
+            let mut foo = span!("foo");
+            foo.enter(|| {});
+            foo
+        });
+        // Even though we enter subscriber 2's context, the subscriber that
+        // tagged the span should see the enter/exit.
+        subscriber2.as_default(move || {
+            let foo2 = foo.enter(|| { Span::current() });
+            drop(foo);
+            drop(foo2);
+        });
+    }
+
+    #[test]
     fn span_closes_when_idle() {
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
@@ -605,6 +679,23 @@ mod tests {
             Dispatch::new(subscriber).as_default(|| {
                 let span = span!("foo").into_shared();
                 drop(span);
+            })
+        }
+
+        #[test]
+        fn shared_only_calls_drop_span_when_the_last_handle_is_dropped() {
+            let subscriber = subscriber::mock()
+                .enter(span::mock().named(Some("foo")))
+                .exit(span::mock().named(Some("foo")))
+                .close(span::mock().named(Some("foo")))
+                .drop_span(span::mock().named(Some("foo"))).done().run();
+            Dispatch::new(subscriber).as_default(|| {
+                let span = span!("foo").into_shared();
+                let foo1 = span.clone();
+                let foo2 = span.clone();
+                drop(foo1);
+                drop(span);
+                foo2.enter(|| {})
             })
         }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -419,7 +419,6 @@ mod tests {
         });
     }
 
-
     #[test]
     fn handles_to_the_same_span_are_equal() {
         // Create a mock subscriber that will return `true` on calls to
@@ -554,7 +553,7 @@ mod tests {
             .run();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
-            let span2 = span.enter(|| { Span::current() });
+            let span2 = span.enter(|| Span::current());
         })
     }
 
@@ -569,7 +568,7 @@ mod tests {
             .run();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
-            let span2 = span.enter(|| { Span::current() });
+            let span2 = span.enter(|| Span::current());
             drop(span);
         })
     }
@@ -596,7 +595,7 @@ mod tests {
         // Even though we enter subscriber 2's context, the subscriber that
         // tagged the span should see the enter/exit.
         subscriber2.as_default(move || {
-            let foo2 = foo.enter(|| { Span::current() });
+            let foo2 = foo.enter(|| Span::current());
             drop(foo);
             drop(foo2);
         });
@@ -688,7 +687,9 @@ mod tests {
                 .enter(span::mock().named(Some("foo")))
                 .exit(span::mock().named(Some("foo")))
                 .close(span::mock().named(Some("foo")))
-                .drop_span(span::mock().named(Some("foo"))).done().run();
+                .drop_span(span::mock().named(Some("foo")))
+                .done()
+                .run();
             Dispatch::new(subscriber).as_default(|| {
                 let span = span!("foo").into_shared();
                 let foo1 = span.clone();


### PR DESCRIPTION
Closes #80

This branch adds new `clone_span` and `drop_span` methods to the `Subscriber`
trait, which are called when a span handle is cloned or dropped, respectively.
This allows the subscriber to track the number of span handles with a given ID,
so that a pointer (or an index into an arena) may be used as span IDs, and the
subscriber may deallocate the storage for a span when that span no longer
exists. 

Both of these methods have default implementations which do nothing, so that
subscriber implementations which don't need to track this information don't need
to implement them. However, they may be overridden by subscribers which do care
about span reference counts. This is similar to the `clone_id` and `drop_id` methods of
`futures::executor::Notify`.

This branch also allows the test support mock subscriber to expect calls to
these methods, and adds new unit tests for them.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

