### PR TITLE
Remove `Value` trait from `tokio-trace-core`

### DIFF
--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -115,7 +115,7 @@ pub mod subscriber;
 pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
-    field::{Key, Value},
+    field::Key,
     span::{Attributes, Event, Id, Span, SpanAttributes},
     subscriber::{Interest, Subscriber},
 };

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -257,7 +257,7 @@ impl Span {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    pub fn record_value_i64(&self,  field: &Key, value: i64) -> Result<(), RecordError> {
+    pub fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
         if let Some(ref inner) = self.inner {
             inner.record_value_i64(field, value)?;
         }
@@ -450,7 +450,7 @@ impl<'a> Event<'a> {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    pub fn record_value_i64(&mut self,  field: &Key, value: i64) -> Result<(), RecordError> {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> Result<(), RecordError> {
         if let Some(ref inner) = self.inner {
             inner.record_value_i64(field, value)?;
         }
@@ -693,7 +693,7 @@ impl<'a> Inner<'a> {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-     pub(crate) fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+    pub(crate) fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
         if !self.meta.contains_key(field) {
             return Err(RecordError::no_field());
         }
@@ -738,7 +738,11 @@ impl<'a> Inner<'a> {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    pub(crate) fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+    pub(crate) fn record_value_fmt(
+        &self,
+        field: &Key,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError> {
         if !self.meta.contains_key(field) {
             return Err(RecordError::no_field());
         }

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -250,17 +250,74 @@ impl Span {
             .and_then(|inner| inner.meta.key_for(name))
     }
 
-    /// Sets the field on this span named `name` to the given `value`.
+    /// Record a signed 64-bit integer value.
     ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_i64(&self,  field: &Key, value: i64) -> Result<(), RecordError> {
         if let Some(ref inner) = self.inner {
-            inner.record(field, value)
-        } else {
-            Ok(())
+            inner.record_value_i64(field, value)?;
         }
+        Ok(())
+    }
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_u64(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a boolean value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_bool(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a string value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_str(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a precompiled set of format arguments.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_fmt(field, value)?;
+        }
+        Ok(())
     }
 
     /// Signals that this span should close the next time it is exited, or when
@@ -386,6 +443,76 @@ impl<'a> Event<'a> {
         Ok(())
     }
 
+    /// Record a signed 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_i64(&mut self,  field: &Key, value: i64) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_i64(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_u64(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a boolean value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_bool(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a string value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_str(field, value)?;
+        }
+        Ok(())
+    }
+
+    /// Record a precompiled set of format arguments.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+        if let Some(ref inner) = self.inner {
+            inner.record_value_fmt(field, value)?;
+        }
+        Ok(())
+    }
+
     /// Returns the `Id` of the parent of this span, if one exists.
     pub fn parent(&self) -> Option<Id> {
         self.inner.as_ref().and_then(Enter::parent)
@@ -400,18 +527,6 @@ impl<'a> Event<'a> {
         self.inner
             .as_ref()
             .and_then(|inner| inner.meta.key_for(name))
-    }
-
-    /// Sets the field on this span named `name` to the given `value`.
-    ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
-        if let Some(ref inner) = self.inner {
-            inner.record(field, value)?;
-        }
-        Ok(())
     }
 
     /// Returns `true` if this span was disabled by the subscriber and does not
@@ -556,21 +671,79 @@ impl<'a> Inner<'a> {
         self.meta
     }
 
-    /// Sets the field on this span named `name` to the given `value`.
+    /// Record a signed 64-bit integer value.
     ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record(&self, field: &Key, value: &dyn field::Value) -> Result<(), RecordError> {
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
         if !self.meta.contains_key(field) {
             return Err(RecordError::no_field());
         }
 
-        match value.record(&self.id, field, &self.subscriber) {
-            Ok(()) => Ok(()),
-            Err(ref e) if e.is_no_span() => panic!("span should still exist!"),
-            Err(e) => Err(e),
+        self.subscriber.record_i64(&self.id, field, value)
+    }
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+     pub(crate) fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
         }
+
+        self.subscriber.record_u64(&self.id, field, value)
+    }
+
+    /// Record a boolean value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        self.subscriber.record_bool(&self.id, field, value)
+    }
+
+    /// Record a string value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        self.subscriber.record_str(&self.id, field, value)
+    }
+
+    /// Record a precompiled set of format arguments value.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    pub(crate) fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+        if !self.meta.contains_key(field) {
+            return Err(RecordError::no_field());
+        }
+
+        self.subscriber.record_fmt(&self.id, field, value)
     }
 
     fn new(id: Id, parent: Option<Id>, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {
@@ -761,8 +934,6 @@ pub use self::test_support::*;
 #[cfg(any(test, feature = "test-support"))]
 mod test_support {
     #![allow(missing_docs)]
-    use field;
-    use std::collections::HashMap;
 
     /// A mock span.
     ///
@@ -771,7 +942,6 @@ mod test_support {
     #[derive(Default)]
     pub struct MockSpan {
         pub name: Option<Option<&'static str>>,
-        pub fields: HashMap<String, Box<dyn field::Value>>,
         // TODO: more
     }
 

--- a/tokio-trace-macros/examples/basic.rs
+++ b/tokio-trace-macros/examples/basic.rs
@@ -19,7 +19,7 @@ fn main() {
             let band = suggest_band();
             event!(
                 Level::Info,
-                { band_recommendation = field::Value::display(&band) },
+                { band_recommendation = field::display(&band) },
                 "Got a rec."
             );
         });

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,7 +1,6 @@
 use tokio_trace::{
-    field,
     span::{self, Attributes, Id, SpanAttributes},
-    subscriber::{FollowsError, RecordError},
+    subscriber::FollowsError,
 };
 
 use std::{
@@ -43,13 +42,6 @@ pub trait RegisterSpan {
     }
 
     fn new_id(&self, new_id: Attributes) -> Id;
-
-    fn record(
-        &self,
-        span: &Id,
-        name: &field::Key,
-        value: &dyn field::Value,
-    ) -> Result<(), RecordError>;
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -182,15 +174,6 @@ impl RegisterSpan for IncreasingCounter {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         id
-    }
-
-    fn record(
-        &self,
-        _span: &Id,
-        _name: &field::Key,
-        _value: &dyn field::Value,
-    ) -> Result<(), RecordError> {
-        unimplemented!("TODO: figure out")
     }
 
     fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -8,7 +8,7 @@ extern crate tokio_trace_futures;
 use std::marker::PhantomData;
 
 use futures::{Future, Poll};
-use tokio_trace::field::Value;
+use tokio_trace::field;
 use tokio_trace_futures::{Instrument, Instrumented};
 use tower_service::{MakeService, Service};
 
@@ -109,10 +109,10 @@ where
                 "request",
                 // TODO: custom `Value` impls for `http` types would be nicer
                 // than just sticking these in `debug`s...
-                method = &Value::debug(request.method()),
-                version = &Value::debug(request.version()),
-                uri = &Value::debug(request.uri()),
-                headers = &Value::debug(request.headers())
+                method = &field::debug(request.method()),
+                version = &field::debug(request.version()),
+                uri = &field::debug(request.uri()),
+                headers = &field::debug(request.headers())
             ).enter(move || inner.call(request).in_current_span())
         })
     }

--- a/tokio-trace-tower/src/lib.rs
+++ b/tokio-trace-tower/src/lib.rs
@@ -5,7 +5,7 @@ extern crate futures;
 extern crate tokio_trace_futures;
 
 use std::fmt;
-use tokio_trace::field::Value;
+use tokio_trace::field;
 use tokio_trace_futures::{Instrument, Instrumented};
 use tower_service::Service;
 
@@ -42,7 +42,7 @@ where
         let inner = &mut self.inner;
         span.enter(|| {
             // TODO: custom `Value` impls for `http` types would be nice...
-            span!("request", request = &Value::debug(&req))
+            span!("request", request = &field::debug(&req))
                 .enter(move || inner.call(req).in_current_span())
         })
     }

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -35,7 +35,7 @@ fn bench_costly_field_no_subscriber(b: &mut Bencher) {
         (0..n).fold(0, |old, new| {
             span!(
                 "span",
-                foo = tokio_trace::Value::display(format!("bar {:?}", 2))
+                foo = tokio_trace::field::display(format!("bar {:?}", 2))
             );
             old ^ new
         })

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -133,6 +133,14 @@ fn span_with_fields(b: &mut Bencher) {
 #[bench]
 fn span_with_fields_record(b: &mut Bencher) {
     tokio_trace::Dispatch::new(Record(Mutex::new(None))).as_default(|| {
-        b.iter(|| span!("span", foo = "foo", bar = "bar", baz = 3, quuux = tokio_trace::field::debug(0.99)))
+        b.iter(|| {
+            span!(
+                "span",
+                foo = "foo",
+                bar = "bar",
+                baz = 3,
+                quuux = tokio_trace::field::debug(0.99)
+            )
+        })
     });
 }

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -121,7 +121,7 @@ fn span_with_fields(b: &mut Bencher) {
                 foo = "foo",
                 bar = "bar",
                 baz = 3u64,
-                quuux = tokio_trace::Value::debug(0.99)
+                quuux = tokio_trace::field::debug(0.99)
             )
         })
     });

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -1,4 +1,7 @@
 #![feature(test)]
+
+#[macro_use]
+extern crate tokio_trace;
 extern crate test;
 use test::Bencher;
 
@@ -120,17 +123,16 @@ fn span_with_fields(b: &mut Bencher) {
                 "span",
                 foo = "foo",
                 bar = "bar",
-                baz = 3u64,
+                baz = 3,
                 quuux = tokio_trace::field::debug(0.99)
             )
         })
     });
 }
 
-// TODO: bring this back
-// #[bench]
-// fn span_with_fields_add_data(b: &mut Bencher) {
-//     tokio_trace::Dispatch::new(Record(Mutex::new(None))).as_default(|| {
-//         b.iter(|| span!("span", foo = &"foo", bar = &"bar", baz = &3, quuux = &0.99))
-//     });
-// }
+#[bench]
+fn span_with_fields_record(b: &mut Bencher) {
+    tokio_trace::Dispatch::new(Record(Mutex::new(None))).as_default(|| {
+        b.iter(|| span!("span", foo = "foo", bar = "bar", baz = 3, quuux = tokio_trace::field::debug(0.99)))
+    });
+}

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,7 +3,7 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{Level, Span, Value};
+use tokio_trace::{Level, Span, field};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
@@ -12,17 +12,17 @@ fn main() {
         .finish();
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
-        let foo: u64 = 3;
+        let foo = 3;
         event!(Level::Info, { foo = foo, bar = "bar" }, "hello world");
 
-        span!("my_great_span", foo = 4u64, baz = 5u64).enter(|| {
+        span!("my_great_span", foo = 4, baz = 5).enter(|| {
             Span::current().close();
 
             event!(Level::Info, { yak_shaved = true }, "hi from inside my span");
             span!("my other span", quux = "quuuux").enter(|| {
                 event!(
                     Level::Debug,
-                    { depth = Value::display("very") },
+                    { depth = field::display("very") },
                     "hi from inside both my spans!"
                 );
             })

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -3,7 +3,7 @@ extern crate tokio_trace;
 extern crate env_logger;
 extern crate tokio_trace_log;
 
-use tokio_trace::{Level, Span, field};
+use tokio_trace::{field, Level, Span};
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -136,9 +136,9 @@ fn main() {
         let mut foo: u64 = 2;
         span!("my_great_span", foo_count = &foo).enter(|| {
             foo += 1;
-            event!(Level::Info, { yak_shaved = true, yak_count = 1i64 }, "hi from inside my span");
-            span!("my other span", foo_count = &foo, baz_count = &5u64).enter(|| {
-                event!(Level::Warn, { yak_shaved = false, yak_count = 2i64 }, "failed to shave yak");
+            event!(Level::Info, { yak_shaved = true, yak_count = 1 }, "hi from inside my span");
+            span!("my other span", foo_count = &foo, baz_count = 5).enter(|| {
+                event!(Level::Warn, { yak_shaved = false, yak_count = -1 }, "failed to shave yak");
             });
         });
     });

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -22,27 +22,27 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {
-        span!("", version = &field::Value::display(5.0)).enter(|| {
-            span!("server", host = "localhost", port = 8080u64).enter(|| {
+        span!("", version = &field::display(5.0)).enter(|| {
+            span!("server", host = "localhost", port = 8080).enter(|| {
                 event!(Level::Info, {}, "starting");
                 event!(Level::Info, {}, "listening");
-                let mut peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381u64);
+                let mut peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381);
                 peer1.enter(|| {
                     event!(Level::Debug, {}, "connected");
-                    event!(Level::Debug, { length = 2u64 }, "message received");
+                    event!(Level::Debug, { length = 2 }, "message received");
                 });
-                let mut peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230u64);
+                let mut peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230);
                 peer2.enter(|| {
                     event!(Level::Debug, {}, "connected");
                 });
                 peer1.enter(|| {
                     event!(Level::Warn, { algo = "xor" }, "weak encryption requested");
-                    event!(Level::Debug, { length = 8u64 }, "response sent");
+                    event!(Level::Debug, { length = 8 }, "response sent");
                     event!(Level::Debug, {}, "disconnected");
                 });
                 peer2.enter(|| {
-                    event!(Level::Debug, { length = 5u64 }, "message received");
-                    event!(Level::Debug, { length = 8u64 }, "response sent");
+                    event!(Level::Debug, { length = 5 }, "message received");
+                    event!(Level::Debug, { length = 8 }, "response sent");
                     event!(Level::Debug, {}, "disconnected");
                 });
                 event!(Level::Error, {}, "internal error");

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,7 +1,7 @@
 pub use tokio_trace_core::field::*;
 
 use std::fmt;
-use {Meta, ::subscriber::RecordError};
+use {subscriber::RecordError, Meta};
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
@@ -31,7 +31,8 @@ pub trait Record {
     /// - The span has a field with the given name, but the value has already
     ///   been set.
     fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
-    where Q: AsKey;
+    where
+        Q: AsKey;
 
     /// Record an umsigned 64-bit integer value.
     ///
@@ -45,7 +46,8 @@ pub trait Record {
     /// - The span has a field with the given name, but the value has already
     ///   been set.
     fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
-    where Q: AsKey;
+    where
+        Q: AsKey;
 
     /// Record a boolean value.
     ///
@@ -59,7 +61,8 @@ pub trait Record {
     /// - The span has a field with the given name, but the value has already
     ///   been set.
     fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
-    where Q: AsKey;
+    where
+        Q: AsKey;
 
     /// Record a string value.
     ///
@@ -73,7 +76,8 @@ pub trait Record {
     /// - The span has a field with the given name, but the value has already
     ///   been set.
     fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
-    where Q: AsKey;
+    where
+        Q: AsKey;
 
     /// Record a set of pre-compiled format arguments.
     ///
@@ -87,7 +91,8 @@ pub trait Record {
         field: &Q,
         value: fmt::Arguments,
     ) -> Result<(), RecordError>
-    where Q: AsKey;
+    where
+        Q: AsKey;
 }
 
 /// A field value of an erased type.
@@ -114,7 +119,6 @@ pub struct DisplayValue<T: fmt::Display>(T);
 /// A `Value` which serializes as a string using `fmt::Debug`.
 #[derive(Clone)]
 pub struct DebugValue<T: fmt::Debug>(T);
-
 
 /// Wraps a type implementing `fmt::Display` as a `Value` that can be
 /// recorded using its `Display` implementation.
@@ -231,11 +235,7 @@ impl<'a, T: ?Sized> Value for &'a T
 where
     T: Value + 'a,
 {
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    ) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
     where
         Q: AsKey,
         R: Record,
@@ -244,18 +244,13 @@ where
     }
 }
 
-
 // ===== impl DisplayValue =====
 
 impl<T> Value for DisplayValue<T>
 where
     T: fmt::Display,
 {
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    ) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
     where
         Q: AsKey,
         R: Record,
@@ -270,11 +265,7 @@ impl<T: fmt::Debug> Value for DebugValue<T>
 where
     T: fmt::Debug,
 {
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    ) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
     where
         Q: AsKey,
         R: Record,

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,5 +1,7 @@
 pub use tokio_trace_core::field::*;
-use Meta;
+
+use std::fmt;
+use {Meta, ::subscriber::RecordError};
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
@@ -14,6 +16,168 @@ pub trait AsKey {
     /// If `metadata` defines a key corresponding to this field, then the key is
     /// returned. Otherwise, this function returns `None`.
     fn as_key<'a>(&self, metadata: &'a Meta<'a>) -> Option<Key<'a>>;
+}
+
+pub trait Record {
+    /// Record a signed 64-bit integer value.
+    ///
+    /// This defaults to calling `self.record_fmt()`; implementations wishing to
+    /// provide behaviour specific to signed integers may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    where Q: AsKey;
+
+    /// Record an umsigned 64-bit integer value.
+    ///
+    /// This defaults to calling `self.record_fmt()`; implementations wishing to
+    /// provide behaviour specific to unsigned integers may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    where Q: AsKey;
+
+    /// Record a boolean value.
+    ///
+    /// This defaults to calling `self.record_fmt()`; implementations wishing to
+    /// provide behaviour specific to booleans may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    where Q: AsKey;
+
+    /// Record a string value.
+    ///
+    /// This defaults to calling `self.record_str()`; implementations wishing to
+    /// provide behaviour specific to strings may override the default
+    /// implementation.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    where Q: AsKey;
+
+    /// Record a set of pre-compiled format arguments.
+    ///
+    /// This is expected to return an error under the following conditions:
+    /// - The span ID does not correspond to a span which currently exists.
+    /// - The span does not have a field with the given name.
+    /// - The span has a field with the given name, but the value has already
+    ///   been set.
+    fn record_fmt<Q: ?Sized>(
+        &mut self,
+        field: &Q,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError>
+    where Q: AsKey;
+}
+
+/// A field value of an erased type.
+///
+/// Implementors of `Value` may call the appropriate typed recording methods on
+/// the `Subscriber` passed to `record` in order to indicate how their data
+/// should be recorded.
+pub trait Value {
+    /// Records this value with the given `Subscriber`.
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), ::subscriber::RecordError>
+    where
+        Q: AsKey,
+        R: Record;
+}
+
+/// A `Value` which serializes as a string using `fmt::Display`.
+#[derive(Clone)]
+pub struct DisplayValue<T: fmt::Display>(T);
+
+/// A `Value` which serializes as a string using `fmt::Debug`.
+#[derive(Clone)]
+pub struct DebugValue<T: fmt::Debug>(T);
+
+
+/// Wraps a type implementing `fmt::Display` as a `Value` that can be
+/// recorded using its `Display` implementation.
+pub fn display<'a, T>(t: T) -> DisplayValue<T>
+where
+    T: fmt::Display,
+{
+    DisplayValue(t)
+}
+
+// ===== impl Value =====
+
+/// Wraps a type implementing `fmt::Debug` as a `Value` that can be
+/// recorded using its `Debug` implementation.
+pub fn debug<T>(t: T) -> DebugValue<T>
+where
+    T: fmt::Debug,
+{
+    DebugValue(t)
+}
+
+macro_rules! impl_values {
+    ( $( $record:ident( $( $whatever:tt)+ ) ),+ ) => {
+        $(
+            impl_value!{ $record( $( $whatever )+ ) }
+        )+
+    }
+}
+macro_rules! impl_value {
+    ( $record:ident( $( $value_ty:ty ),+ ) ) => {
+        $(
+            impl $crate::field::Value for $value_ty {
+                fn record<Q: ?Sized, R>(
+                    &self,
+                    key: &Q,
+                    recorder: &mut R,
+                ) -> Result<(), $crate::subscriber::RecordError>
+                where
+                    Q: $crate::field::AsKey,
+                    R: $crate::field::Record,
+                {
+                    recorder.$record(key, *self)
+                }
+            }
+        )+
+    };
+    ( $record:ident( $( $value_ty:ty ),+ as $as_ty:ty) ) => {
+        $(
+            impl Value for $value_ty {
+                fn record<Q: ?Sized, R>(
+                    &self,
+                    key: &Q,
+                    recorder: &mut R,
+                ) -> Result<(), $crate::subscriber::RecordError>
+                where
+                    Q: $crate::field::AsKey,
+                    R: $crate::field::Record,
+                {
+                    recorder.$record(key, *self as $as_ty)
+                }
+            }
+        )+
+    };
 }
 
 // ===== impl AsKey =====
@@ -36,5 +200,85 @@ impl AsKey for str {
     #[inline]
     fn as_key<'a>(&self, metadata: &'a Meta<'a>) -> Option<Key<'a>> {
         metadata.key_for(&self)
+    }
+}
+
+// ===== impl Value =====
+
+impl_values! {
+    record_u64(u64),
+    record_u64(usize, u32, u16 as u64),
+    record_i64(i64),
+    record_i64(isize, i32, i16, i8 as i64),
+    record_bool(bool)
+}
+
+impl Value for str {
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), ::subscriber::RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        recorder.record_str(key, &self)
+    }
+}
+
+impl<'a, T: ?Sized> Value for &'a T
+where
+    T: Value + 'a,
+{
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        (*self).record(key, recorder)
+    }
+}
+
+
+// ===== impl DisplayValue =====
+
+impl<T> Value for DisplayValue<T>
+where
+    T: fmt::Display,
+{
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        recorder.record_fmt(key, format_args!("{}", self.0))
+    }
+}
+
+// ===== impl DebugValue =====
+
+impl<T: fmt::Debug> Value for DebugValue<T>
+where
+    T: fmt::Debug,
+{
+    fn record<Q: ?Sized, R>(
+        &self,
+        key: &Q,
+        recorder: &mut R,
+    ) -> Result<(), RecordError>
+    where
+        Q: AsKey,
+        R: Record,
+    {
+        recorder.record_fmt(key, format_args!("{:?}", self.0))
     }
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -97,7 +97,7 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
-            use $crate::{callsite, callsite::Callsite, Span};
+            use $crate::{callsite, callsite::Callsite, Span,  span::SpanExt, field::{Value, AsKey}};
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
             // not actually be used, but it doesn't make sense to repeat it.
@@ -125,7 +125,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
-            use $crate::{callsite, SpanAttributes, Id, Subscriber, Event, field::Value};
+            use $crate::{callsite, Id, Subscriber, Event, span::SpanExt, field::{Value, AsKey}};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:
                 $lvl,
@@ -170,11 +170,11 @@ pub mod subscriber;
 pub use self::{
     dispatcher::Dispatch,
     field::Value,
-    span::{Attributes, Id, Span, SpanAttributes},
+    span::{Attributes, Event, Id, Span, SpanAttributes},
     subscriber::Subscriber,
     tokio_trace_core::{
         callsite::{self, Callsite},
-        Event, Level, Meta, MetaKind,
+        Level, Meta, MetaKind,
     },
 };
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -196,14 +196,14 @@
 //! [`Attributes`]: ::span::Attributes
 //! [shared span]: ::span::Shared
 //! [`IntoShared`]: ::span::IntoShared
-pub use tokio_trace_core::span::{Attributes, Id, Span, SpanAttributes};
+pub use tokio_trace_core::span::{Attributes, Id, Span, Event, SpanAttributes};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 use tokio_trace_core::span::Enter;
-use {field, subscriber};
+use {field, subscriber::{self, RecordError}};
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
 pub trait IntoShared {
@@ -213,14 +213,12 @@ pub trait IntoShared {
     fn into_shared(self) -> Shared;
 }
 
-pub trait SpanExt: ::sealed::Sealed {
-    fn record_field<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: &dyn field::Value,
-    ) -> Result<(), subscriber::RecordError>
+pub trait SpanExt: field::Record + ::sealed::Sealed {
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
     where
-        Q: field::AsKey;
+        Q: field::AsKey,
+        V: field::Value,
+    ;
 
     fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
     where
@@ -300,26 +298,6 @@ impl Shared {
         self.inner.is_some()
     }
 
-    /// Sets the field on this span named `name` to the given `value`.
-    ///
-    /// `name` must name a field already defined by this span's metadata, and
-    /// the field must not already have a value. If this is not the case, this
-    /// function returns an [`RecordError`](::subscriber::RecordError).
-    pub fn record<Q: field::AsKey>(
-        &self,
-        field: &Q,
-        value: &dyn field::Value,
-    ) -> Result<(), subscriber::RecordError> {
-        if let Some(ref inner) = self.inner {
-            let field = field
-                .as_key(inner.metadata())
-                .ok_or_else(subscriber::RecordError::no_field)?;
-            inner.record(&field, value)
-        } else {
-            Ok(())
-        }
-    }
-
     /// Indicates that the span with the given ID has an indirect causal
     /// relationship with this span.
     ///
@@ -346,23 +324,6 @@ impl Shared {
 impl ::sealed::Sealed for Span {}
 
 impl SpanExt for Span {
-    fn record_field<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: &dyn field::Value,
-    ) -> Result<(), subscriber::RecordError>
-    where
-        Q: field::AsKey,
-    {
-        if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(subscriber::RecordError::no_field)?;
-            self.record(&key, value)
-        } else {
-            Ok(())
-        }
-    }
     fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
     where
         Q: field::AsKey,
@@ -370,6 +331,187 @@ impl SpanExt for Span {
         self.metadata()
             .and_then(|meta| field.as_key(meta))
             .is_some()
+    }
+
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+        V: field::Value,
+    {
+        value.record(field, self)
+    }
+}
+
+impl field::Record for Span {
+    #[inline]
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_i64(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_u64(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_bool(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_str(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_fmt<Q: ?Sized>(
+        &mut self,
+        field: &Q,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_fmt(&key, value)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> field::Record for Event<'a> {
+    #[inline]
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_i64(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_u64(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_bool(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_str(&key, value)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn record_fmt<Q: ?Sized>(
+        &mut self,
+        field: &Q,
+        value: fmt::Arguments,
+    ) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+    {
+        if let Some(meta) = self.metadata() {
+            let key = field
+                .as_key(meta)
+                .ok_or_else(RecordError::no_field)?;
+            self.record_value_fmt(&key, value)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> ::sealed::Sealed for Event<'a> {}
+
+impl<'a> SpanExt for Event<'a> {
+    fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
+    where
+        Q: field::AsKey,
+    {
+        self.metadata()
+            .and_then(|meta| field.as_key(meta))
+            .is_some()
+    }
+
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
+    where
+        Q: field::AsKey,
+        V: field::Value,
+    {
+        value.record(field, self)
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -196,14 +196,17 @@
 //! [`Attributes`]: ::span::Attributes
 //! [shared span]: ::span::Shared
 //! [`IntoShared`]: ::span::IntoShared
-pub use tokio_trace_core::span::{Attributes, Id, Span, Event, SpanAttributes};
+pub use tokio_trace_core::span::{Attributes, Event, Id, Span, SpanAttributes};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};
 
 use std::{fmt, sync::Arc};
 use tokio_trace_core::span::Enter;
-use {field, subscriber::{self, RecordError}};
+use {
+    field,
+    subscriber::{self, RecordError},
+};
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
 pub trait IntoShared {
@@ -217,8 +220,7 @@ pub trait SpanExt: field::Record + ::sealed::Sealed {
     fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
     where
         Q: field::AsKey,
-        V: field::Value,
-    ;
+        V: field::Value;
 
     fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
     where
@@ -349,9 +351,7 @@ impl field::Record for Span {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_i64(&key, value)?;
         }
         Ok(())
@@ -363,9 +363,7 @@ impl field::Record for Span {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_u64(&key, value)?;
         }
         Ok(())
@@ -377,9 +375,7 @@ impl field::Record for Span {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_bool(&key, value)?;
         }
         Ok(())
@@ -391,27 +387,19 @@ impl field::Record for Span {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_str(&key, value)?;
         }
         Ok(())
     }
 
     #[inline]
-    fn record_fmt<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: fmt::Arguments,
-    ) -> Result<(), RecordError>
+    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments) -> Result<(), RecordError>
     where
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_fmt(&key, value)?;
         }
         Ok(())
@@ -425,9 +413,7 @@ impl<'a> field::Record for Event<'a> {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_i64(&key, value)?;
         }
         Ok(())
@@ -439,9 +425,7 @@ impl<'a> field::Record for Event<'a> {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_u64(&key, value)?;
         }
         Ok(())
@@ -453,9 +437,7 @@ impl<'a> field::Record for Event<'a> {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_bool(&key, value)?;
         }
         Ok(())
@@ -467,27 +449,19 @@ impl<'a> field::Record for Event<'a> {
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_str(&key, value)?;
         }
         Ok(())
     }
 
     #[inline]
-    fn record_fmt<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: fmt::Arguments,
-    ) -> Result<(), RecordError>
+    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments) -> Result<(), RecordError>
     where
         Q: field::AsKey,
     {
         if let Some(meta) = self.metadata() {
-            let key = field
-                .as_key(meta)
-                .ok_or_else(RecordError::no_field)?;
+            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
             self.record_value_fmt(&key, value)?;
         }
         Ok(())


### PR DESCRIPTION
This branch removes the `Value` trait from `tokio-trace-core`.

Since the dispatch of value types to subscriber methods which that
trait provided was really only necessary for the `event!` and `span!`
macros in the `tokio-trace` crate, it was moved to that crate. This
simplifies `core`'s field module significantly, and doesn't require
this trait to be part of the stable API (yet).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>