### PR TITLE
Remove errors from `core::Subscriber`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -1,7 +1,7 @@
 use {
     callsite, field,
     span::{self, Span},
-    subscriber::{self, RecordError, Subscriber},
+    subscriber::{self, Subscriber},
     Id, Meta,
 };
 
@@ -102,22 +102,22 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) -> Result<(), RecordError> {
+    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) {
         self.subscriber.record_i64(span, field, value)
     }
 
     #[inline]
-    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) -> Result<(), RecordError> {
+    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) {
         self.subscriber.record_u64(span, field, value)
     }
 
     #[inline]
-    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) -> Result<(), RecordError> {
+    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) {
         self.subscriber.record_bool(span, field, value)
     }
 
     #[inline]
-    fn record_str(&self, span: &Id, field: &field::Key, value: &str) -> Result<(), RecordError> {
+    fn record_str(&self, span: &Id, field: &field::Key, value: &str) {
         self.subscriber.record_str(span, field, value)
     }
 
@@ -127,12 +127,12 @@ impl Subscriber for Dispatch {
         span: &Id,
         field: &field::Key,
         value: fmt::Arguments,
-    ) -> Result<(), RecordError> {
+    ) {
         self.subscriber.record_fmt(span, field, value)
     }
 
     #[inline]
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         self.subscriber.add_follows_from(span, follows)
     }
 
@@ -178,13 +178,9 @@ impl Subscriber for NoSubscriber {
         _span: &Id,
         _key: &field::Key,
         _value: fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        Ok(())
-    }
+    ) {}
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
-        Ok(())
-    }
+    fn add_follows_from(&self, _span: &Id, _follows: Id) {}
 
     fn enabled(&self, _metadata: &Meta) -> bool {
         false

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -122,12 +122,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record_fmt(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: fmt::Arguments,
-    ) {
+    fn record_fmt(&self, span: &Id, field: &field::Key, value: fmt::Arguments) {
         self.subscriber.record_fmt(span, field, value)
     }
 
@@ -173,12 +168,7 @@ impl Subscriber for NoSubscriber {
         Id::from_u64(0)
     }
 
-    fn record_fmt(
-        &self,
-        _span: &Id,
-        _key: &field::Key,
-        _value: fmt::Arguments,
-    ) {}
+    fn record_fmt(&self, _span: &Id, _key: &field::Key, _value: fmt::Arguments) {}
 
     fn add_follows_from(&self, _span: &Id, _follows: Id) {}
 

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -250,7 +250,7 @@ impl Span {
             .and_then(|inner| inner.meta.key_for(name))
     }
     /// Record a signed 64-bit integer value.
-    pub fn record_value_i64(&mut self, field: &Key, value: i64) ->  &Self {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> &Self {
         if let Some(ref inner) = self.inner {
             inner.record_value_i64(field, value);
         }
@@ -400,11 +400,7 @@ impl<'a> Event<'a> {
     }
 
     /// Adds a formattable message describing the event that occurred.
-    pub fn message(
-        &mut self,
-        key: &field::Key,
-        message: fmt::Arguments,
-    ) -> &mut Self {
+    pub fn message(&mut self, key: &field::Key, message: fmt::Arguments) -> &mut Self {
         if let Some(ref mut inner) = self.inner {
             inner.subscriber.record_fmt(&inner.id, key, message);
         }
@@ -412,7 +408,7 @@ impl<'a> Event<'a> {
     }
 
     /// Record a signed 64-bit integer value.
-    pub fn record_value_i64(&mut self, field: &Key, value: i64) ->  &Self {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> &Self {
         if let Some(ref inner) = self.inner {
             inner.record_value_i64(field, value);
         }
@@ -613,7 +609,6 @@ impl<'a> Inner<'a> {
         if self.meta.contains_key(field) {
             self.subscriber.record_i64(&self.id, field, value)
         }
-
     }
 
     /// Record an umsigned 64-bit integer value.
@@ -638,11 +633,7 @@ impl<'a> Inner<'a> {
     }
 
     /// Record a precompiled set of format arguments value.
-    pub(crate) fn record_value_fmt(
-        &self,
-        field: &Key,
-        value: fmt::Arguments,
-    ) {
+    pub(crate) fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) {
         if !self.meta.contains_key(field) {
             self.subscriber.record_fmt(&self.id, field, value)
         }

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -9,7 +9,7 @@ use std::{
 use {
     callsite::Callsite,
     field::{self, Key},
-    subscriber::{FollowsError, Interest, RecordError, Subscriber},
+    subscriber::{Interest, Subscriber},
     Dispatch, Meta,
 };
 
@@ -249,75 +249,44 @@ impl Span {
             .as_ref()
             .and_then(|inner| inner.meta.key_for(name))
     }
-
     /// Record a signed 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) ->  &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_i64(field, value)?;
+            inner.record_value_i64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_u64(field, value)?;
+            inner.record_value_u64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a boolean value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_bool(field, value)?;
+            inner.record_value_bool(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a string value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+    pub fn record_value_str(&self, field: &Key, value: &str) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_str(field, value)?;
+            inner.record_value_str(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a precompiled set of format arguments.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_fmt(field, value)?;
+            inner.record_value_fmt(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Signals that this span should close the next time it is exited, or when
@@ -355,14 +324,13 @@ impl Span {
     /// executing. This is used to model causal relationships such as when a
     /// single future spawns several related background tasks, et cetera.
     ///
-    /// If this span is disabled, this function will do nothing. Otherwise, it
-    /// returns `Ok(())` if the other span was added as a precedent of this
-    /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
-        self.inner
-            .as_ref()
-            .map(move |inner| inner.follows_from(from))
-            .unwrap_or(Ok(()))
+    /// If this span is disabled, or the resulting follows-from relationship
+    /// would be invalid, this function will do nothing.
+    pub fn follows_from(&self, from: Id) -> &Self {
+        if let Some(ref inner) = self.inner {
+            inner.follows_from(from);
+        }
+        self
     }
 
     /// Returns this span's `Id`, if it is enabled.
@@ -436,81 +404,51 @@ impl<'a> Event<'a> {
         &mut self,
         key: &field::Key,
         message: fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
+    ) -> &mut Self {
         if let Some(ref mut inner) = self.inner {
-            inner.subscriber.record_fmt(&inner.id, key, message)?;
+            inner.subscriber.record_fmt(&inner.id, key, message);
         }
-        Ok(())
+        self
     }
 
     /// Record a signed 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_i64(&mut self, field: &Key, value: i64) -> Result<(), RecordError> {
+    pub fn record_value_i64(&mut self, field: &Key, value: i64) ->  &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_i64(field, value)?;
+            inner.record_value_i64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
+    pub fn record_value_u64(&self, field: &Key, value: u64) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_u64(field, value)?;
+            inner.record_value_u64(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a boolean value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
+    pub fn record_value_bool(&self, field: &Key, value: bool) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_bool(field, value)?;
+            inner.record_value_bool(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a string value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
+    pub fn record_value_str(&self, field: &Key, value: &str) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_str(field, value)?;
+            inner.record_value_str(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Record a precompiled set of format arguments.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> Result<(), RecordError> {
+    pub fn record_value_fmt(&self, field: &Key, value: fmt::Arguments) -> &Self {
         if let Some(ref inner) = self.inner {
-            inner.record_value_fmt(field, value)?;
+            inner.record_value_fmt(field, value);
         }
-        Ok(())
+        self
     }
 
     /// Returns the `Id` of the parent of this span, if one exists.
@@ -536,7 +474,7 @@ impl<'a> Event<'a> {
     }
 
     /// Indicates that the span with the given ID has an indirect causal
-    /// relationship with this span.
+    /// relationship with this event.
     ///
     /// This relationship differs somewhat from the parent-child relationship: a
     /// span may have any number of prior spans, rather than a single one; and
@@ -547,14 +485,13 @@ impl<'a> Event<'a> {
     /// executing. This is used to model causal relationships such as when a
     /// single future spawns several related background tasks, et cetera.
     ///
-    /// If this span is disabled, this function will do nothing. Otherwise, it
-    /// returns `Ok(())` if the other span was added as a precedent of this
-    /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
-        self.inner
-            .as_ref()
-            .map(move |inner| inner.follows_from(from))
-            .unwrap_or(Ok(()))
+    /// If this event is disabled, or the resulting follows-from relationship
+    /// would be invalid, this function will do nothing.
+    pub fn follows_from(&self, from: Id) -> &Self {
+        if let Some(ref inner) = self.inner {
+            inner.follows_from(from);
+        }
+        self
     }
 
     /// Returns this span's `Id`, if it is enabled.
@@ -652,7 +589,7 @@ impl<'a> Inner<'a> {
     /// If this span is disabled, this function will do nothing. Otherwise, it
     /// returns `Ok(())` if the other span was added as a precedent of this
     /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), FollowsError> {
+    pub fn follows_from(&self, from: Id) {
         self.subscriber.add_follows_from(&self.id, from)
     }
 
@@ -672,82 +609,43 @@ impl<'a> Inner<'a> {
     }
 
     /// Record a signed 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_i64(&self, field: &Key, value: i64) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_i64(&self, field: &Key, value: i64) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_i64(&self.id, field, value)
         }
 
-        self.subscriber.record_i64(&self.id, field, value)
     }
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_u64(&self, field: &Key, value: u64) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_u64(&self, field: &Key, value: u64) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_u64(&self.id, field, value)
         }
-
-        self.subscriber.record_u64(&self.id, field, value)
     }
 
     /// Record a boolean value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_bool(&self, field: &Key, value: bool) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_bool(&self, field: &Key, value: bool) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_bool(&self.id, field, value)
         }
-
-        self.subscriber.record_bool(&self.id, field, value)
     }
 
     /// Record a string value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    pub(crate) fn record_value_str(&self, field: &Key, value: &str) -> Result<(), RecordError> {
-        if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+    pub(crate) fn record_value_str(&self, field: &Key, value: &str) {
+        if self.meta.contains_key(field) {
+            self.subscriber.record_str(&self.id, field, value)
         }
-
-        self.subscriber.record_str(&self.id, field, value)
     }
 
     /// Record a precompiled set of format arguments value.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
     pub(crate) fn record_value_fmt(
         &self,
         field: &Key,
         value: fmt::Arguments,
-    ) -> Result<(), RecordError> {
+    ) {
         if !self.meta.contains_key(field) {
-            return Err(RecordError::no_field());
+            self.subscriber.record_fmt(&self.id, field, value)
         }
-
-        self.subscriber.record_fmt(&self.id, field, value)
     }
 
     fn new(id: Id, parent: Option<Id>, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -192,12 +192,7 @@ pub trait Subscriber {
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_fmt(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: fmt::Arguments,
-    );
+    fn record_fmt(&self, span: &Id, field: &field::Key, value: fmt::Arguments);
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -486,12 +481,7 @@ mod test_support {
             (self.filter)(meta)
         }
 
-        fn record_fmt(
-            &self,
-            _id: &Id,
-            _field: &field::Key,
-            _value: ::std::fmt::Arguments,
-        ) {
+        fn record_fmt(&self, _id: &Id, _field: &field::Key, _value: ::std::fmt::Arguments) {
             // TODO: it would be nice to be able to expect field values...
         }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -1,7 +1,7 @@
 //! Subscribers collect and record trace data.
 use {field, span, Id, Meta};
 
-use std::{error::Error, fmt};
+use std::fmt;
 
 /// Trait representing the functions required to collect trace data.
 ///
@@ -314,40 +314,6 @@ enum InterestKind {
     Never = 0,
     Sometimes = 1,
     Always = 2,
-}
-
-/// Errors which may prevent a value from being successfully added to a span.
-#[derive(Debug)]
-pub struct RecordError {
-    kind: RecordErrorKind,
-}
-
-#[derive(Debug)]
-enum RecordErrorKind {
-    /// The span with the given ID does not exist.
-    NoSpan(Id),
-    /// The span exists, but does not have the specified field.
-    NoField,
-    /// The named field already has a value.
-    AlreadyExists,
-    /// An error occurred recording the field.
-    Record,
-}
-
-/// Errors which may prevent a span from following another span.
-#[derive(Debug)]
-pub struct FollowsError {
-    kind: FollowsErrorKind,
-}
-
-#[derive(Debug)]
-enum FollowsErrorKind {
-    /// The span with the given ID does not exist.
-    /// TODO: can this error type be generalized between `FollowsError` and
-    /// `RecordError`?
-    NoSpan(Id),
-    /// The span that this span follows from does not exist (it has no ID).
-    NoPreceedingId,
 }
 
 impl Interest {

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -141,12 +141,10 @@ pub trait Subscriber {
     /// provide behaviour specific to signed integers may override the default
     /// implementation.
     ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) -> Result<(), RecordError> {
+    /// If recording the field is invalid (i.e. the span ID doesn't exist, the
+    /// field has already been recorded, and so on), the subscriber may silently
+    /// do nothing.
+    fn record_i64(&self, span: &Id, field: &field::Key, value: i64) {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -156,12 +154,10 @@ pub trait Subscriber {
     /// provide behaviour specific to unsigned integers may override the default
     /// implementation.
     ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) -> Result<(), RecordError> {
+    /// If recording the field is invalid (i.e. the span ID doesn't exist, the
+    /// field has already been recorded, and so on), the subscriber may silently
+    /// do nothing.
+    fn record_u64(&self, span: &Id, field: &field::Key, value: u64) {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -171,12 +167,10 @@ pub trait Subscriber {
     /// provide behaviour specific to booleans may override the default
     /// implementation.
     ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) -> Result<(), RecordError> {
+    /// If recording the field is invalid (i.e. the span ID doesn't exist, the
+    /// field has already been recorded, and so on), the subscriber may silently
+    /// do nothing.
+    fn record_bool(&self, span: &Id, field: &field::Key, value: bool) {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
@@ -186,28 +180,24 @@ pub trait Subscriber {
     /// provide behaviour specific to strings may override the default
     /// implementation.
     ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_str(&self, span: &Id, field: &field::Key, value: &str) -> Result<(), RecordError> {
+    /// If recording the field is invalid (i.e. the span ID doesn't exist, the
+    /// field has already been recorded, and so on), the subscriber may silently
+    /// do nothing.
+    fn record_str(&self, span: &Id, field: &field::Key, value: &str) {
         self.record_fmt(span, field, format_args!("{}", value))
     }
 
-    /// Record a set of pre-compile``d format arguments.
+    /// Record a set of pre-compiled format arguments.
     ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
+    /// If recording the field is invalid (i.e. the span ID doesn't exist, the
+    /// field has already been recorded, and so on), the subscriber may silently
+    /// do nothing.
     fn record_fmt(
         &self,
         span: &Id,
         field: &field::Key,
         value: fmt::Arguments,
-    ) -> Result<(), RecordError>;
+    );
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -226,10 +216,8 @@ pub trait Subscriber {
     /// if one or both of the given span IDs do not correspond to spans that the
     /// subscriber knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
-    /// follow from _b_), it should return a [`FollowsError`].
-    ///
-    /// [`FollowsError`]: FollowsError
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError>;
+    /// follow from _b_), it may silently do nothing.
+    fn add_follows_from(&self, span: &Id, follows: Id);
 
     // === Filtering methods ==================================================
 
@@ -412,137 +400,6 @@ impl Interest {
     }
 }
 
-// ===== impl RecordError =====
-
-impl RecordError {
-    /// Returns an error indicating that no span exists for the given `id`.
-    pub fn no_span(id: Id) -> Self {
-        Self {
-            kind: RecordErrorKind::NoSpan(id),
-        }
-    }
-
-    /// Returns an error indicating that the span exists, but does not have the
-    /// specified field.
-    pub fn no_field() -> Self {
-        Self {
-            kind: RecordErrorKind::NoField,
-        }
-    }
-
-    /// Return an error indicating that the named field already has a value.
-    pub fn already_exists() -> Self {
-        Self {
-            kind: RecordErrorKind::AlreadyExists,
-        }
-    }
-
-    /// Returns an error indicating that an error occurred recording the field.
-    pub fn record() -> Self {
-        Self {
-            kind: RecordErrorKind::Record,
-        }
-    }
-
-    /// Returns `true` if this error was due to no span existing for the
-    /// specified field.
-    pub fn is_no_span(&self) -> bool {
-        match self.kind {
-            RecordErrorKind::NoSpan(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Returns `true` if this error was due to no field existing with the
-    /// specified name.
-    pub fn is_no_field(&self) -> bool {
-        match self.kind {
-            RecordErrorKind::NoField => true,
-            _ => false,
-        }
-    }
-
-    /// Returns `true` if this error was due to the named field already
-    /// existing.
-    pub fn is_already_exists(&self) -> bool {
-        match self.kind {
-            RecordErrorKind::AlreadyExists => true,
-            _ => false,
-        }
-    }
-
-    /// Returns `true` if this error was due to an error occurring while
-    /// recording the field.
-    pub fn is_record(&self) -> bool {
-        match self.kind {
-            RecordErrorKind::Record => true,
-            _ => false,
-        }
-    }
-}
-
-impl fmt::Display for RecordError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.kind {
-            RecordErrorKind::NoSpan(ref id) => write!(f, "no span exists with id {:?}", id),
-            RecordErrorKind::NoField => f.pad("no such field exists"),
-            RecordErrorKind::AlreadyExists => f.pad("field already has a value"),
-            RecordErrorKind::Record => f.pad("an error occurred recording the field"),
-        }
-    }
-}
-
-impl Error for RecordError {}
-
-impl From<fmt::Error> for RecordError {
-    fn from(_e: fmt::Error) -> Self {
-        RecordError::record()
-    }
-}
-
-// ===== impl FollowsError =====
-
-impl FollowsError {
-    /// Returns an error indicating that no span exists for the given `id`.
-    pub fn no_following_span(id: Id) -> Self {
-        Self {
-            kind: FollowsErrorKind::NoSpan(id),
-        }
-    }
-
-    /// Returns an error indicating the preceeding span does not exist.
-    pub fn no_preceeding_span() -> Self {
-        Self {
-            kind: FollowsErrorKind::NoPreceedingId,
-        }
-    }
-
-    /// Returns `true` if this error was due to the following span not existing.
-    pub fn is_no_following_span(&self) -> bool {
-        match self.kind {
-            FollowsErrorKind::NoSpan(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Returns `true` if this error was due to the preceeding span not existing.
-    pub fn is_no_preceeding_span(&self) -> bool {
-        match self.kind {
-            FollowsErrorKind::NoPreceedingId => true,
-            _ => false,
-        }
-    }
-}
-
-impl fmt::Display for FollowsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.kind {
-            FollowsErrorKind::NoSpan(ref id) => write!(f, "no span exists with id {:?}", id),
-            FollowsErrorKind::NoPreceedingId => f.pad("the preceeding span does not exist"),
-        }
-    }
-}
-
 #[cfg(any(test, feature = "test-support"))]
 pub use self::test_support::*;
 
@@ -668,14 +525,12 @@ mod test_support {
             _id: &Id,
             _field: &field::Key,
             _value: ::std::fmt::Arguments,
-        ) -> Result<(), ::subscriber::RecordError> {
+        ) {
             // TODO: it would be nice to be able to expect field values...
-            Ok(())
         }
 
-        fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {
+        fn add_follows_from(&self, _span: &Id, _follows: Id) {
             // TODO: it should be possible to expect spans to follow from other spans
-            Ok(())
         }
 
         fn new_id(&self, _span: span::Attributes) -> Id {

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -406,11 +406,15 @@ impl Subscriber for TraceLogger {
     ) {
         let mut in_progress = self.in_progress.lock().unwrap();
         if let Some(span) = in_progress.spans.get_mut(span) {
-            span.record(key, val);
+            if let Err(e) = span.record(key, val) {
+                eprintln!("error formatting span");
+            }
             return;
         }
         if let Some(event) = in_progress.events.get_mut(span) {
-            event.record(key, val);
+            if let Err(e) = event.record(key, val) {
+                eprintln!("error formatting event");
+            }
         }
     }
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -398,12 +398,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn record_fmt(
-        &self,
-        span: &Id,
-        key: &field::Key,
-        val: fmt::Arguments,
-    ) {
+    fn record_fmt(&self, span: &Id, key: &field::Key, val: fmt::Arguments) {
         let mut in_progress = self.in_progress.lock().unwrap();
         if let Some(span) = in_progress.spans.get_mut(span) {
             if let Err(e) = span.record(key, val) {

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -34,7 +34,7 @@ use std::{
 };
 use tokio_trace::{
     field, span,
-    subscriber::{self, Subscriber},
+    subscriber::Subscriber,
     Id, Meta,
 };
 
@@ -401,13 +401,13 @@ impl Subscriber for TraceLogger {
     fn record_fmt(&self, span: &Id, key: &field::Key, val: fmt::Arguments) {
         let mut in_progress = self.in_progress.lock().unwrap();
         if let Some(span) = in_progress.spans.get_mut(span) {
-            if let Err(e) = span.record(key, val) {
+            if let Err(_e) = span.record(key, val) {
                 eprintln!("error formatting span");
             }
             return;
         }
         if let Some(event) = in_progress.events.get_mut(span) {
-            if let Err(e) = event.record(key, val) {
+            if let Err(_e) = event.record(key, val) {
                 eprintln!("error formatting event");
             }
         }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -32,11 +32,7 @@ use std::{
         Mutex,
     },
 };
-use tokio_trace::{
-    field, span,
-    subscriber::Subscriber,
-    Id, Meta,
-};
+use tokio_trace::{field, span, subscriber::Subscriber, Id, Meta};
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,8 +1,4 @@
-use tokio_trace::{
-    span,
-    subscriber::Subscriber,
-    Id, Meta,
-};
+use tokio_trace::{span, subscriber::Subscriber, Id, Meta};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
     span,
-    subscriber::{FollowsError, RecordError, Subscriber},
+    subscriber::Subscriber,
     Id, Meta,
 };
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -111,11 +111,11 @@ where
         _span: &Id,
         _name: &tokio_trace::field::Key,
         _value: ::std::fmt::Arguments,
-    ) -> Result<(), RecordError> {
+    ) {
         unimplemented!()
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         self.registry.add_follows_from(span, follows)
     }
 

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -60,8 +60,8 @@ pub trait RegisterSpan {
     /// if one or both of the given span IDs do not correspond to spans that the
     /// registry knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
-    /// follow from _b_), it should return a `FollowsError`.
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), FollowsError>;
+    /// follow from _b_), it should do nothing.
+    fn add_follows_from(&self, span: &Id, follows: Id) ;
 
     /// Queries the registry for an iterator over the IDs of the spans that
     /// `span` follows from.
@@ -176,9 +176,8 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) {
         // unimplemented
-        Ok(())
     }
 
     fn prior_spans(&self, _span: &Id) -> Self::PriorSpans {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,5 @@
 use tokio_trace::{
     span::{self, Attributes, Id, SpanAttributes},
-    subscriber::FollowsError,
 };
 
 use std::{

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,4 @@
-use tokio_trace::{
-    span::{self, Attributes, Id, SpanAttributes},
-};
+use tokio_trace::span::{self, Attributes, Id, SpanAttributes};
 
 use std::{
     cmp,
@@ -60,7 +58,7 @@ pub trait RegisterSpan {
     /// registry knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
     /// follow from _b_), it should do nothing.
-    fn add_follows_from(&self, span: &Id, follows: Id) ;
+    fn add_follows_from(&self, span: &Id, follows: Id);
 
     /// Queries the registry for an iterator over the IDs of the spans that
     /// `span` follows from.

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -95,7 +95,7 @@ impl tower_service::Service<()> for NewSvc {
         Ok(Async::Ready(()))
     }
 
-    fn call(&mut self, target: ()) -> Self::Future {
+    fn call(&mut self, _target: ()) -> Self::Future {
         future::ok(Svc)
     }
 }

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -6,7 +6,7 @@ extern crate test;
 use test::Bencher;
 
 use std::sync::Mutex;
-use tokio_trace::{field, span, subscriber, Id, Meta};
+use tokio_trace::{field, span, Id, Meta};
 
 /// A subscriber that is enabled but otherwise does nothing.
 struct EnabledSubscriber;
@@ -22,14 +22,12 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         span: &Id,
         field: &field::Key,
         value: ::std::fmt::Arguments,
-    ) -> Result<(), tokio_trace::subscriber::RecordError> {
+    ) {
         let _ = (span, field, value);
-        Ok(())
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         let _ = (span, follows);
-        Ok(())
     }
 
     fn enabled(&self, metadata: &Meta) -> bool {
@@ -68,14 +66,12 @@ impl tokio_trace::Subscriber for Record {
         _span: &Id,
         _field: &field::Key,
         value: ::std::fmt::Arguments,
-    ) -> Result<(), tokio_trace::subscriber::RecordError> {
+    ) {
         let _ = ::std::fmt::format(value);
-        Ok(())
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, span: &Id, follows: Id) {
         let _ = (span, follows);
-        Ok(())
     }
 
     fn enabled(&self, metadata: &Meta) -> bool {

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -57,7 +57,7 @@ impl tokio_trace::Subscriber for Record {
         Id::from_u64(0)
     }
 
-    fn new_id(&self, span: span::Attributes) -> Id {
+    fn new_id(&self, _span: span::Attributes) -> Id {
         Id::from_u64(0)
     }
 

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -17,12 +17,7 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         Id::from_u64(0)
     }
 
-    fn record_fmt(
-        &self,
-        span: &Id,
-        field: &field::Key,
-        value: ::std::fmt::Arguments,
-    ) {
+    fn record_fmt(&self, span: &Id, field: &field::Key, value: ::std::fmt::Arguments) {
         let _ = (span, field, value);
     }
 
@@ -61,12 +56,7 @@ impl tokio_trace::Subscriber for Record {
         Id::from_u64(0)
     }
 
-    fn record_fmt(
-        &self,
-        _span: &Id,
-        _field: &field::Key,
-        value: ::std::fmt::Arguments,
-    ) {
+    fn record_fmt(&self, _span: &Id, _field: &field::Key, value: ::std::fmt::Arguments) {
         let _ = ::std::fmt::format(value);
     }
 

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -51,12 +51,7 @@ impl Subscriber for CounterSubscriber {
         // unimplemented
     }
 
-    fn record_i64(
-        &self,
-        _id: &Id,
-        field: &field::Key,
-        value: i64,
-    ) {
+    fn record_i64(&self, _id: &Id, field: &field::Key, value: i64) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             if value > 0 {
@@ -67,12 +62,7 @@ impl Subscriber for CounterSubscriber {
         };
     }
 
-    fn record_u64(
-        &self,
-        _id: &Id,
-        field: &field::Key,
-        value: u64,
-    ) {
+    fn record_u64(&self, _id: &Id, field: &field::Key, value: u64) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             counter.fetch_add(value as usize, Ordering::Release);
@@ -86,12 +76,7 @@ impl Subscriber for CounterSubscriber {
     /// - The span does not have a field with the given name.
     /// - The span has a field with the given name, but the value has already
     ///   been set.
-    fn record_fmt(
-        &self,
-        _id: &Id,
-        _field: &field::Key,
-        _value: ::std::fmt::Arguments,
-    ) { }
+    fn record_fmt(&self, _id: &Id, _field: &field::Key, _value: ::std::fmt::Arguments) {}
 
     fn enabled(&self, metadata: &Meta) -> bool {
         if !metadata.is_span() {

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -47,9 +47,8 @@ impl Subscriber for CounterSubscriber {
         Id::from_u64(id as u64)
     }
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) -> Result<(), subscriber::FollowsError> {
+    fn add_follows_from(&self, _span: &Id, _follows: Id) {
         // unimplemented
-        Ok(())
     }
 
     fn record_i64(
@@ -57,7 +56,7 @@ impl Subscriber for CounterSubscriber {
         _id: &Id,
         field: &field::Key,
         value: i64,
-    ) -> Result<(), ::subscriber::RecordError> {
+    ) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             if value > 0 {
@@ -66,7 +65,6 @@ impl Subscriber for CounterSubscriber {
                 counter.fetch_sub(value as usize, Ordering::Release);
             }
         };
-        Ok(())
     }
 
     fn record_u64(
@@ -74,12 +72,11 @@ impl Subscriber for CounterSubscriber {
         _id: &Id,
         field: &field::Key,
         value: u64,
-    ) -> Result<(), ::subscriber::RecordError> {
+    ) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             counter.fetch_add(value as usize, Ordering::Release);
         };
-        Ok(())
     }
 
     /// Adds a new field to an existing span observed by this `Subscriber`.
@@ -94,9 +91,7 @@ impl Subscriber for CounterSubscriber {
         _id: &Id,
         _field: &field::Key,
         _value: ::std::fmt::Arguments,
-    ) -> Result<(), ::subscriber::RecordError> {
-        Ok(())
-    }
+    ) { }
 
     fn enabled(&self, metadata: &Meta) -> bool {
         if !metadata.is_span() {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -13,11 +13,7 @@
 extern crate ansi_term;
 extern crate humantime;
 use self::ansi_term::{Color, Style};
-use super::tokio_trace::{
-    self,
-    subscriber::Subscriber,
-    Id, Level, SpanAttributes,
-};
+use super::tokio_trace::{self, subscriber::Subscriber, Id, Level, SpanAttributes};
 
 use std::{
     collections::HashMap,
@@ -74,11 +70,7 @@ impl Span {
         }
     }
 
-    fn record(
-        &mut self,
-        key: &tokio_trace::field::Key,
-        value: fmt::Arguments,
-    ) {
+    fn record(&mut self, key: &tokio_trace::field::Key, value: fmt::Arguments) {
         // TODO: shouldn't have to alloc the key...
         let k = key.name().unwrap_or("???").to_owned();
         let v = fmt::format(value);
@@ -98,11 +90,7 @@ impl Event {
         }
     }
 
-    fn record(
-        &mut self,
-        key: &tokio_trace::field::Key,
-        value: fmt::Arguments,
-    ) {
+    fn record(&mut self, key: &tokio_trace::field::Key, value: fmt::Arguments) {
         if key.name() == Some("message") {
             self.message = fmt::format(value);
             return;
@@ -197,16 +185,12 @@ impl Subscriber for SloggishSubscriber {
             return event.record(name, value);
         };
         let mut spans = self.spans.lock().expect("mutex poisoned!");
-        if let Some(span)= spans.get_mut(span) {
+        if let Some(span) = spans.get_mut(span) {
             span.record(name, value)
         }
     }
 
-    fn add_follows_from(
-        &self,
-        _span: &tokio_trace::Id,
-        _follows: tokio_trace::Id,
-    )  {
+    fn add_follows_from(&self, _span: &tokio_trace::Id, _follows: tokio_trace::Id) {
         // unimplemented
     }
 

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -24,13 +24,7 @@ pub trait Record {
     /// This defaults to calling `self.record_fmt()`; implementations wishing to
     /// provide behaviour specific to signed integers may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
         Q: AsKey;
 
@@ -39,13 +33,7 @@ pub trait Record {
     /// This defaults to calling `self.record_fmt()`; implementations wishing to
     /// provide behaviour specific to unsigned integers may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
         Q: AsKey;
 
@@ -54,13 +42,7 @@ pub trait Record {
     /// This defaults to calling `self.record_fmt()`; implementations wishing to
     /// provide behaviour specific to booleans may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
         Q: AsKey;
 
@@ -69,28 +51,16 @@ pub trait Record {
     /// This defaults to calling `self.record_str()`; implementations wishing to
     /// provide behaviour specific to strings may override the default
     /// implementation.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
         Q: AsKey;
 
     /// Record a set of pre-compiled format arguments.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
     fn record_fmt<Q: ?Sized>(
         &mut self,
         field: &Q,
         value: fmt::Arguments,
-    ) -> Result<(), RecordError>
+    )
     where
         Q: AsKey;
 }
@@ -106,7 +76,7 @@ pub trait Value {
         &self,
         key: &Q,
         recorder: &mut R,
-    ) -> Result<(), ::subscriber::RecordError>
+    )
     where
         Q: AsKey,
         R: Record;
@@ -155,7 +125,7 @@ macro_rules! impl_value {
                     &self,
                     key: &Q,
                     recorder: &mut R,
-                ) -> Result<(), $crate::subscriber::RecordError>
+                )
                 where
                     Q: $crate::field::AsKey,
                     R: $crate::field::Record,
@@ -172,7 +142,7 @@ macro_rules! impl_value {
                     &self,
                     key: &Q,
                     recorder: &mut R,
-                ) -> Result<(), $crate::subscriber::RecordError>
+                )
                 where
                     Q: $crate::field::AsKey,
                     R: $crate::field::Record,
@@ -222,7 +192,7 @@ impl Value for str {
         &self,
         key: &Q,
         recorder: &mut R,
-    ) -> Result<(), ::subscriber::RecordError>
+    )
     where
         Q: AsKey,
         R: Record,
@@ -235,7 +205,7 @@ impl<'a, T: ?Sized> Value for &'a T
 where
     T: Value + 'a,
 {
-    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,
@@ -250,7 +220,7 @@ impl<T> Value for DisplayValue<T>
 where
     T: fmt::Display,
 {
-    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,
@@ -265,7 +235,7 @@ impl<T: fmt::Debug> Value for DebugValue<T>
 where
     T: fmt::Debug,
 {
-    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R) -> Result<(), RecordError>
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,7 +1,7 @@
 pub use tokio_trace_core::field::*;
 
 use std::fmt;
-use {subscriber::RecordError, Meta};
+use Meta;
 
 /// Trait implemented to allow a type to be used as a field key.
 ///

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -56,11 +56,7 @@ pub trait Record {
         Q: AsKey;
 
     /// Record a set of pre-compiled format arguments.
-    fn record_fmt<Q: ?Sized>(
-        &mut self,
-        field: &Q,
-        value: fmt::Arguments,
-    )
+    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments)
     where
         Q: AsKey;
 }
@@ -72,11 +68,7 @@ pub trait Record {
 /// should be recorded.
 pub trait Value {
     /// Records this value with the given `Subscriber`.
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    )
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record;
@@ -188,11 +180,7 @@ impl_values! {
 }
 
 impl Value for str {
-    fn record<Q: ?Sized, R>(
-        &self,
-        key: &Q,
-        recorder: &mut R,
-    )
+    fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
         Q: AsKey,
         R: Record,

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -114,7 +114,6 @@ macro_rules! span {
     };
     (@ record: $span:expr, $k:expr, $i:expr, $val:expr) => (
         $span.record($i, &$val)
-            .expect(concat!("adding value for field '", stringify!($k), "' failed"));
     );
     (@ record: $span:expr, $k:expr, $i:expr,) => (
         // skip
@@ -140,8 +139,7 @@ macro_rules! event {
                 event.message(
                     &keys.next().expect("event metadata should define a key for the message"),
                     format_args!( $($arg)+ )
-                )
-                .expect("adding value for event message failed");
+                );
                 $(
                     let key = keys.next()
                         .expect(concat!("metadata should define a key for '", stringify!($k), "'"));
@@ -154,8 +152,7 @@ macro_rules! event {
         event!(target: module_path!(), $lvl, { $($k $( = $val)* ),* }, $($arg)+)
     );
     (@ record: $ev:expr, $k:expr, $i:expr, $val:expr) => (
-        $ev.record($i, &$val)
-            .expect(concat!("adding value for field '", stringify!($k), "' failed"));
+        $ev.record($i, &$val);
     );
     (@ record: $ev:expr, $k:expr, $i:expr,) => (
         // skip

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -97,6 +97,7 @@ macro_rules! span {
     ($name:expr) => { span!($name,) };
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
+            #[allow(unused_imports)]
             use $crate::{callsite, callsite::Callsite, Span,  span::SpanExt, field::{Value, AsKey}};
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
@@ -124,6 +125,7 @@ macro_rules! span {
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
+            #[allow(unused_imports)]
             use $crate::{callsite, Id, Subscriber, Event, span::SpanExt, field::{Value, AsKey}};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -203,10 +203,7 @@ pub use tokio_trace_core::span::{mock, MockSpan};
 
 use std::{fmt, sync::Arc};
 use tokio_trace_core::span::Enter;
-use {
-    field,
-    subscriber,
-};
+use {field, subscriber};
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
 pub trait IntoShared {
@@ -217,7 +214,7 @@ pub trait IntoShared {
 }
 
 pub trait SpanExt: field::Record + ::sealed::Sealed {
-    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V)-> &mut Self
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> &mut Self
     where
         Q: field::AsKey,
         V: field::Value;
@@ -335,7 +332,7 @@ impl SpanExt for Span {
             .is_some()
     }
 
-    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V)-> &mut Self
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> &mut Self
     where
         Q: field::AsKey,
         V: field::Value,
@@ -351,10 +348,7 @@ impl field::Record for Span {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_i64(&key, value);
         }
     }
@@ -364,10 +358,7 @@ impl field::Record for Span {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_u64(&key, value);
         }
     }
@@ -377,10 +368,7 @@ impl field::Record for Span {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_bool(&key, value);
         }
     }
@@ -390,10 +378,7 @@ impl field::Record for Span {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_str(&key, value);
         }
     }
@@ -403,10 +388,7 @@ impl field::Record for Span {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_fmt(&key, value);
         }
     }
@@ -418,10 +400,7 @@ impl<'a> field::Record for Event<'a> {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_i64(&key, value);
         }
     }
@@ -431,10 +410,7 @@ impl<'a> field::Record for Event<'a> {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_u64(&key, value);
         }
     }
@@ -444,10 +420,7 @@ impl<'a> field::Record for Event<'a> {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_bool(&key, value);
         }
     }
@@ -457,10 +430,7 @@ impl<'a> field::Record for Event<'a> {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_str(&key, value);
         }
     }
@@ -470,10 +440,7 @@ impl<'a> field::Record for Event<'a> {
     where
         Q: field::AsKey,
     {
-        if let Some(key) = self
-            .metadata()
-            .and_then(|meta| field.as_key(meta))
-        {
+        if let Some(key) = self.metadata().and_then(|meta| field.as_key(meta)) {
             self.record_value_fmt(&key, value);
         }
     }
@@ -491,7 +458,7 @@ impl<'a> SpanExt for Event<'a> {
             .is_some()
     }
 
-    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V)-> &mut Self
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> &mut Self
     where
         Q: field::AsKey,
         V: field::Value,

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -201,9 +201,9 @@ pub use tokio_trace_core::span::{Attributes, Event, Id, Span, SpanAttributes};
 #[cfg(any(test, feature = "test-support"))]
 pub use tokio_trace_core::span::{mock, MockSpan};
 
+use field;
 use std::{fmt, sync::Arc};
 use tokio_trace_core::span::Enter;
-use field;
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
 pub trait IntoShared {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -203,7 +203,7 @@ pub use tokio_trace_core::span::{mock, MockSpan};
 
 use std::{fmt, sync::Arc};
 use tokio_trace_core::span::Enter;
-use {field, subscriber};
+use field;
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
 pub trait IntoShared {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -205,7 +205,7 @@ use std::{fmt, sync::Arc};
 use tokio_trace_core::span::Enter;
 use {
     field,
-    subscriber::{self, RecordError},
+    subscriber,
 };
 
 /// Trait for converting a `Span` into a cloneable `Shared` span.
@@ -217,7 +217,7 @@ pub trait IntoShared {
 }
 
 pub trait SpanExt: field::Record + ::sealed::Sealed {
-    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V)-> &mut Self
     where
         Q: field::AsKey,
         V: field::Value;
@@ -315,11 +315,11 @@ impl Shared {
     /// If this span is disabled, this function will do nothing. Otherwise, it
     /// returns `Ok(())` if the other span was added as a precedent of this
     /// span, or an error if this was not possible.
-    pub fn follows_from(&self, from: Id) -> Result<(), subscriber::FollowsError> {
-        self.inner
-            .as_ref()
-            .map(move |inner| inner.follows_from(from))
-            .unwrap_or(Ok(()))
+    pub fn follows_from(&self, from: Id) -> &Self {
+        if let Some(ref inner) = self.inner {
+            inner.follows_from(from);
+        }
+        self
     }
 }
 
@@ -335,136 +335,147 @@ impl SpanExt for Span {
             .is_some()
     }
 
-    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V)-> &mut Self
     where
         Q: field::AsKey,
         V: field::Value,
     {
-        value.record(field, self)
+        value.record(field, self);
+        self
     }
 }
 
 impl field::Record for Span {
     #[inline]
-    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_i64(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_i64(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_u64(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_u64(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_bool(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_bool(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_str(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_str(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments) -> Result<(), RecordError>
+    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_fmt(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_fmt(&key, value);
         }
-        Ok(())
     }
 }
 
 impl<'a> field::Record for Event<'a> {
     #[inline]
-    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64) -> Result<(), RecordError>
+    fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_i64(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_i64(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64) -> Result<(), RecordError>
+    fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_u64(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_u64(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool) -> Result<(), RecordError>
+    fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_bool(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_bool(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str) -> Result<(), RecordError>
+    fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_str(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_str(&key, value);
         }
-        Ok(())
     }
 
     #[inline]
-    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments) -> Result<(), RecordError>
+    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments)
     where
         Q: field::AsKey,
     {
-        if let Some(meta) = self.metadata() {
-            let key = field.as_key(meta).ok_or_else(RecordError::no_field)?;
-            self.record_value_fmt(&key, value)?;
+        if let Some(key) = self
+            .metadata()
+            .and_then(|meta| field.as_key(meta))
+        {
+            self.record_value_fmt(&key, value);
         }
-        Ok(())
     }
 }
 
@@ -480,12 +491,13 @@ impl<'a> SpanExt for Event<'a> {
             .is_some()
     }
 
-    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> Result<(), RecordError>
+    fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V)-> &mut Self
     where
         Q: field::AsKey,
         V: field::Value,
     {
-        value.record(field, self)
+        value.record(field, self);
+        self
     }
 }
 


### PR DESCRIPTION
Closes #104. 

This branch removes the `Result` return types from `Subscriber` trait
methods in `tokio-trace-core`. We can still add a fallible subscriber
type later, but that won't require a change to core.

This has the side benefit of making span and event
`follows_from`/`record_$TY` methods chainable.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>