### PR TITLE
Add Span::enter_final convenience function

### DIFF
--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -528,6 +528,22 @@ mod tests {
         })
     }
 
+     #[test]
+    fn enter_final_closes_span() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .drop_span(span::mock().named(Some("foo")))
+            .done()
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            let mut span = span!("foo");
+            span.enter(|| {});
+            drop(span);
+        })
+    }
+
     #[test]
     fn dropping_a_span_calls_drop_span() {
         let subscriber = subscriber::mock()

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -528,7 +528,7 @@ mod tests {
         })
     }
 
-     #[test]
+    #[test]
     fn enter_final_closes_span() {
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))


### PR DESCRIPTION
This branch adds an `enter_final` function to `Span`s, which functions
equivalently to 
```rust
    span.enter(|| {
        // ...
        Span::current().close();
        // ...
    });
```
but without the overhead of getting the current span.

I've also added a test for this function.

I'm not 100% sure if this is necessary, but I thought it might
potentially be useful, especially given that it lets us avoid a
thread-local access inside the span.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>