### PR TITLE
Make event fields private and replace with accessors

### DIFF
--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -132,24 +132,24 @@ pub use self::{
 /// [`Span`]: ::span::Span
 pub struct Event<'a> {
     /// The span ID of the span in which this event occurred.
-    pub parent: Option<SpanId>,
+    parent: Option<SpanId>,
 
     /// The IDs of a set of spans which are causally linked with this event, but
     /// are not its direct parent.
-    pub follows_from: &'a [SpanId],
+    follows_from: &'a [SpanId],
 
     /// Metadata describing this event.
-    pub meta: &'a Meta<'a>,
+    meta: &'a Meta<'a>,
 
     /// The values of the fields on this event.
     ///
     /// The names of these fields are defined in the event's metadata. Each
     /// index in this array corresponds to the name at the same index in
     /// `self.meta.field_names`.
-    pub field_values: &'a [&'a dyn Value],
+    field_values: &'a [&'a dyn Value],
 
     /// A textual message describing the event that occurred.
-    pub message: fmt::Arguments<'a>,
+    message: fmt::Arguments<'a>,
 }
 
 /// Metadata describing a [`Span`] or [`Event`].
@@ -368,6 +368,24 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn has_field(&self, key: &field::Key) -> bool {
         self.meta.contains_key(key)
+    }
+
+    /// Returns a reference to the event's metadata.
+    #[inline]
+    pub fn metadata(&self) -> &Meta<'a> {
+        self.meta
+    }
+
+    /// Returns the ID of the event's parent span, if it has one.
+    #[inline]
+    pub fn parent(&self) -> Option<span::Id> {
+        self.parent.as_ref().cloned()
+    }
+
+    /// Returns the event's message.
+    #[inline]
+    pub fn message(&self) -> &fmt::Arguments<'a> {
+        &self.message
     }
 
     /// Borrows the value of the field named `name`, if it exists. Otherwise,

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -269,19 +269,20 @@ impl Subscriber for TraceLogger {
     }
 
     fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        let meta = event.meta.as_log();
+        let meta = event.metadata();
+        let log_meta = meta.as_log();
         let logger = log::logger();
-        if logger.enabled(&meta) {
+        if logger.enabled(&log_meta) {
             logger.log(
                 &log::Record::builder()
-                    .metadata(meta)
-                    .module_path(event.meta.module_path)
-                    .file(event.meta.file)
-                    .line(event.meta.line)
+                    .metadata(log_meta)
+                    .module_path(meta.module_path)
+                    .file(meta.file)
+                    .line(meta.line)
                     .args(format_args!(
                         "{}; in_span={:?}; {:?}",
-                        event.message,
-                        event.parent,
+                        event.message(),
+                        event.parent(),
                         LogFields(event),
                     )).build(),
             );

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -189,7 +189,7 @@ impl Subscriber for SloggishSubscriber {
         let stack = self.stack.lock().unwrap();
         if let Some(idx) = stack
             .iter()
-            .position(|id| event.parent.as_ref().map(|p| p == id).unwrap_or(false))
+            .position(|id| event.parent().as_ref().map(|p| p == id).unwrap_or(false))
         {
             self.print_indent(&mut stderr, idx + 1).unwrap();
         }
@@ -198,11 +198,11 @@ impl Subscriber for SloggishSubscriber {
             "{} ",
             humantime::format_rfc3339_seconds(SystemTime::now())
         ).unwrap();
-        self.print_meta(&mut stderr, event.meta).unwrap();
+        self.print_meta(&mut stderr, event.metadata()).unwrap();
         write!(
             &mut stderr,
             "{}",
-            Style::new().bold().paint(format!("{}", event.message))
+            Style::new().bold().paint(format!("{}", event.message()))
         ).unwrap();
         self.print_kvs(
             &mut stderr,


### PR DESCRIPTION
Since events no longer have to be constructed as struct initializers, we
can remove its fields from the public API.

This is in service of #73.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>