### PR TITLE
Add support for `follows_from` in the `event!` macro

### DIFF
--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -404,6 +404,12 @@ impl<'a> Event<'a> {
             Some((key, val))
         })
     }
+
+    /// Returns a slice containing the IDs of the spans that this event follows
+    /// from.
+    pub fn follows(&self) -> &[SpanId] {
+        self.follows_from
+    }
 }
 
 impl<'a> IntoIterator for &'a Event<'a> {

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -123,7 +123,7 @@ macro_rules! span {
 
 #[macro_export]
 macro_rules! event {
-    (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
+    (target: $target:expr, $lvl:expr, follows: [ $( $follows:expr),* ], { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
         {
             use $crate::{callsite, SpanAttributes, SpanId, Subscriber, Event, field::Value};
             use $crate::callsite::Callsite;
@@ -133,17 +133,24 @@ macro_rules! event {
                 $target, $( $k ),*
             };
             let field_values: &[ &dyn Value ] = &[ $( &$val ),* ];
+            let follows_from: &[SpanId] = &[ $( $follows ),* ];
             Event::observe(
                 callsite,
                 &field_values[..],
-                &[],
+                &follows_from[..],
                 format_args!( $($arg)+ ),
             );
         }
     });
+    (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $lvl, follows: [],  { $($k = $val),* }, $($arg)+)
+    );
     ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $lvl, { $($k = $val),* }, $($arg)+)
-    )
+    );
+    ($lvl:expr, follows: [ $( $follows:expr),* ], { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
+        event!(target: module_path!(), $lvl, follows: [ $( $follows ),* ], { $($k = $val),* }, $($arg)+)
+    );
 }
 
 mod dispatcher;


### PR DESCRIPTION
Closes #98 

This branch allows the `event!` macro to actually construct and pass in
a slice of IDs that a span follows from. It also adds a function on
`Event` returning the IDs of the spans that the event follows from.

The syntax in the macro isn't _great_ --- it's a little verbose.
Possibly this will need another pass prior to stabilizing the macros

Signed-off-by: Eliza Weisman <eliza@buoyant.io>