### PR TITLE
Make `Event`s more similar to `Span`s

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -1,8 +1,8 @@
 use {
     callsite, field,
     span::{self, Span},
-    subscriber::{self, Subscriber, RecordError},
-    Meta, Id,
+    subscriber::{self, RecordError, Subscriber},
+    Id, Meta,
 };
 
 use std::{
@@ -102,42 +102,22 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record_i64(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: i64,
-    ) -> Result<(), RecordError> {
+    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) -> Result<(), RecordError> {
         self.subscriber.record_i64(span, field, value)
     }
 
     #[inline]
-    fn record_u64(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: u64,
-    ) -> Result<(), RecordError> {
+    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) -> Result<(), RecordError> {
         self.subscriber.record_u64(span, field, value)
     }
 
     #[inline]
-    fn record_bool(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: bool,
-    ) -> Result<(), RecordError> {
+    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) -> Result<(), RecordError> {
         self.subscriber.record_bool(span, field, value)
     }
 
     #[inline]
-    fn record_str(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: &str,
-    ) -> Result<(), RecordError> {
+    fn record_str(&self, span: &Id, field: &field::Key, value: &str) -> Result<(), RecordError> {
         self.subscriber.record_str(span, field, value)
     }
 
@@ -152,11 +132,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn add_follows_from(
-        &self,
-        span: &Id,
-        follows: Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
         self.subscriber.add_follows_from(span, follows)
     }
 
@@ -206,11 +182,7 @@ impl Subscriber for NoSubscriber {
         Ok(())
     }
 
-    fn add_follows_from(
-        &self,
-        _span: &Id,
-        _follows: Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
         Ok(())
     }
 

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -2,7 +2,7 @@ use {
     callsite, field,
     span::{self, Span},
     subscriber::{self, Subscriber, RecordError},
-    Event, Meta,
+    Event, Meta, Id,
 };
 
 use std::{
@@ -92,19 +92,19 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn new_span(&self, span: span::SpanAttributes) -> span::Id {
+    fn new_span(&self, span: span::SpanAttributes) -> Id {
         self.subscriber.new_span(span)
     }
 
     #[inline]
-    fn new_id(&self, span: span::Attributes) -> span::Id {
+    fn new_id(&self, span: span::Attributes) -> Id {
         self.subscriber.new_id(span)
     }
 
     #[inline]
     fn record_i64(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: i64,
     ) -> Result<(), RecordError> {
@@ -114,7 +114,7 @@ impl Subscriber for Dispatch {
     #[inline]
     fn record_u64(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: u64,
     ) -> Result<(), RecordError> {
@@ -124,7 +124,7 @@ impl Subscriber for Dispatch {
     #[inline]
     fn record_bool(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: bool,
     ) -> Result<(), RecordError> {
@@ -134,7 +134,7 @@ impl Subscriber for Dispatch {
     #[inline]
     fn record_str(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: &str,
     ) -> Result<(), RecordError> {
@@ -144,7 +144,7 @@ impl Subscriber for Dispatch {
     #[inline]
     fn record_fmt(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: fmt::Arguments,
     ) -> Result<(), RecordError> {
@@ -154,8 +154,8 @@ impl Subscriber for Dispatch {
     #[inline]
     fn add_follows_from(
         &self,
-        span: &span::Id,
-        follows: span::Id,
+        span: &Id,
+        follows: Id,
     ) -> Result<(), subscriber::FollowsError> {
         self.subscriber.add_follows_from(span, follows)
     }
@@ -166,40 +166,40 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn enter(&self, span: span::Id) {
+    fn enter(&self, span: Id) {
         self.subscriber.enter(span)
     }
 
     #[inline]
-    fn exit(&self, span: span::Id) {
+    fn exit(&self, span: Id) {
         self.subscriber.exit(span)
     }
 
     #[inline]
-    fn close(&self, span: span::Id) {
+    fn close(&self, span: Id) {
         self.subscriber.close(span)
     }
 
     #[inline]
-    fn clone_span(&self, id: span::Id) -> span::Id {
+    fn clone_span(&self, id: Id) -> Id {
         self.subscriber.clone_span(id)
     }
 
     #[inline]
-    fn drop_span(&self, id: span::Id) {
+    fn drop_span(&self, id: Id) {
         self.subscriber.drop_span(id)
     }
 }
 
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
-    fn new_id(&self, _span: span::Attributes) -> span::Id {
-        span::Id::from_u64(0)
+    fn new_id(&self, _span: span::Attributes) -> Id {
+        Id::from_u64(0)
     }
 
     fn record_fmt(
         &self,
-        _span: &span::Id,
+        _span: &Id,
         _key: &field::Key,
         _value: fmt::Arguments,
     ) -> Result<(), ::subscriber::RecordError> {
@@ -208,8 +208,8 @@ impl Subscriber for NoSubscriber {
 
     fn add_follows_from(
         &self,
-        _span: &span::Id,
-        _follows: span::Id,
+        _span: &Id,
+        _follows: Id,
     ) -> Result<(), subscriber::FollowsError> {
         Ok(())
     }
@@ -218,11 +218,11 @@ impl Subscriber for NoSubscriber {
         false
     }
 
-    fn enter(&self, _span: span::Id) {}
+    fn enter(&self, _span: Id) {}
 
-    fn exit(&self, _span: span::Id) {}
+    fn exit(&self, _span: Id) {}
 
-    fn close(&self, _span: span::Id) {}
+    fn close(&self, _span: Id) {}
 }
 
 impl Registrar {

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -2,7 +2,7 @@ use {
     callsite, field,
     span::{self, Span},
     subscriber::{self, Subscriber, RecordError},
-    Event, Meta, Id,
+    Meta, Id,
 };
 
 use std::{

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -1,7 +1,7 @@
 use {
     callsite, field,
     span::{self, Span},
-    subscriber::{self, Subscriber},
+    subscriber::{self, Subscriber, RecordError},
     Event, Meta,
 };
 
@@ -92,8 +92,13 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn new_span(&self, span: span::Attributes) -> span::Id {
+    fn new_span(&self, span: span::SpanAttributes) -> span::Id {
         self.subscriber.new_span(span)
+    }
+
+    #[inline]
+    fn new_event(&self, span: span::Attributes) -> span::Id {
+        self.subscriber.new_event(span)
     }
 
     #[inline]
@@ -161,11 +166,6 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        self.subscriber.observe_event(event)
-    }
-
-    #[inline]
     fn enter(&self, span: span::Id) {
         self.subscriber.enter(span)
     }
@@ -193,7 +193,7 @@ impl Subscriber for Dispatch {
 
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
-    fn new_span(&self, _span: span::Attributes) -> span::Id {
+    fn new_event(&self, _span: span::Attributes) -> span::Id {
         span::Id::from_u64(0)
     }
 
@@ -216,10 +216,6 @@ impl Subscriber for NoSubscriber {
 
     fn enabled(&self, _metadata: &Meta) -> bool {
         false
-    }
-
-    fn observe_event<'a>(&self, _event: &'a Event<'a>) {
-        // Do nothing.
     }
 
     fn enter(&self, _span: span::Id) {}

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -97,13 +97,53 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record(
+    fn record_i64(
         &self,
         span: &span::Id,
-        key: &field::Key,
-        value: &dyn field::Value,
-    ) -> Result<(), ::subscriber::RecordError> {
-        self.subscriber.record(span, key, value)
+        field: &field::Key,
+        value: i64,
+    ) -> Result<(), RecordError> {
+        self.subscriber.record_i64(span, field, value)
+    }
+
+    #[inline]
+    fn record_u64(
+        &self,
+        span: &span::Id,
+        field: &field::Key,
+        value: u64,
+    ) -> Result<(), RecordError> {
+        self.subscriber.record_u64(span, field, value)
+    }
+
+    #[inline]
+    fn record_bool(
+        &self,
+        span: &span::Id,
+        field: &field::Key,
+        value: bool,
+    ) -> Result<(), RecordError> {
+        self.subscriber.record_bool(span, field, value)
+    }
+
+    #[inline]
+    fn record_str(
+        &self,
+        span: &span::Id,
+        field: &field::Key,
+        value: &str,
+    ) -> Result<(), RecordError> {
+        self.subscriber.record_str(span, field, value)
+    }
+
+    #[inline]
+    fn record_fmt(
+        &self,
+        span: &span::Id,
+        field: &field::Key,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError> {
+        self.subscriber.record_fmt(span, field, value)
     }
 
     #[inline]
@@ -157,11 +197,11 @@ impl Subscriber for NoSubscriber {
         span::Id::from_u64(0)
     }
 
-    fn record(
+    fn record_fmt(
         &self,
         _span: &span::Id,
         _key: &field::Key,
-        _value: &dyn field::Value,
+        _value: fmt::Arguments,
     ) -> Result<(), ::subscriber::RecordError> {
         Ok(())
     }

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -97,8 +97,8 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn new_event(&self, span: span::Attributes) -> span::Id {
-        self.subscriber.new_event(span)
+    fn new_id(&self, span: span::Attributes) -> span::Id {
+        self.subscriber.new_id(span)
     }
 
     #[inline]
@@ -193,7 +193,7 @@ impl Subscriber for Dispatch {
 
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
-    fn new_event(&self, _span: span::Attributes) -> span::Id {
+    fn new_id(&self, _span: span::Attributes) -> span::Id {
         span::Id::from_u64(0)
     }
 

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -26,7 +26,7 @@
 //! their field names, rather than printing them.
 //
 use std::fmt;
-use {Id, Subscriber, Meta};
+use {Id, Meta, Subscriber};
 
 /// A field value of an erased type.
 ///

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -1,7 +1,8 @@
 //! `Span` and `Event` key-value data.
 //!
 //! Spans and events may be annotated with key-value data, referred to as known
-//! as _fields_. These fields consist of a mapping
+//! as _fields_. These fields consist of a mapping from a key (corresponding to
+//! a `&str` but represented internally as an array index) to a `Value`.
 //!
 //! # `Value`s and `Subscriber`s
 //!

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -26,7 +26,7 @@
 //! their field names, rather than printing them.
 //
 use std::fmt;
-use {span::Id, Subscriber, Meta};
+use {Id, Subscriber, Meta};
 
 /// A field value of an erased type.
 ///

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -116,7 +116,6 @@ pub use self::{
     subscriber::{Interest, Subscriber},
 };
 
-
 /// Metadata describing a [`Span`] or [`Event`].
 ///
 /// This includes the source code location where the span or event occurred, the
@@ -282,7 +281,6 @@ impl<'a> PartialEq for Meta<'a> {
         ::std::ptr::eq(self, other)
     }
 }
-
 
 // ===== impl Level =====
 

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -112,45 +112,10 @@ pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
     field::{Key, Value},
-    span::{Attributes as SpanAttributes, Id as SpanId, Span},
+    span::{Attributes, Event, Id as SpanId, Span, SpanAttributes},
     subscriber::{Interest, Subscriber},
 };
 
-/// `Event`s represent single points in time where something occurred during the
-/// execution of a program.
-///
-/// An event can be compared to a log record in unstructured logging, but with
-/// two key differences:
-/// - Events exist _within the context of a [`Span`]_. Unlike log lines, they may
-///   be located within the trace tree, allowing visibility into the context in
-///   which the event occurred.
-/// - Events have structured key-value data known as _fields_, as well as a
-///   textual message. In general, a majority of the data associated with an
-///   event should be in the event's fields rather than in the textual message,
-///   as the fields are more structed.
-///
-/// [`Span`]: ::span::Span
-pub struct Event<'a> {
-    /// The span ID of the span in which this event occurred.
-    parent: Option<SpanId>,
-
-    /// The IDs of a set of spans which are causally linked with this event, but
-    /// are not its direct parent.
-    follows_from: &'a [SpanId],
-
-    /// Metadata describing this event.
-    meta: &'a Meta<'a>,
-
-    /// The values of the fields on this event.
-    ///
-    /// The names of these fields are defined in the event's metadata. Each
-    /// index in this array corresponds to the name at the same index in
-    /// `self.meta.field_names`.
-    field_values: &'a [&'a dyn Value],
-
-    /// A textual message describing the event that occurred.
-    message: fmt::Arguments<'a>,
-}
 
 /// Metadata describing a [`Span`] or [`Event`].
 ///
@@ -320,105 +285,6 @@ impl<'a> PartialEq for Meta<'a> {
     }
 }
 
-// ===== impl Event =====
-
-impl<'a> Event<'a> {
-    /// Notifies the currently active [`Subscriber`] of an `Event` at the given
-    /// [`Callsite`].
-    ///
-    /// If the given callsite is enabled, a  new `Event` will be constructed
-    /// with the provided `field_values` and `message`, following from the
-    /// provided span IDs. The subscriber will then observe that event.
-    ///
-    /// If the callsite is not enabled, this function does nothing.
-    ///
-    /// [`Subscriber`]: ::subscriber::Subscriber
-    /// [`Callsite`]: ::callsite::Callsite
-    pub fn observe(
-        callsite: &'a dyn callsite::Callsite,
-        field_values: &[&dyn field::Value],
-        follows_from: &[SpanId],
-        message: fmt::Arguments<'a>,
-    ) {
-        let interest = callsite.interest();
-        if interest == Interest::NEVER {
-            return;
-        }
-        Dispatch::with_current(|dispatch| {
-            let meta = callsite.metadata();
-            if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
-                return;
-            }
-            dispatch.observe_event(&Event {
-                parent: SpanId::current(),
-                follows_from,
-                meta,
-                field_values,
-                message,
-            });
-        })
-    }
-
-    /// Returns an iterator over the names of all the fields on this `Event`.
-    pub fn field_names(&self) -> slice::Iter<&'a str> {
-        self.meta.field_names.iter()
-    }
-
-    /// Returns true if this event has a field for the specified `key`.
-    #[inline]
-    pub fn has_field(&self, key: &field::Key) -> bool {
-        self.meta.contains_key(key)
-    }
-
-    /// Returns a reference to the event's metadata.
-    #[inline]
-    pub fn metadata(&self) -> &Meta<'a> {
-        self.meta
-    }
-
-    /// Returns the ID of the event's parent span, if it has one.
-    #[inline]
-    pub fn parent(&self) -> Option<span::Id> {
-        self.parent.as_ref().cloned()
-    }
-
-    /// Returns the event's message.
-    #[inline]
-    pub fn message(&self) -> &fmt::Arguments<'a> {
-        &self.message
-    }
-
-    /// Borrows the value of the field named `name`, if it exists. Otherwise,
-    /// returns `None`.
-    pub fn field(&self, key: &field::Key) -> Option<&dyn Value> {
-        if !self.has_field(key) {
-            return None;
-        }
-        self.field_values.get(key.as_usize()).map(|&v| v)
-    }
-
-    /// Returns an iterator over all the field names and values on this event.
-    pub fn fields<'b: 'a>(&'b self) -> impl Iterator<Item = (field::Key<'a>, &'a dyn Value)> {
-        self.meta.fields().filter_map(move |key| {
-            let val = self.field(&key)?;
-            Some((key, val))
-        })
-    }
-
-    /// Returns a slice containing the IDs of the spans that this event follows
-    /// from.
-    pub fn follows(&self) -> &[SpanId] {
-        self.follows_from
-    }
-}
-
-impl<'a> IntoIterator for &'a Event<'a> {
-    type Item = (field::Key<'a>, &'a dyn Value);
-    type IntoIter = Box<Iterator<Item = (field::Key<'a>, &'a dyn Value)> + 'a>; // TODO: unbox
-    fn into_iter(self) -> Self::IntoIter {
-        Box::new(self.fields())
-    }
-}
 
 // ===== impl Level =====
 

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -29,9 +29,9 @@
 //! An [`Event`] represents a _point_ in time. It signifies something that
 //! happened while the trace was executing. `Event`s are comparable to the log
 //! records emitted by unstructured logging code, but unlike a typical log line,
-//! an `Event` always occurs within the context of a `Span`. Like a `Span`, it
+//! an `Event` may occur within the context of a `Span`. Like a `Span`, it
 //! may have fields, and implicitly inherits any of the fields present on its
-//! parent span. Additionally, it may be linked with one or more additional
+//! parent span, and it may be linked with one or more additional
 //! spans that are not its parent; in this case, the event is said to _follow
 //! from_ those spans.
 //!
@@ -42,6 +42,10 @@
 //! within the context of the tree of spans that comprise a trase. Thus,
 //! individual log record-like events can be pinpointed not only in time, but
 //! in the logical execution flow of the system.
+//!
+//! Events are represented as a special case of spans --- they are created, they
+//! may have fields added, and then they close immediately, without being
+//! entered.
 //!
 //! # `Subscriber`s
 //!

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -224,7 +224,7 @@ impl<'a> Meta<'a> {
 
     /// Construct new metadata for an event, with a target, level, field names,
     /// and optional source code location.
-    pub fn new_event(
+    pub fn new_id(
         target: &'a str,
         level: Level,
         module_path: Option<&'a str>,

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -74,7 +74,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-use std::{borrow::Borrow, fmt, slice};
+use std::borrow::Borrow;
 
 /// Describes the level of verbosity of a `Span` or `Event`.
 #[repr(usize)]
@@ -193,8 +193,6 @@ enum KindInner {
     Span,
     Event,
 }
-
-type StaticMeta = Meta<'static>;
 
 // ===== impl Meta =====
 

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -112,7 +112,7 @@ pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
     field::{Key, Value},
-    span::{Attributes, Event, Id as SpanId, Span, SpanAttributes},
+    span::{Attributes, Event, Id, Span, SpanAttributes},
     subscriber::{Interest, Subscriber},
 };
 

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -13,6 +13,9 @@ use {
     Dispatch, Meta, StaticMeta,
 };
 
+pub type SpanAttributes = Attributes<'static>;
+pub type Enter = Inner<'static>;
+
 thread_local! {
     // TODO: can this be a `Cell`?
     static CURRENT_SPAN: RefCell<Option<Enter>> = RefCell::new(None);
@@ -39,16 +42,38 @@ pub struct Span {
     is_closed: bool,
 }
 
+/// `Event`s represent single points in time where something occurred during the
+/// execution of a program.
+///
+/// An event can be compared to a log record in unstructured logging, but with
+/// two key differences:
+/// - Events exist _within the context of a [`Span`]_. Unlike log lines, they may
+///   be located within the trace tree, allowing visibility into the context in
+///   which the event occurred.
+/// - Events have structured key-value data known as _fields_, as well as a
+///   textual message. In general, a majority of the data associated with an
+///   event should be in the event's fields rather than in the textual message,
+///   as the fields are more structed.
+///
+/// [`Span`]: ::span::Span
+#[derive(PartialEq, Hash)]
+pub struct Event<'a> {
+    /// A handle used to enter the span when it is not executing.
+    ///
+    /// If this is `None`, then the span has either closed or was never enabled.
+    inner: Option<Inner<'a>>,
+}
+
 /// A set of attributes describing a new `Span`.
 ///
 /// This may *not* be used to enter the span.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Attributes {
+pub struct Attributes<'a> {
     /// The span ID of the parent span, or `None` if that span does not exist.
     parent: Option<Id>,
 
     /// Metadata describing this span.
-    metadata: &'static Meta<'static>,
+    metadata: &'a Meta<'a>,
 }
 
 /// Identifies a span within the context of a process.
@@ -69,7 +94,7 @@ pub struct Id(u64);
 /// enabled by the current filter. This type is primarily used for implementing
 /// span handles; users should typically not need to interact with it directly.
 #[derive(Debug)]
-pub struct Enter {
+pub struct Inner<'a> {
     /// The span's ID, as provided by `subscriber`.
     id: Id,
 
@@ -98,7 +123,7 @@ pub struct Enter {
     /// dropped if this is the current span.
     handles: AtomicUsize,
 
-    meta: &'static StaticMeta,
+    meta: &'a Meta<'a>,
 }
 
 /// A guard representing a span which has been entered and is currently
@@ -156,7 +181,7 @@ impl Span {
             let parent = Id::current();
             let attrs = Attributes::new(parent.clone(), meta);
             let id = dispatch.new_span(attrs);
-            let inner = Some(Enter::new(id, dispatch, parent, meta));
+            let inner = Some(Enter::new(id, parent, dispatch, meta));
             let mut span = Self {
                 inner,
                 is_closed: false,
@@ -299,16 +324,139 @@ impl fmt::Debug for Span {
     }
 }
 
-// ===== impl Attributes =====
-
-impl Attributes {
-    fn new(parent: Option<Id>, metadata: &'static StaticMeta) -> Self {
-        Attributes { parent, metadata }
+// ===== impl Event =====
+impl<'a> Event<'a> {
+    /// Constructs a new `Span` originating from the given [`Callsite`].
+    ///
+    /// The new span will be constructed by the currently-active [`Subscriber`],
+    /// with the [current span] as its parent (if one exists).
+    ///
+    /// If the new span is enabled, then the provided function `if_enabled` is
+    /// envoked on it before it is returned. This allows [field values] and/or
+    /// [`follows_from` annotations] to be added to the span, but skips this
+    /// work for spans which are disabled.
+    ///
+    /// [`Callsite`]: ::callsite::Callsite
+    /// [`Subscriber`]: ::subscriber::Subscriber
+    /// [current span]: ::span::Span::current
+    /// [field values]: ::span::Span::record
+    /// [`follows_from` annotations]: ::span::Span::follows_from
+    #[inline]
+    pub fn new<F>(callsite: &'a dyn Callsite, if_enabled: F) -> Self
+    where
+        F: FnOnce(&mut Self),
+    {
+        let interest = callsite.interest();
+        if interest == Interest::NEVER {
+            return Self { inner: None };
+        }
+        Dispatch::with_current(|dispatch| {
+            let meta = callsite.metadata();
+            if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
+                return Self { inner: None };
+            }
+            let parent = Id::current();
+            let attrs = Attributes::new(parent.clone(), meta);
+            let id = dispatch.new_event(attrs);
+            let inner = Enter::new(id, parent, dispatch, meta);
+            inner.has_entered.store(true, Ordering::Relaxed);
+            inner.close();
+            let mut event = Self { inner: Some(inner) };
+            if_enabled(&mut event);
+            event
+        })
     }
 
-    /// Returns the name of this span, or `None` if it is unnamed,
+    pub fn message(
+        &mut self,
+        key: &field::Key,
+        message: fmt::Arguments,
+    ) -> Result<(), ::subscriber::RecordError> {
+        if let Some(ref mut inner) = self.inner {
+            inner.subscriber.record_fmt(&inner.id, key, message)?;
+        }
+        Ok(())
+    }
+
+    /// Returns the `Id` of the parent of this span, if one exists.
+    pub fn parent(&self) -> Option<Id> {
+        self.inner.as_ref().and_then(Enter::parent)
+    }
+
+    /// Returns a [`Key`](::field::Key) for the field with the given `name`, if
+    /// one exists,
+    pub fn key_for<Q>(&self, name: &Q) -> Option<Key<'a>>
+    where
+        Q: Borrow<str>,
+    {
+        self.inner
+            .as_ref()
+            .and_then(|inner| inner.meta.key_for(name))
+    }
+
+    /// Sets the field on this span named `name` to the given `value`.
+    ///
+    /// `name` must name a field already defined by this span's metadata, and
+    /// the field must not already have a value. If this is not the case, this
+    /// function returns an [`RecordError`](::subscriber::RecordError).
+    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Returns `true` if this span was disabled by the subscriber and does not
+    /// exist.
+    pub fn is_disabled(&self) -> bool {
+        self.inner.is_none()
+    }
+
+    /// Indicates that the span with the given ID has an indirect causal
+    /// relationship with this span.
+    ///
+    /// This relationship differs somewhat from the parent-child relationship: a
+    /// span may have any number of prior spans, rather than a single one; and
+    /// spans are not considered to be executing _inside_ of the spans they
+    /// follow from. This means that a span may close even if subsequent spans
+    /// that follow from it are still open, and time spent inside of a
+    /// subsequent span should not be included in the time its precedents were
+    /// executing. This is used to model causal relationships such as when a
+    /// single future spawns several related background tasks, et cetera.
+    ///
+    /// If this span is disabled, this function will do nothing. Otherwise, it
+    /// returns `Ok(())` if the other span was added as a precedent of this
+    /// span, or an error if this was not possible.
+    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
+        self.inner
+            .as_ref()
+            .map(move |inner| inner.follows_from(from))
+            .unwrap_or(Ok(()))
+    }
+
+    /// Returns this span's `Id`, if it is enabled.
+    pub fn id(&self) -> Option<Id> {
+        self.inner.as_ref().map(Enter::id)
+    }
+
+    /// Returns this span's `Meta`, if it is enabled.
+    pub fn metadata(&self) -> Option<&'a Meta<'a>> {
+        self.inner.as_ref().map(|inner| inner.metadata())
+    }
+}
+
+// ===== impl Attributes =====
+
+impl SpanAttributes {
+    /// Returns the name of this span, or `None` if it is unnamed.
     pub fn name(&self) -> Option<&'static str> {
         self.metadata.name
+    }
+}
+
+impl<'a> Attributes<'a> {
+    fn new(parent: Option<Id>, metadata: &'a Meta<'a>) -> Self {
+        Attributes { parent, metadata }
     }
 
     /// Returns the `Id` of the parent of this span, if one exists.
@@ -317,18 +465,18 @@ impl Attributes {
     }
 
     /// Borrows this span's metadata.
-    pub fn metadata(&self) -> &'static StaticMeta {
+    pub fn metadata(&self) -> &'a Meta<'a> {
         self.metadata
     }
 
     /// Returns an iterator over the names of all the fields on this span.
-    pub fn field_keys(&self) -> impl Iterator<Item = Key<'static>> {
+    pub fn field_keys(&self) -> impl Iterator<Item = Key<'a>> {
         self.metadata.fields()
     }
 
     /// Returns a [`Key`](::field::Key) for the field with the given `name`, if
     /// one exists,
-    pub fn key_for<Q>(&self, name: &Q) -> Option<Key<'static>>
+    pub fn key_for<Q>(&self, name: &Q) -> Option<Key<'a>>
     where
         Q: Borrow<str>,
     {
@@ -359,83 +507,11 @@ impl Id {
 
 // ===== impl Enter =====
 
-impl Enter {
-    /// Consumes `span` and returns the inner entering handle, if the span is
-    /// enabled.
-    ///
-    /// The returned `Enter` has approximately the same behaviour to a `Span`.
-    /// However, it is primarily intended for use in libraries custom span
-    /// types; the `Span` handle will typically represent a more ergonomic API
-    /// for actually _using_ spans.
-    pub fn from_span(span: Span) -> Option<Self> {
-        span.inner
-    }
-
-    /// Enters the span, returning a guard that may be used to exit the span and
-    /// re-enter the prior span.
-    ///
-    /// This is used internally to implement `Span::enter`. It may be used for
-    /// writing custom span handles, but should generally not be called directly
-    /// when entering a span.
-    pub fn enter(&self) -> Entered {
-        // The current handle will no longer enter the span, since it has just
-        // been used to enter. Therefore, it will be safe to close the span if
-        // no additional handles exist when the span is exited.
-        self.handles.fetch_sub(1, Ordering::Release);
-        // The span has now been entered, so it's okay to close it.
-        self.has_entered.store(true, Ordering::Release);
-        self.subscriber.enter(self.id());
-        let prior = CURRENT_SPAN.with(|current_span| current_span.replace(Some(self.duplicate())));
-        self.wants_close.store(false, Ordering::Release);
-        Entered { prior }
-    }
-
+impl<'a> Inner<'a> {
     /// Indicates the span _should_ be closed the next time it exits or this
     /// handle is dropped.
     pub fn close(&self) {
         self.wants_close.store(true, Ordering::Release);
-    }
-
-    /// Exits the span entry represented by an `Entered` guard, consuming it,
-    /// and updates `self` to canonically represent the referenced span's state
-    /// after the other entry has exited.
-    ///
-    /// If the other handle to the span wanted to close the span on exit, it
-    /// will not do so. Instead, the responsibility for performing the `close`
-    /// will be transferred to `self` --- if `self` did not previously want to
-    /// close, but `other` did, `self` will now want to close.
-    ///
-    /// This means that dropping `other` will no longer close the span, even if
-    /// it previously would have.
-    ///
-    /// This function is intended to be used by span handle implementations to
-    /// ensuring that multiple entering handles are kept consistent. Probably
-    /// don't use this unless you know what you're doing.
-    pub fn exit_and_join(&self, other: Entered) {
-        if let Some(other) = other.exit() {
-            self.handles.store(other.handle_count(), Ordering::Release);
-            self.has_entered
-                .store(other.has_entered(), Ordering::Release);
-            self.wants_close
-                .store(other.take_close(), Ordering::Release);
-        }
-    }
-
-    /// Sets the field on this span named `name` to the given `value`.
-    ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
-        }
-
-        match self.subscriber.record(&self.id, field, value) {
-            Ok(()) => Ok(()),
-            Err(ref e) if e.is_no_span() => panic!("span should still exist!"),
-            Err(e) => Err(e),
-        }
     }
 
     /// Indicates that the span with the given ID has an indirect causal
@@ -468,11 +544,28 @@ impl Enter {
     }
 
     /// Returns the span's metadata.
-    pub fn metadata(&self) -> &'static Meta<'static> {
+    pub fn metadata(&self) -> &'a Meta<'a> {
         self.meta
     }
 
-    fn new(id: Id, subscriber: &Dispatch, parent: Option<Id>, meta: &'static StaticMeta) -> Self {
+    /// Sets the field on this span named `name` to the given `value`.
+    ///
+    /// `name` must name a field already defined by this span's metadata, and
+    /// the field must not already have a value. If this is not the case, this
+    /// function returns an [`RecordError`](::subscriber::RecordError).
+    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        match value.record(&self.id, field, &self.subscriber) {
+            Ok(()) => Ok(()),
+            Err(ref e) if e.is_no_span() => panic!("span should still exist!"),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn new(id: Id, parent: Option<Id>, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {
         Self {
             id,
             subscriber: subscriber.clone(),
@@ -482,15 +575,6 @@ impl Enter {
             handles: AtomicUsize::from(1),
             meta,
         }
-    }
-
-    fn clone_current() -> Option<Self> {
-        CURRENT_SPAN.with(|current| {
-            current.borrow().as_ref().map(|ref current| {
-                current.handles.fetch_add(1, Ordering::Release);
-                current.duplicate()
-            })
-        })
     }
 
     fn duplicate(&self) -> Self {
@@ -534,19 +618,85 @@ impl Enter {
     }
 }
 
-impl cmp::PartialEq for Enter {
-    fn eq(&self, other: &Enter) -> bool {
+impl Enter {
+    /// Consumes `span` and returns the inner entering handle, if the span is
+    /// enabled.
+    ///
+    /// The returned `Enter` has approximately the same behaviour to a `Span`.
+    /// However, it is primarily intended for use in libraries custom span
+    /// types; the `Span` handle will typically represent a more ergonomic API
+    /// for actually _using_ spans.
+    pub fn from_span(span: Span) -> Option<Self> {
+        span.inner
+    }
+
+    /// Enters the span, returning a guard that may be used to exit the span and
+    /// re-enter the prior span.
+    ///
+    /// This is used internally to implement `Span::enter`. It may be used for
+    /// writing custom span handles, but should generally not be called directly
+    /// when entering a span.
+    pub fn enter(&self) -> Entered {
+        // The current handle will no longer enter the span, since it has just
+        // been used to enter. Therefore, it will be safe to close the span if
+        // no additional handles exist when the span is exited.
+        self.handles.fetch_sub(1, Ordering::Release);
+        // The span has now been entered, so it's okay to close it.
+        self.has_entered.store(true, Ordering::Release);
+        self.subscriber.enter(self.id());
+        let prior = CURRENT_SPAN.with(|current_span| current_span.replace(Some(self.duplicate())));
+        self.wants_close.store(false, Ordering::Release);
+        Entered { prior }
+    }
+
+    pub fn exit_and_join(&self, other: Entered) {
+        if let Some(other) = other.exit() {
+            self.handles.store(other.handle_count(), Ordering::Release);
+            self.has_entered
+                .store(other.has_entered(), Ordering::Release);
+            self.wants_close
+                .store(other.take_close(), Ordering::Release);
+        }
+    }
+
+    /// Exits the span entry represented by an `Entered` guard, consuming it,
+    /// and updates `self` to canonically represent the referenced span's state
+    /// after the other entry has exited.
+    ///
+    /// If the other handle to the span wanted to close the span on exit, it
+    /// will not do so. Instead, the responsibility for performing the `close`
+    /// will be transferred to `self` --- if `self` did not previously want to
+    /// close, but `other` did, `self` will now want to close.
+    ///
+    /// This means that dropping `other` will no longer close the span, even if
+    /// it previously would have.
+    ///
+    /// This function is intended to be used by span handle implementations to
+    /// ensuring that multiple entering handles are kept consistent. Probably
+    /// don't use this unless you know what you're doing.
+    fn clone_current() -> Option<Self> {
+        CURRENT_SPAN.with(|current| {
+            current.borrow().as_ref().map(|ref current| {
+                current.handles.fetch_add(1, Ordering::Release);
+                current.duplicate()
+            })
+        })
+    }
+}
+
+impl<'a> cmp::PartialEq for Inner<'a> {
+    fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
 
-impl Hash for Enter {
+impl<'a> Hash for Inner<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id.hash(state);
     }
 }
 
-impl Drop for Enter {
+impl<'a> Drop for Inner<'a> {
     fn drop(&mut self) {
         self.subscriber.drop_span(self.id.clone());
         // If this handle wants to be closed, try to close it --- either by

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -357,7 +357,7 @@ impl<'a> Event<'a> {
             }
             let parent = Id::current();
             let attrs = Attributes::new(parent.clone(), meta);
-            let id = dispatch.new_event(attrs);
+            let id = dispatch.new_id(attrs);
             let inner = Enter::new(id, parent, dispatch, meta);
             inner.has_entered.store(true, Ordering::Relaxed);
             inner.close();

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -609,7 +609,7 @@ mod test_support {
 
         pub fn event(mut self) -> Self {
             // TODO: expect message/fields!
-            self.expected.push_back(Expect::Event( ExpectEvent { } ));
+            self.expected.push_back(Expect::Event(ExpectEvent {}));
             self
         }
 
@@ -681,14 +681,20 @@ mod test_support {
         fn new_id(&self, _span: span::Attributes) -> Id {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Id::from_u64(id as u64);
-            self.spans.lock().unwrap().insert(id.clone(), SpanOrEvent::Event);
+            self.spans
+                .lock()
+                .unwrap()
+                .insert(id.clone(), SpanOrEvent::Event);
             id
         }
 
         fn new_span(&self, span: SpanAttributes) -> Id {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Id::from_u64(id as u64);
-            self.spans.lock().unwrap().insert(id.clone(), SpanOrEvent::Span(span));
+            self.spans
+                .lock()
+                .unwrap()
+                .insert(id.clone(), SpanOrEvent::Span(span));
             id
         }
 
@@ -790,13 +796,13 @@ mod test_support {
                 .get(&span)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", span));
             match (span, self.expected.lock().unwrap().pop_front()) {
-                (_, None) => {},
+                (_, None) => {}
                 (SpanOrEvent::Event, Some(Expect::Event(_))) => {
                     // TODO: expect fields, message!
-                },
-                (SpanOrEvent::Event, Some(_)) => panic!(
-                    "expected to close a span, but closed an event instead",
-                ),
+                }
+                (SpanOrEvent::Event, Some(_)) => {
+                    panic!("expected to close a span, but closed an event instead",)
+                }
                 (SpanOrEvent::Span(span), Some(Expect::Event(_))) => panic!(
                     "expected an event, but closed span {:?} instead",
                     span.name()
@@ -806,7 +812,7 @@ mod test_support {
                     expected_span.name,
                     span.name()
                 ),
-                (SpanOrEvent::Span(span), Some(Expect::Exit(ref expected_span)))=> panic!(
+                (SpanOrEvent::Span(span), Some(Expect::Exit(ref expected_span))) => panic!(
                     "expected to exit span {:?}, but closed span {:?} instead",
                     expected_span.name,
                     span.name()
@@ -831,9 +837,9 @@ mod test_support {
                     "expected nothing else to happen, but closed span {:?}",
                     span.name(),
                 ),
-                (SpanOrEvent::Event, Some(Expect::Nothing)) => panic!(
-                    "expected nothing else to happen, but closed an event"
-                ),
+                (SpanOrEvent::Event, Some(Expect::Nothing)) => {
+                    panic!("expected nothing else to happen, but closed an event")
+                }
             }
         }
 
@@ -842,17 +848,13 @@ mod test_support {
             let mut expected = self.expected.lock().unwrap();
             let was_expected = if let Some(Expect::CloneSpan(ref span)) = expected.front() {
                 assert_eq!(
-                    self.spans
-                        .lock()
-                        .unwrap()
-                        .get(&id)
-                        .map(|span_or_event| {
-                            if let SpanOrEvent::Span(ref span) = span_or_event {
-                                span.metadata().name
-                            } else {
-                                Some("event")
-                            }
-                        }),
+                    self.spans.lock().unwrap().get(&id).map(|span_or_event| {
+                        if let SpanOrEvent::Span(ref span) = span_or_event {
+                            span.metadata().name
+                        } else {
+                            Some("event")
+                        }
+                    }),
                     span.name
                 );
                 true
@@ -873,17 +875,13 @@ mod test_support {
                     // as failing the assertion can cause a double panic.
                     if !::std::thread::panicking() {
                         assert_eq!(
-                            self.spans
-                                .lock()
-                                .unwrap()
-                                .get(&id)
-                                .map(|span_or_event| {
-                                    if let SpanOrEvent::Span(ref span) = span_or_event {
-                                        span.metadata().name
-                                    } else {
-                                        Some("event")
-                                    }
-                                }),
+                            self.spans.lock().unwrap().get(&id).map(|span_or_event| {
+                                if let SpanOrEvent::Span(ref span) = span_or_event {
+                                    span.metadata().name
+                                } else {
+                                    Some("event")
+                                }
+                            }),
                             span.name
                         );
                     }

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -1,5 +1,5 @@
 //! Subscribers collect and record trace data.
-use {field, span, Meta, Id};
+use {field, span, Id, Meta};
 
 use std::{error::Error, fmt};
 
@@ -146,12 +146,7 @@ pub trait Subscriber {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    fn record_i64(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: i64,
-    ) -> Result<(), RecordError> {
+    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) -> Result<(), RecordError> {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -166,12 +161,7 @@ pub trait Subscriber {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    fn record_u64(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: u64,
-    ) -> Result<(), RecordError> {
+    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) -> Result<(), RecordError> {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -186,12 +176,7 @@ pub trait Subscriber {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    fn record_bool(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: bool,
-    ) -> Result<(), RecordError> {
+    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) -> Result<(), RecordError> {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -206,12 +191,7 @@ pub trait Subscriber {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    fn record_str(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: &str,
-    ) -> Result<(), RecordError> {
+    fn record_str(&self, span: &Id, field: &field::Key, value: &str) -> Result<(), RecordError> {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -572,7 +552,7 @@ mod test_support {
 
     use super::*;
     use span::{self, MockSpan};
-    use {field, Meta, SpanAttributes, Id};
+    use {field, Id, Meta, SpanAttributes};
 
     use std::{
         collections::{HashMap, VecDeque},
@@ -682,11 +662,7 @@ mod test_support {
             Ok(())
         }
 
-        fn add_follows_from(
-            &self,
-            _span: &Id,
-            _follows: Id,
-        ) -> Result<(), FollowsError> {
+        fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {
             // TODO: it should be possible to expect spans to follow from other spans
             Ok(())
         }

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -691,7 +691,7 @@ mod test_support {
             Ok(())
         }
 
-        fn new_id(&self, span: span::Attributes) -> Id {
+        fn new_id(&self, _span: span::Attributes) -> Id {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Id::from_u64(id as u64);
             id

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -1,5 +1,5 @@
 //! Subscribers collect and record trace data.
-use {field, span, Event, Meta, Id};
+use {field, span, Meta, Id};
 
 use std::{error::Error, fmt};
 
@@ -572,7 +572,7 @@ mod test_support {
 
     use super::*;
     use span::{self, MockSpan};
-    use {field, Event, Meta, SpanAttributes, Id};
+    use {field, Meta, SpanAttributes, Id};
 
     use std::{
         collections::{HashMap, VecDeque},

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -34,7 +34,7 @@ use std::{
 use tokio_trace::{
     field, span,
     subscriber::{self, Subscriber},
-    Event, Meta, Id,
+    Meta, Id,
 };
 
 /// Format a log record as a trace event in the current span.
@@ -143,10 +143,6 @@ pub struct TraceLogger {
     // TODO: the hashmap can definitely be replaced with some kind of arena eventually.
     in_progress: Mutex<HashMap<Id, LineBuilder>>,
 }
-
-struct LogFields<'a, 'b: 'a, I: 'a>(&'a I)
-where
-    &'a I: IntoIterator<Item = (field::Key<'b>, &'b field::Value)>;
 
 // ===== impl LogTracer =====
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -93,7 +93,7 @@ impl<'a> AsLog for Meta<'a> {
 impl<'a> AsTrace for log::Record<'a> {
     type Trace = Meta<'a>;
     fn as_trace(&self) -> Self::Trace {
-        Meta::new_event(
+        Meta::new_id(
             self.target(),
             self.level().as_trace(),
             self.module_path(),
@@ -238,7 +238,7 @@ impl Subscriber for TraceLogger {
         log::logger().enabled(&metadata.as_log())
     }
 
-    fn new_event(&self, new_span: span::Attributes) -> span::Id {
+    fn new_id(&self, new_span: span::Attributes) -> span::Id {
         static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
         let id = span::Id::from_u64(NEXT_ID.fetch_add(1, Ordering::SeqCst) as u64);
         self.in_progress

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -102,8 +102,8 @@ where
         self.registry.new_span(new_span)
     }
 
-    fn new_event(&self, new_event: span::Attributes) -> span::Id {
-        self.registry.new_event(new_event)
+    fn new_id(&self, new_id: span::Attributes) -> span::Id {
+        self.registry.new_id(new_id)
     }
 
     fn record_fmt(

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -108,9 +108,9 @@ where
 
     fn record_fmt(
         &self,
-        span: &Id,
-        name: &tokio_trace::field::Key,
-        value: ::std::fmt::Arguments,
+        _span: &Id,
+        _name: &tokio_trace::field::Key,
+        _value: ::std::fmt::Arguments,
     ) -> Result<(), RecordError> {
         unimplemented!()
     }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -98,25 +98,25 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_span(&self, new_span: span::Attributes) -> span::Id {
+    fn new_span(&self, new_span: span::SpanAttributes) -> span::Id {
         self.registry.new_span(new_span)
     }
 
-    fn record(
+    fn new_event(&self, new_event: span::Attributes) -> span::Id {
+        self.registry.new_event(new_event)
+    }
+
+    fn record_fmt(
         &self,
         span: &span::Id,
         name: &tokio_trace::field::Key,
-        value: &dyn field::Value,
+        value: ::std::fmt::Arguments,
     ) -> Result<(), RecordError> {
-        self.registry.record(span, name, value)
+        unimplemented!()
     }
 
     fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsError> {
         self.registry.add_follows_from(span, follows)
-    }
-
-    fn observe_event<'a>(&self, event: &'a Event<'a>) {
-        self.observer.observe_event(event)
     }
 
     fn enter(&self, id: span::Id) {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
     field, span,
     subscriber::{FollowsError, RecordError, Subscriber},
-    Event, Meta,
+    Event, Meta, Id,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
@@ -98,50 +98,50 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_span(&self, new_span: span::SpanAttributes) -> span::Id {
+    fn new_span(&self, new_span: span::SpanAttributes) -> Id {
         self.registry.new_span(new_span)
     }
 
-    fn new_id(&self, new_id: span::Attributes) -> span::Id {
+    fn new_id(&self, new_id: span::Attributes) -> Id {
         self.registry.new_id(new_id)
     }
 
     fn record_fmt(
         &self,
-        span: &span::Id,
+        span: &Id,
         name: &tokio_trace::field::Key,
         value: ::std::fmt::Arguments,
     ) -> Result<(), RecordError> {
         unimplemented!()
     }
 
-    fn add_follows_from(&self, span: &span::Id, follows: span::Id) -> Result<(), FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError> {
         self.registry.add_follows_from(span, follows)
     }
 
-    fn enter(&self, id: span::Id) {
+    fn enter(&self, id: Id) {
         self.registry.with_span(&id, |span| {
             self.observer.enter(span);
         });
     }
 
-    fn exit(&self, id: span::Id) {
+    fn exit(&self, id: Id) {
         self.registry.with_span(&id, |span| {
             self.observer.exit(span);
         });
     }
 
-    fn close(&self, id: span::Id) {
+    fn close(&self, id: Id) {
         self.registry.with_span(&id, |span| {
             self.observer.close(span);
         });
     }
 
-    fn clone_span(&self, id: span::Id) -> span::Id {
+    fn clone_span(&self, id: Id) -> Id {
         self.registry.clone_span(id)
     }
 
-    fn drop_span(&self, id: span::Id) {
+    fn drop_span(&self, id: Id) {
         self.registry.drop_span(id)
     }
 }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,7 +1,7 @@
 use tokio_trace::{
-    field, span,
+    span,
     subscriber::{FollowsError, RecordError, Subscriber},
-    Event, Meta, Id,
+    Id, Meta,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 

--- a/tokio-trace-subscriber/src/lib.rs
+++ b/tokio-trace-subscriber/src/lib.rs
@@ -1,7 +1,7 @@
 //! Utilities and helpers for implementing and composing subscribers.
 
 extern crate tokio_trace;
-pub use tokio_trace::{Event, SpanId};
+pub use tokio_trace::{Event, Id};
 
 mod compose;
 pub use compose::Composed;

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     field,
-    span::{Attributes, Id},
+    span::{self, Attributes, SpanAttributes, Id},
     subscriber::{FollowsError, RecordError},
 };
 
@@ -38,7 +38,11 @@ pub trait RegisterSpan {
     /// from all calls to this function, if they so choose.
     ///
     /// [span ID]: ../span/struct.Id.html
-    fn new_span(&self, new_span: Attributes) -> Id;
+    fn new_span(&self, new_span: SpanAttributes) -> Id {
+        self.new_event(new_span)
+    }
+
+    fn new_event(&self, new_event: Attributes) -> Id;
 
     fn record(
         &self,
@@ -113,7 +117,7 @@ pub trait RegisterSpan {
 #[derive(Debug)]
 pub struct SpanRef<'a> {
     pub id: &'a Id,
-    pub data: Option<&'a Attributes>,
+    pub data: Option<&'a SpanAttributes>,
     // TODO: the registry can still have a concept of span states...
 }
 
@@ -155,7 +159,7 @@ impl<'a> cmp::Eq for SpanRef<'a> {}
 #[derive(Default)]
 pub struct IncreasingCounter {
     next_id: AtomicUsize,
-    spans: Mutex<HashMap<Id, Attributes>>,
+    spans: Mutex<HashMap<Id, SpanAttributes>>,
 }
 
 pub fn increasing_counter() -> IncreasingCounter {
@@ -165,12 +169,18 @@ pub fn increasing_counter() -> IncreasingCounter {
 impl RegisterSpan for IncreasingCounter {
     type PriorSpans = iter::Empty<Id>;
 
-    fn new_span(&self, new_span: Attributes) -> Id {
+    fn new_span(&self, new_span: SpanAttributes) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         if let Ok(mut spans) = self.spans.lock() {
             spans.insert(id.clone(), new_span);
         }
+        id
+    }
+
+    fn new_event(&self, new_event: span::Attributes) -> Id {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let id = Id::from_u64(id as u64);
         id
     }
 

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -178,7 +178,7 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn new_id(&self, new_id: span::Attributes) -> Id {
+    fn new_id(&self, _new_id: span::Attributes) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         id

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     field,
-    span::{self, Attributes, SpanAttributes, Id},
+    span::{self, Attributes, Id, SpanAttributes},
     subscriber::{FollowsError, RecordError},
 };
 

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -39,10 +39,10 @@ pub trait RegisterSpan {
     ///
     /// [span ID]: ../span/struct.Id.html
     fn new_span(&self, new_span: SpanAttributes) -> Id {
-        self.new_event(new_span)
+        self.new_id(new_span)
     }
 
-    fn new_event(&self, new_event: Attributes) -> Id;
+    fn new_id(&self, new_id: Attributes) -> Id;
 
     fn record(
         &self,
@@ -178,7 +178,7 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn new_event(&self, new_event: span::Attributes) -> Id {
+    fn new_id(&self, new_id: span::Attributes) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         id

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -139,7 +139,7 @@ fn main() {
 
                         let serve = h2
                             .serve(sock)
-                            .map_err(|e| event!(Level::Error, {}, "error {:?}", e))
+                            .map_err(|e| { event!(Level::Error, {}, "error {:?}", e); })
                             .and_then(|_| {
                                 event!(Level::Debug, {}, "response finished");
                                 future::ok(())
@@ -148,7 +148,7 @@ fn main() {
 
                         Ok((h2, reactor))
                     })
-                }).map_err(|e| event!(Level::Error, {}, "serve error {:?}", e))
+                }).map_err(|e| { event!(Level::Error, {}, "serve error {:?}", e); })
                 .map(|_| {})
                 .in_current_span();
 

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -139,8 +139,9 @@ fn main() {
 
                         let serve = h2
                             .serve(sock)
-                            .map_err(|e| { event!(Level::Error, {}, "error {:?}", e); })
-                            .and_then(|_| {
+                            .map_err(|e| {
+                                event!(Level::Error, {}, "error {:?}", e);
+                            }).and_then(|_| {
                                 event!(Level::Debug, {}, "response finished");
                                 future::ok(())
                             }).in_current_span();
@@ -148,8 +149,9 @@ fn main() {
 
                         Ok((h2, reactor))
                     })
-                }).map_err(|e| { event!(Level::Error, {}, "serve error {:?}", e); })
-                .map(|_| {})
+                }).map_err(|e| {
+                    event!(Level::Error, {}, "serve error {:?}", e);
+                }).map(|_| {})
                 .in_current_span();
 
             rt.spawn(serve);

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -23,9 +23,6 @@ use tokio_trace_futures::Instrument;
 use tower_h2::{Body, RecvBody, Server};
 use tower_service::{MakeService, Service};
 
-#[path = "../../tokio-trace/examples/sloggish/sloggish_subscriber.rs"]
-mod sloggish;
-use self::sloggish::SloggishSubscriber;
 
 type Response = http::Response<RspBody>;
 
@@ -105,7 +102,10 @@ impl tower_service::Service<()> for NewSvc {
 }
 
 fn main() {
-    let subscriber = SloggishSubscriber::new(2);
+    env_logger::Builder::new().parse("tower_h2_server=trace").init();
+    let subscriber = tokio_trace_log::TraceLogger::builder()
+        .with_parent_fields(true)
+        .finish();
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let mut rt = Runtime::new().unwrap();

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -23,7 +23,6 @@ use tokio_trace_futures::Instrument;
 use tower_h2::{Body, RecvBody, Server};
 use tower_service::{MakeService, Service};
 
-
 type Response = http::Response<RspBody>;
 
 struct RspBody(Option<Bytes>);
@@ -102,7 +101,9 @@ impl tower_service::Service<()> for NewSvc {
 }
 
 fn main() {
-    env_logger::Builder::new().parse("tower_h2_server=trace").init();
+    env_logger::Builder::new()
+        .parse("tower_h2_server=trace")
+        .init();
     let subscriber = tokio_trace_log::TraceLogger::builder()
         .with_parent_fields(true)
         .finish();

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -11,13 +11,13 @@ use tokio_trace::{field, span, subscriber, Event, Meta};
 struct EnabledSubscriber;
 
 impl tokio_trace::Subscriber for EnabledSubscriber {
-    fn new_span(&self, span: span::Attributes) -> span::Id {
+    fn new_span(&self, span: span::Attributes) -> Id {
         let _ = span;
-        span::Id::from_u64(0)
+        Id::from_u64(0)
     }
     fn record(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: &dyn field::Value,
     ) -> Result<(), tokio_trace::subscriber::RecordError> {
@@ -27,8 +27,8 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
 
     fn add_follows_from(
         &self,
-        span: &span::Id,
-        follows: span::Id,
+        span: &Id,
+        follows: Id,
     ) -> Result<(), subscriber::FollowsError> {
         let _ = (span, follows);
         Ok(())
@@ -43,15 +43,15 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         let _ = event;
     }
 
-    fn enter(&self, span: span::Id) {
+    fn enter(&self, span: Id) {
         let _ = span;
     }
 
-    fn exit(&self, span: span::Id) {
+    fn exit(&self, span: Id) {
         let _ = span;
     }
 
-    fn close(&self, span: span::Id) {
+    fn close(&self, span: Id) {
         let _ = span;
     }
 }
@@ -60,14 +60,14 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
 struct AddAttributes(Mutex<Option<span::Attributes>>);
 
 impl tokio_trace::Subscriber for AddAttributes {
-    fn new_span(&self, span: span::Attributes) -> span::Id {
+    fn new_span(&self, span: span::Attributes) -> Id {
         *self.0.lock().unwrap() = Some(span.into());
-        span::Id::from_u64(0)
+        Id::from_u64(0)
     }
 
     fn record(
         &self,
-        span: &span::Id,
+        span: &Id,
         field: &field::Key,
         value: &dyn field::Value,
     ) -> Result<(), tokio_trace::subscriber::RecordError> {
@@ -76,8 +76,8 @@ impl tokio_trace::Subscriber for AddAttributes {
 
     fn add_follows_from(
         &self,
-        span: &span::Id,
-        follows: span::Id,
+        span: &Id,
+        follows: Id,
     ) -> Result<(), subscriber::FollowsError> {
         let _ = (span, follows);
         Ok(())
@@ -92,15 +92,15 @@ impl tokio_trace::Subscriber for AddAttributes {
         let _ = event;
     }
 
-    fn enter(&self, span: span::Id) {
+    fn enter(&self, span: Id) {
         let _ = span;
     }
 
-    fn exit(&self, span: span::Id) {
+    fn exit(&self, span: Id) {
         let _ = span;
     }
 
-    fn close(&self, span: span::Id) {
+    fn close(&self, span: Id) {
         let _ = span;
     }
 }

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -3,7 +3,7 @@ extern crate test;
 use test::Bencher;
 
 use std::sync::Mutex;
-use tokio_trace::{field, span, subscriber, Meta, Id};
+use tokio_trace::{field, span, subscriber, Id, Meta};
 
 /// A subscriber that is enabled but otherwise does nothing.
 struct EnabledSubscriber;
@@ -24,11 +24,7 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         Ok(())
     }
 
-    fn add_follows_from(
-        &self,
-        span: &Id,
-        follows: Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
         let _ = (span, follows);
         Ok(())
     }
@@ -74,11 +70,7 @@ impl tokio_trace::Subscriber for Record {
         Ok(())
     }
 
-    fn add_follows_from(
-        &self,
-        span: &Id,
-        follows: Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
         let _ = (span, follows);
         Ok(())
     }

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -1,11 +1,9 @@
 #![feature(test)]
-#[macro_use]
-extern crate tokio_trace;
 extern crate test;
 use test::Bencher;
 
 use std::sync::Mutex;
-use tokio_trace::{field, span, subscriber, Event, Meta, Id};
+use tokio_trace::{field, span, subscriber, Meta, Id};
 
 /// A subscriber that is enabled but otherwise does nothing.
 struct EnabledSubscriber;
@@ -68,8 +66,8 @@ impl tokio_trace::Subscriber for Record {
 
     fn record_fmt(
         &self,
-        span: &Id,
-        field: &field::Key,
+        _span: &Id,
+        _field: &field::Key,
         value: ::std::fmt::Arguments,
     ) -> Result<(), tokio_trace::subscriber::RecordError> {
         let _ = ::std::fmt::format(value);
@@ -119,7 +117,7 @@ fn span_repeatedly(b: &mut Bencher) {
 
     let n = test::black_box(N_SPANS);
     tokio_trace::Dispatch::new(EnabledSubscriber)
-        .as_default(|| b.iter(|| (0..n).fold(mk_span(0), |span, i| mk_span(i as u64))));
+        .as_default(|| b.iter(|| (0..n).fold(mk_span(0), |_, i| mk_span(i as u64))));
 }
 
 #[bench]

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,7 +3,7 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{Level, Value, Span};
+use tokio_trace::{Level, Span, Value};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
@@ -20,7 +20,11 @@ fn main() {
 
             event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
             span!("my other span", quux = "quuuux").enter(|| {
-                event!(Level::Debug, { depth = Value::display("very") }, "hi from inside both my spans!");
+                event!(
+                    Level::Debug,
+                    { depth = Value::display("very") },
+                    "hi from inside both my spans!"
+                );
             })
         });
     });

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,11 +3,13 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{Level, Span};
+use tokio_trace::{Level, Value, Span};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
-    let subscriber = tokio_trace_log::TraceLogger::new();
+    let subscriber = tokio_trace_log::TraceLogger::builder()
+        .with_parent_fields(true)
+        .finish();
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
         let foo: u64 = 3;
@@ -15,7 +17,11 @@ fn main() {
 
         span!("my_great_span", foo = 4u64, baz = 5u64).enter(|| {
             Span::current().close();
+
             event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
+            span!("my other span", quux = "quuuux").enter(|| {
+                event!(Level::Debug, { depth = Value::display("very") }, "hi from inside both my spans!");
+            })
         });
     });
 }

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -4,7 +4,7 @@ extern crate tokio_trace;
 use tokio_trace::{
     field, span,
     subscriber::{self, Subscriber},
-    Event, Level, Meta, Id,
+    Level, Meta, Id,
 };
 
 use std::{

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -4,7 +4,7 @@ extern crate tokio_trace;
 use tokio_trace::{
     field, span,
     subscriber::{self, Subscriber},
-    Level, Meta, Id,
+    Id, Level, Meta,
 };
 
 use std::{
@@ -47,11 +47,7 @@ impl Subscriber for CounterSubscriber {
         Id::from_u64(id as u64)
     }
 
-    fn add_follows_from(
-        &self,
-        _span: &Id,
-        _follows: Id,
-    ) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
         // unimplemented
         Ok(())
     }

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -4,7 +4,7 @@ extern crate tokio_trace;
 use tokio_trace::{
     field, span,
     subscriber::{self, Subscriber},
-    Event, Level, Meta,
+    Event, Level, Meta, Id,
 };
 
 use std::{
@@ -42,15 +42,15 @@ impl Subscriber for CounterSubscriber {
         interest
     }
 
-    fn new_id(&self, _new_span: span::Attributes) -> span::Id {
+    fn new_id(&self, _new_span: span::Attributes) -> Id {
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
-        span::Id::from_u64(id as u64)
+        Id::from_u64(id as u64)
     }
 
     fn add_follows_from(
         &self,
-        _span: &span::Id,
-        _follows: span::Id,
+        _span: &Id,
+        _follows: Id,
     ) -> Result<(), subscriber::FollowsError> {
         // unimplemented
         Ok(())
@@ -58,7 +58,7 @@ impl Subscriber for CounterSubscriber {
 
     fn record_i64(
         &self,
-        _id: &span::Id,
+        _id: &Id,
         field: &field::Key,
         value: i64,
     ) -> Result<(), ::subscriber::RecordError> {
@@ -75,7 +75,7 @@ impl Subscriber for CounterSubscriber {
 
     fn record_u64(
         &self,
-        _id: &span::Id,
+        _id: &Id,
         field: &field::Key,
         value: u64,
     ) -> Result<(), ::subscriber::RecordError> {
@@ -95,7 +95,7 @@ impl Subscriber for CounterSubscriber {
     ///   been set.
     fn record_fmt(
         &self,
-        _id: &span::Id,
+        _id: &Id,
         _field: &field::Key,
         _value: ::std::fmt::Arguments,
     ) -> Result<(), ::subscriber::RecordError> {
@@ -111,9 +111,9 @@ impl Subscriber for CounterSubscriber {
             .any(|f| f.name().map(|name| name.contains("count")).unwrap_or(false))
     }
 
-    fn enter(&self, _span: span::Id) {}
-    fn exit(&self, _span: span::Id) {}
-    fn close(&self, _span: span::Id) {}
+    fn enter(&self, _span: Id) {}
+    fn exit(&self, _span: Id) {}
+    fn close(&self, _span: Id) {}
 }
 
 impl Counters {

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -42,7 +42,7 @@ impl Subscriber for CounterSubscriber {
         interest
     }
 
-    fn new_event(&self, _new_span: span::Attributes) -> span::Id {
+    fn new_id(&self, _new_span: span::Attributes) -> span::Id {
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
         span::Id::from_u64(id as u64)
     }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -14,7 +14,7 @@ extern crate ansi_term;
 extern crate humantime;
 use self::ansi_term::{Color, Style};
 use super::tokio_trace::{
-    self, field,
+    self,
     subscriber::{self, Subscriber},
     Id, Level, SpanAttributes,
 };
@@ -35,12 +35,21 @@ pub struct SloggishSubscriber {
     stderr: io::Stderr,
     stack: Mutex<Vec<Id>>,
     spans: Mutex<HashMap<Id, Span>>,
+    events: Mutex<HashMap<Id, Event>>,
     ids: AtomicUsize,
 }
 
 struct Span {
     attrs: SpanAttributes,
     kvs: Vec<(String, String)>,
+}
+
+struct Event {
+    id: Id,
+    level: tokio_trace::Level,
+    target: String,
+    message: String,
+    kvs: Vec<(String, String)>
 }
 
 struct ColorLevel(Level);
@@ -70,12 +79,42 @@ impl Span {
         key: &tokio_trace::field::Key,
         value: fmt::Arguments,
     ) -> Result<(), subscriber::RecordError> {
-        let mut s = String::new();
         // value.record(key, &mut tokio_trace::field::DebugRecorder::new(&mut s))?;
         // TODO: shouldn't have to alloc the key...
-        // self.kvs.push((key.name().unwrap_or("???").to_owned(), s));
-        unimplemented!()
-        // Ok(())
+        let k = key.name().unwrap_or("???").to_owned();
+        let v = fmt::format(value);
+        self.kvs.push((k, v));
+        Ok(())
+    }
+}
+
+impl Event {
+    fn new(attrs: tokio_trace::Attributes, id: Id) -> Self {
+        let meta = attrs.metadata();
+        Self {
+            id,
+            target: meta.target.to_owned(),
+            level: meta.level,
+            message: String::new(),
+            kvs: Vec::new(),
+        }
+    }
+
+    fn record(
+        &mut self,
+        key: &tokio_trace::field::Key,
+        value: fmt::Arguments,
+    ) -> Result<(), subscriber::RecordError> {
+        if key.name() == Some("message") {
+            self.message = fmt::format(value);
+            return Ok(())
+        }
+
+        // TODO: shouldn't have to alloc the key...
+        let k = key.name().unwrap_or("???").to_owned();
+        let v = fmt::format(value);
+        self.kvs.push((k, v));
+        Ok(())
     }
 }
 
@@ -86,6 +125,7 @@ impl SloggishSubscriber {
             stderr: io::stderr(),
             stack: Mutex::new(vec![]),
             spans: Mutex::new(HashMap::new()),
+            events: Mutex::new(HashMap::new()),
             ids: AtomicUsize::new(0),
         }
     }
@@ -117,15 +157,6 @@ impl SloggishSubscriber {
         Ok(())
     }
 
-    fn print_meta(&self, writer: &mut impl Write, meta: &tokio_trace::Meta) -> io::Result<()> {
-        write!(
-            writer,
-            "{level} {target} ",
-            level = ColorLevel(meta.level),
-            target = meta.target,
-        )
-    }
-
     fn print_indent(&self, writer: &mut impl Write, indent: usize) -> io::Result<()> {
         for _ in 0..(indent * self.indent_amount) {
             write!(writer, " ")?;
@@ -142,6 +173,10 @@ impl Subscriber for SloggishSubscriber {
     fn new_id(&self, span: tokio_trace::span::Attributes) -> tokio_trace::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         let id = tokio_trace::Id::from_u64(next);
+        self.events
+            .lock()
+            .unwrap()
+            .insert(id.clone(), Event::new(span, id.clone()));
         id
     }
 
@@ -161,13 +196,16 @@ impl Subscriber for SloggishSubscriber {
         name: &tokio_trace::field::Key,
         value: fmt::Arguments,
     ) -> Result<(), subscriber::RecordError> {
+        let mut events = self.events.lock().expect("mutex poisoned!");
+        if let Some(event) = events.get_mut(span) {
+            return event.record(name, value)
+        };
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans
             .get_mut(span)
             .ok_or_else(|| subscriber::RecordError::no_span(span.clone()))?;
-        // span.record(name, value)?;
-        unimplemented!()
-        // Ok(())
+        span.record(name, value)?;
+        Ok(())
     }
 
     fn add_follows_from(
@@ -215,7 +253,26 @@ impl Subscriber for SloggishSubscriber {
     fn exit(&self, _span: tokio_trace::Id) {}
 
     #[inline]
-    fn close(&self, _span: tokio_trace::Id) {
+    fn close(&self, id: tokio_trace::Id) {
+        if let Some(event) = self.events
+            .lock()
+            .expect("mutex poisoned")
+            .remove(&id)
+        {
+            let mut stderr = self.stderr.lock();
+            let indent = self.stack.lock().unwrap().len();
+            self.print_indent(&mut stderr, indent).unwrap();
+            write!(
+                &mut stderr,
+                "{timestamp} {level} {target} {message}",
+                timestamp = humantime::format_rfc3339_seconds(SystemTime::now()),
+                level = ColorLevel(event.level),
+                target = &event.target,
+                message = Style::new().bold().paint(event.message),
+            ).unwrap();
+            self.print_kvs(&mut stderr, event.kvs.iter().map(|&(ref k, ref v)| (k, v)), ", ").unwrap();
+            write!(&mut stderr, "\n").unwrap();
+        }
         // TODO: it's *probably* safe to remove the span from the cache
         // now...but that doesn't really matter for this example.
     }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -49,7 +49,7 @@ struct Event {
     level: tokio_trace::Level,
     target: String,
     message: String,
-    kvs: Vec<(String, String)>
+    kvs: Vec<(String, String)>,
 }
 
 struct ColorLevel(Level);
@@ -107,7 +107,7 @@ impl Event {
     ) -> Result<(), subscriber::RecordError> {
         if key.name() == Some("message") {
             self.message = fmt::format(value);
-            return Ok(())
+            return Ok(());
         }
 
         // TODO: shouldn't have to alloc the key...
@@ -198,7 +198,7 @@ impl Subscriber for SloggishSubscriber {
     ) -> Result<(), subscriber::RecordError> {
         let mut events = self.events.lock().expect("mutex poisoned!");
         if let Some(event) = events.get_mut(span) {
-            return event.record(name, value)
+            return event.record(name, value);
         };
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         let span = spans
@@ -254,11 +254,7 @@ impl Subscriber for SloggishSubscriber {
 
     #[inline]
     fn close(&self, id: tokio_trace::Id) {
-        if let Some(event) = self.events
-            .lock()
-            .expect("mutex poisoned")
-            .remove(&id)
-        {
+        if let Some(event) = self.events.lock().expect("mutex poisoned").remove(&id) {
             let mut stderr = self.stderr.lock();
             let indent = self.stack.lock().unwrap().len();
             self.print_indent(&mut stderr, indent).unwrap();
@@ -270,7 +266,11 @@ impl Subscriber for SloggishSubscriber {
                 target = &event.target,
                 message = Style::new().bold().paint(event.message),
             ).unwrap();
-            self.print_kvs(&mut stderr, event.kvs.iter().map(|&(ref k, ref v)| (k, v)), ", ").unwrap();
+            self.print_kvs(
+                &mut stderr,
+                event.kvs.iter().map(|&(ref k, ref v)| (k, v)),
+                ", ",
+            ).unwrap();
             write!(&mut stderr, "\n").unwrap();
         }
         // TODO: it's *probably* safe to remove the span from the cache

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -16,7 +16,7 @@ use self::ansi_term::{Color, Style};
 use super::tokio_trace::{
     self, field,
     subscriber::{self, Subscriber},
-    Level, SpanAttributes, Id,
+    Id, Level, SpanAttributes,
 };
 
 use std::{

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -139,7 +139,7 @@ impl Subscriber for SloggishSubscriber {
         true
     }
 
-    fn new_event(&self, span: tokio_trace::span::Attributes) -> tokio_trace::span::Id {
+    fn new_id(&self, span: tokio_trace::span::Attributes) -> tokio_trace::span::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         let id = tokio_trace::span::Id::from_u64(next);
         id

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -46,20 +46,20 @@ impl<'a, W: fmt::Write + 'a> DebugRecorder<'a, W> {
     }
 }
 
-impl<'a, W: fmt::Write + 'a> Record for DebugRecorder<'a, W> {
-    fn record_fmt(
-        &mut self,
-        key: &Key,
-        args: fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        if self.with_key {
-            self.write
-                .write_fmt(format_args!("{}=", key.name().unwrap_or("???")))?;
-        }
-        self.write.write_fmt(args)?;
-        Ok(())
-    }
-}
+// impl<'a, W: fmt::Write + 'a> Record for DebugRecorder<'a, W> {
+//     fn record_fmt(
+//         &mut self,
+//         key: &Key,
+//         args: fmt::Arguments,
+//     ) -> Result<(), ::subscriber::RecordError> {
+//         if self.with_key {
+//             self.write
+//                 .write_fmt(format_args!("{}=", key.name().unwrap_or("???")))?;
+//         }
+//         self.write.write_fmt(args)?;
+//         Ok(())
+//     }
+// }
 
 // ===== impl AsKey =====
 

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 pub use tokio_trace_core::field::*;
 use Meta;
 
@@ -16,50 +15,6 @@ pub trait AsKey {
     /// returned. Otherwise, this function returns `None`.
     fn as_key<'a>(&self, metadata: &'a Meta<'a>) -> Option<Key<'a>>;
 }
-
-pub struct DebugRecorder<'a, W: 'a> {
-    write: &'a mut W,
-    with_key: bool,
-}
-
-// ===== impl DebugRecorder =====
-
-impl<'a, W: 'a> DebugRecorder<'a, W> {
-    pub fn into_inner(self) -> &'a mut W {
-        self.write
-    }
-}
-
-impl<'a, W: fmt::Write + 'a> DebugRecorder<'a, W> {
-    pub fn new(write: &'a mut W) -> Self {
-        Self {
-            write,
-            with_key: false,
-        }
-    }
-
-    pub fn new_with_key(write: &'a mut W) -> Self {
-        Self {
-            write,
-            with_key: true,
-        }
-    }
-}
-
-// impl<'a, W: fmt::Write + 'a> Record for DebugRecorder<'a, W> {
-//     fn record_fmt(
-//         &mut self,
-//         key: &Key,
-//         args: fmt::Arguments,
-//     ) -> Result<(), ::subscriber::RecordError> {
-//         if self.with_key {
-//             self.write
-//                 .write_fmt(format_args!("{}=", key.name().unwrap_or("???")))?;
-//         }
-//         self.write.write_fmt(args)?;
-//         Ok(())
-//     }
-// }
 
 // ===== impl AsKey =====
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -161,7 +161,7 @@ pub mod subscriber;
 pub use self::{
     dispatcher::Dispatch,
     field::Value,
-    span::{Attributes as SpanAttributes, Id as SpanId, Span},
+    span::{Attributes, Id as SpanId, Span, SpanAttributes},
     subscriber::Subscriber,
     tokio_trace_core::{
         callsite::{self, Callsite},

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -25,7 +25,7 @@ macro_rules! callsite {
             module_path: Some(module_path!()),
             file: Some(file!()),
             line: Some(line!()),
-            field_names: &[ $(stringify!($field_name)),* ],
+            field_names: &[ "message", $(stringify!($field_name)),* ],
             kind: $crate::MetaKind::EVENT,
         })
     });

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -123,7 +123,7 @@ macro_rules! span {
 
 #[macro_export]
 macro_rules! event {
-    (target: $target:expr, $lvl:expr, follows: [ $( $follows:expr),* ], { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => ({
+    (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
             use $crate::{callsite, SpanAttributes, SpanId, Subscriber, Event, field::Value};
             use $crate::callsite::Callsite;
@@ -132,24 +132,33 @@ macro_rules! event {
                 target:
                 $target, $( $k ),*
             };
-            let field_values: &[ &dyn Value ] = &[ $( &$val ),* ];
-            let follows_from: &[SpanId] = &[ $( $follows ),* ];
-            Event::observe(
-                callsite,
-                &field_values[..],
-                &follows_from[..],
-                format_args!( $($arg)+ ),
-            );
+            // Depending on how many fields are generated, this may or may
+            // not actually be used, but it doesn't make sense to repeat it.
+            #[allow(unused_variables, unused_mut)]
+            Event::new(callsite, |event| {
+                let mut keys = callsite.metadata().fields();
+                event.message(
+                    &keys.next().expect("event metadata should define a key for the message"),
+                    format_args!( $($arg)+ )
+                )
+                .expect("adding value for event message failed");
+                $(
+                    let key = keys.next()
+                        .expect(concat!("metadata should define a key for '", stringify!($k), "'"));
+                    event!(@ record: event, $k, &key, $($val)*);
+                )*
+            })
         }
     });
-    (target: $target:expr, $lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $lvl, follows: [],  { $($k = $val),* }, $($arg)+)
+    ( $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
+        event!(target: module_path!(), $lvl, { $($k $( = $val)* ),* }, $($arg)+)
     );
-    ($lvl:expr, { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $lvl, { $($k = $val),* }, $($arg)+)
+    (@ record: $ev:expr, $k:expr, $i:expr, $val:expr) => (
+        $ev.record($i, &$val)
+            .expect(concat!("adding value for field '", stringify!($k), "' failed"));
     );
-    ($lvl:expr, follows: [ $( $follows:expr),* ], { $($k:ident = $val:expr),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $lvl, follows: [ $( $follows ),* ], { $($k = $val),* }, $($arg)+)
+    (@ record: $ev:expr, $k:expr, $i:expr,) => (
+        // skip
     );
 }
 

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -125,7 +125,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{callsite, SpanAttributes, SpanId, Subscriber, Event, field::Value};
+            use $crate::{callsite, SpanAttributes, Id, Subscriber, Event, field::Value};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:
                 $lvl,
@@ -170,7 +170,7 @@ pub mod subscriber;
 pub use self::{
     dispatcher::Dispatch,
     field::Value,
-    span::{Attributes, Id as SpanId, Span, SpanAttributes},
+    span::{Attributes, Id, Span, SpanAttributes},
     subscriber::Subscriber,
     tokio_trace_core::{
         callsite::{self, Callsite},

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -196,7 +196,7 @@
 //! [`Attributes`]: ::span::Attributes
 //! [shared span]: ::span::Shared
 //! [`IntoShared`]: ::span::IntoShared
-pub use tokio_trace_core::span::{Attributes, SpanAttributes, Id, Span};
+pub use tokio_trace_core::span::{Attributes, Id, Span, SpanAttributes};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -529,6 +529,63 @@ mod tests {
     }
 
     #[test]
+    fn span_closes_after_event() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .event()
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .done()
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            span!("foo").enter(|| {
+                Span::current().close();
+                event!(::Level::Debug, {}, "my event!");
+            });
+        })
+    }
+
+    #[test]
+    fn new_span_after_event() {
+        let subscriber = subscriber::mock()
+            .enter(span::mock().named(Some("foo")))
+            .event()
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .enter(span::mock().named(Some("bar")))
+            .exit(span::mock().named(Some("bar")))
+            .close(span::mock().named(Some("bar")))
+            .done()
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            span!("foo").enter(|| {
+                Span::current().close();
+                event!(::Level::Debug, {}, "my event!");
+            });
+            span!("bar").enter(|| {
+                Span::current().close();
+            });
+        })
+    }
+
+    #[test]
+    fn event_outside_of_span() {
+        let subscriber = subscriber::mock()
+            .event()
+            .enter(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
+            .done()
+            .run();
+        Dispatch::new(subscriber).as_default(|| {
+            event!(::Level::Debug, {}, "my event!");
+            span!("foo").enter(|| {
+                Span::current().close();
+            });
+        })
+    }
+
+    #[test]
     fn dropping_a_span_calls_drop_span() {
         let subscriber = subscriber::mock()
             .enter(span::mock().named(Some("foo")))

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -196,7 +196,7 @@
 //! [`Attributes`]: ::span::Attributes
 //! [shared span]: ::span::Shared
 //! [`IntoShared`]: ::span::IntoShared
-pub use tokio_trace_core::span::{Attributes, Id, Span};
+pub use tokio_trace_core::span::{Attributes, SpanAttributes, Id, Span};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};


### PR DESCRIPTION
This branch changes the implementation of the `Event` type so that
`Event`s are now implemented on top of the same internals as `Span`s.
The `Subscriber::observe_event` function has been removed; events are
now created by calls to `Subscriber::new_id`, populated by calls to
`Subscriber::record` and `Subscriber::follows_from` with the event's ID,
and completed by `Subscriber::close`. 

This change was made primarily because it allows the `Record` trait to
be removed from `tokio-trace-core`. Since `Event`s now have IDs, fields
on them can be recorded through the same mechanism as `Span`s; a
separate `Record` type that provides context is no longer necessary. The
methods on `Record` have been replaced with `Subscriber` trait methods
with the same behaviour. 

This also will allow us to remove the `Value` trait from `core`, as
requested by @carllerche --- I have a separate branch that makes that
change, and I'll open a PR for it shortly.

Both the `tokio-trace-log` crate and the examples had to be reworked
significantly to accomodate this change, but I think the resulting code
is better (and the new log output is much nicer).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>