### PR TITLE
Make subscribers responsible for tracking the current span

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -36,11 +36,7 @@ impl Dispatch {
         F: FnOnce(&Dispatch) -> T,
     {
             CURRENT_DISPATCH.with(|current| {
-                if let Some(c) = current.borrow().current_span().dispatch() {
-                    f(c)
-                } else {
                     f(&*current.borrow())
-                }
             })
     }
 

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -144,12 +144,12 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn exit(&self, span: Id) {
-        self.subscriber.exit(span)
+    fn exit(&self, span: Id, parent: Span) -> Span {
+        self.subscriber.exit(span, parent)
     }
 
     #[inline]
-    fn current_span(&self) -> Span {
+    fn current_span(&self) -> &Span {
         self.subscriber.current_span()
     }
 
@@ -187,12 +187,13 @@ impl Subscriber for NoSubscriber {
         Span::new_disabled()
     }
 
-    fn current_span(&self) -> Span {
-        Span::new_disabled()
+    fn current_span(&self) -> &Span {
+        &Span::NONE
     }
 
-
-    fn exit(&self, _span: Id) {}
+    fn exit(&self, _exited: Id, _parent: Span) -> Span {
+        Span::new_disabled()
+    }
 
     fn close(&self, _span: Id) {}
 }

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -8,8 +8,8 @@ use {
 use std::{
     cell::RefCell,
     fmt,
-    thread,
     sync::{Arc, Weak},
+    thread,
 };
 
 thread_local! {
@@ -45,9 +45,7 @@ impl Dispatch {
             // SIGSEGV.
             return f(&Dispatch::none());
         }
-        CURRENT_DISPATCH.with(|current| {
-            f(&*current.borrow())
-        })
+        CURRENT_DISPATCH.with(|current| f(&*current.borrow()))
     }
 
     /// Returns a `Dispatch` to the given [`Subscriber`](::Subscriber).
@@ -83,7 +81,6 @@ impl Dispatch {
             *current.borrow_mut() = prior;
             result
         })
-
     }
 
     pub(crate) fn registrar(&self) -> Registrar {

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -152,7 +152,7 @@ pub struct Entered {
 // ===== impl Span =====
 
 impl Span {
-    pub const NONE: Span = Span {
+    pub(crate) const NONE: Span = Span {
         inner: None,
         is_closed: false,
     };
@@ -214,12 +214,6 @@ impl Span {
     /// executing.
     pub fn current() -> Self {
         Dispatch::with_current(|dispatch| dispatch.current_span().clone())
-    }
-
-    /// Returns a reference to the dispatcher that tracks this span, or `None`
-    /// if the span is disabled.
-    pub(crate) fn dispatch(&self) -> Option<&Dispatch> {
-        self.inner.as_ref().map(|inner| &inner.subscriber)
     }
 
     /// Executes the given function in the context of this span.

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -847,7 +847,7 @@ mod test_support {
     ///
     /// This is intended for use with the mock subscriber API in the
     /// `subscriber` module.
-    #[derive(Default)]
+    #[derive(Debug, Default, Eq, PartialEq)]
     pub struct MockSpan {
         pub name: Option<Option<&'static str>>,
         // TODO: more

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -831,10 +831,8 @@ impl Entered {
                  if inner.should_close() {
                     // Dropping `inner` will allow it to perform the closure if
                     // able.
-                    println!("exiting {}, should_close={:?}; handles={:?};", inner.metadata().name.unwrap_or("???"), inner.should_close(), inner.handle_count());
                     None
                 } else {
-                    println!("exiting {}, should_close={:?}; handles={:?};", inner.metadata().name.unwrap_or("???"), inner.should_close(), inner.handle_count());
                     // We are returning a new `Enter`. Increment the number of
                     // handles that may enter the span.
                     inner.handles.fetch_add(1, Ordering::Release);

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -232,13 +232,13 @@ impl Span {
     /// Returns the result of evaluating `f`.
     pub fn enter<F: FnOnce() -> T, T>(&mut self, f: F) -> T {
         match self.inner.take() {
-            Some(inner) => {
+            Some(inner) => inner.subscriber.as_default(|| {
                 let guard = inner.enter();
                 inner.take_close();
                 let result = f();
                 self.inner = guard.exit();
                 result
-            }
+            }),
             None => f(),
         }
     }

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -720,9 +720,6 @@ mod test_support {
                     "expected nothing else to happen, but closed span {:?}",
                     span.name(),
                 ),
-                (SpanOrEvent::Event, Some(Expect::Nothing)) => {
-                    panic!("expected nothing else to happen, but closed an event")
-                }
             }
         }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -507,7 +507,7 @@ mod test_support {
             // TODO: it should be possible to expect spans to follow from other spans
         }
 
-        fn new_id(&self, attrs: span::Attributes) -> Id {
+        fn new_id(&self, _attrs: span::Attributes) -> Id {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Id::from_u64(id as u64);
             println!("new_id: id={:?};", id);

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -234,9 +234,9 @@ pub trait Subscriber {
     /// Records that a [`Span`] has been entered.
     ///
     /// When entering a span, this method is called to notify the subscriber
-    /// that the span has been entered. The subscriber is provided with the
-    /// [`Id`] that identifies the entered span, and the current [`State`]
-    /// of the span.
+    /// that the span has been entered. The subscriber is provided with a handle
+    /// to the entered span, and should return its handle to the span that was
+    /// currently executing prior to entering the new span.
     ///
     /// [`Span`]: ::span::Span
     /// [`Id`]: ::Id
@@ -247,7 +247,9 @@ pub trait Subscriber {
     ///
     /// When exiting a span, this method is called to notify the subscriber
     /// that the span has been exited. The subscriber is provided with the
-    /// [`Id`] that identifies the exited span.
+    /// [`Id`] that identifies the exited span, and a handle to the
+    /// previously executing span, which should become the new current span. The
+    /// subscriber should return its handle to the exited span.
     ///
     /// Exiting a span does not imply that the span will not be re-entered.
     /// [`Span`]: ::span::Span
@@ -269,6 +271,10 @@ pub trait Subscriber {
     /// [`Id`]: ::Id
     fn close(&self, span: Id);
 
+    /// Returns a reference to the currently-executing span.
+    ///
+    /// If no span is currently executing, the subscriber may return
+    /// `Span::new_disabled()`.
     fn current_span(&self) -> &Span;
 
     /// Notifies the subscriber that a [`Span`] handle with the given [`Id`] has

--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -9,3 +9,4 @@ tokio-trace = { path = "../tokio-trace" }
 
 [dev-dependencies]
 tokio-trace = { path = "../tokio-trace", features = ["test-support"] }
+tokio = "0.1"

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn span_follows_future_onto_threadpool() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("a")))
             .enter(span::mock().named(Some("b")))
             .exit(span::mock().named(Some("b")))
@@ -243,7 +243,7 @@ mod tests {
             .close(span::mock().named(Some("a")))
             .enter(span::mock().named(Some("c")))
             .exit(span::mock().named(Some("c")))
-            .run();
+            .run_with_handle();
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
         Dispatch::new(subscriber).as_default(move || {
             span!("a").enter(|| {
@@ -255,6 +255,7 @@ mod tests {
                 Span::current().close();
                 runtime.block_on(Box::new(future)).unwrap();
             })
-        })
+        });
+        handle.assert_finished();
     }
 }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -32,7 +32,12 @@ use std::{
         Mutex,
     },
 };
-use tokio_trace::{field, span::{self, Span}, subscriber::{self, Subscriber}, Id, Meta};
+use tokio_trace::{
+    field,
+    span::{self, Span},
+    subscriber::{self, Subscriber},
+    Id, Meta,
+};
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
@@ -432,7 +437,8 @@ impl Subscriber for TraceLogger {
                     let name = meta.name.unwrap_or("???");
                     let current_id = self.current.id();
                     let in_progress = self.in_progress.lock().unwrap();
-                    let current_fields = current_id.as_ref()
+                    let current_fields = current_id
+                        .as_ref()
                         .and_then(|id| in_progress.spans.get(&id))
                         .map(|span| span.fields.as_ref())
                         .unwrap_or("");
@@ -445,8 +451,10 @@ impl Subscriber for TraceLogger {
                                 .module_path(meta.module_path)
                                 .file(meta.file)
                                 .line(meta.line)
-                                .args(format_args!("enter {}; id={:?}; in={:?}; {}", name, id, current_id, current_fields))
-                                .build()
+                                .args(format_args!(
+                                    "enter {}; id={:?}; in={:?}; {}",
+                                    name, id, current_id, current_fields
+                                )).build(),
                         );
                     } else {
                         logger.log(
@@ -457,7 +465,7 @@ impl Subscriber for TraceLogger {
                                 .file(meta.file)
                                 .line(meta.line)
                                 .args(format_args!("enter {}; {}", name, current_fields))
-                                .build()
+                                .build(),
                         );
                     }
                 }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -133,6 +133,7 @@ pub struct LogTracer {
 
 /// A `tokio_trace_subscriber::Observe` implementation that logs all recorded
 /// trace events.
+#[derive(Default)]
 pub struct TraceLogger {
     settings: TraceLoggerBuilder,
     in_progress: Mutex<InProgress>,
@@ -148,6 +149,7 @@ pub struct TraceLoggerBuilder {
     parent_fields: bool,
 }
 
+#[derive(Default)]
 struct InProgress {
     spans: HashMap<Id, SpanLineBuilder>,
     events: HashMap<Id, EventLineBuilder>,

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,8 @@
-use tokio_trace::{span::{self, Span}, subscriber::Subscriber, Id, Meta};
+use tokio_trace::{
+    span::{self, Span},
+    subscriber::Subscriber,
+    Id, Meta,
+};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span, subscriber::Subscriber, Id, Meta};
+use tokio_trace::{span::{self, Span}, subscriber::Subscriber, Id, Meta};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -115,16 +115,19 @@ where
         self.registry.add_follows_from(span, follows)
     }
 
-    fn enter(&self, id: Id) {
-        self.registry.with_span(&id, |span| {
-            self.observer.enter(span);
-        });
+    fn enter(&self, span: Span) -> Span {
+        self.observer.enter(&span);
+        self.registry.enter(span)
     }
 
-    fn exit(&self, id: Id) {
-        self.registry.with_span(&id, |span| {
-            self.observer.exit(span);
-        });
+    fn current_span(&self) -> &Span {
+        self.registry.current_span()
+    }
+
+    fn exit(&self, id: Id, parent: Span) -> Span {
+        let span = self.registry.exit(parent);
+        self.observer.exit(&span);
+        span
     }
 
     fn close(&self, id: Id) {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -128,7 +128,7 @@ where
         self.registry.current_span()
     }
 
-    fn exit(&self, id: Id, parent: Span) -> Span {
+    fn exit(&self, _id: Id, parent: Span) -> Span {
         let span = self.registry.exit(parent);
         self.observer.exit(&span);
         span

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -1,9 +1,9 @@
 use {
+    registry::SpanRef,
     filter::{self, Filter},
-    SpanRef,
 };
 
-use tokio_trace::{Event, Meta};
+use tokio_trace::{Event, Span, Meta};
 
 /// The notification processing portion of the [`Subscriber`] trait.
 ///
@@ -11,9 +11,9 @@ use tokio_trace::{Event, Meta};
 /// and span notifications, but don't implement span registration.
 pub trait Observe {
     fn observe_event<'a>(&self, event: &'a Event<'a>);
-    fn enter<'a>(&self, span: &SpanRef<'a>);
-    fn exit<'a>(&self, span: &SpanRef<'a>);
-    fn close<'a>(&self, span: &SpanRef<'a>);
+    fn enter(&self, span: &Span);
+    fn exit(&self, span: &Span);
+    fn close(&self, span: &SpanRef);
 
     fn filter(&self) -> &dyn Filter {
         &filter::NoFilter
@@ -32,7 +32,7 @@ pub trait ObserveExt: Observe {
     /// extern crate tokio_trace_subscriber;
     /// use tokio_trace_subscriber::{registry, Event, Observe, ObserveExt, SpanRef};
     /// # use tokio_trace_subscriber::filter::{Filter, NoFilter};
-    /// # use tokio_trace::{Level, Meta};
+    /// # use tokio_trace::{Level, Meta, Span};
     /// # fn main() {
     ///
     /// struct Foo {
@@ -46,8 +46,8 @@ pub trait ObserveExt: Observe {
     /// impl Observe for Foo {
     ///     // ...
     /// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
-    /// # fn enter(&self, _: &SpanRef) {}
-    /// # fn exit(&self, _: &SpanRef) {}
+    /// # fn enter(&self, _: &Span) {}
+    /// # fn exit(&self, _: &Span) {}
     /// # fn close(&self, _: &SpanRef) {}
     /// # fn filter(&self) -> &dyn Filter { &NoFilter}
     /// }
@@ -55,8 +55,8 @@ pub trait ObserveExt: Observe {
     /// impl Observe for Bar {
     ///     // ...
     /// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
-    /// # fn enter(&self, _: &SpanRef) {}
-    /// # fn exit(&self, _: &SpanRef) {}
+    /// # fn enter(&self, _: &Span) {}
+    /// # fn exit(&self, _: &Span) {}
     /// # fn close(&self, _: &SpanRef) {}
     /// # fn filter(&self) -> &dyn Filter { &NoFilter}
     /// }
@@ -105,8 +105,8 @@ pub trait ObserveExt: Observe {
     /// extern crate tokio_trace;
     /// extern crate tokio_trace_log;
     /// extern crate tokio_trace_subscriber;
-    /// use tokio_trace_subscriber::{registry, filter, Observe, ObserveExt};
-    /// # use tokio_trace::{Level, Meta};
+    /// use tokio_trace_subscriber::{registry, filter, Observe, ObserveExt, SpanRef};
+    /// # use tokio_trace::{Level, Meta, Span};
     /// # fn main() {
     ///
     /// let observer = tokio_trace_log::TraceLogger::new()
@@ -167,6 +167,7 @@ pub struct NoObserver;
 /// extern crate tokio_trace_subscriber;
 /// use tokio_trace_subscriber::{observe, Event, Observe, SpanRef};
 /// # use tokio_trace_subscriber::filter::{Filter, NoFilter};
+/// # use tokio_trace::Span;
 /// # fn main() {}
 ///
 /// struct Foo {
@@ -180,8 +181,8 @@ pub struct NoObserver;
 /// impl Observe for Foo {
 ///     // ...
 /// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
-/// # fn enter(&self, _: &SpanRef) {}
-/// # fn exit(&self, _: &SpanRef) {}
+/// # fn enter(&self, _: &Span) {}
+/// # fn exit(&self, _: &Span) {}
 /// # fn close(&self, _: &SpanRef) {}
 /// # fn filter(&self) -> &dyn Filter { &NoFilter}
 /// }
@@ -189,8 +190,8 @@ pub struct NoObserver;
 /// impl Observe for Bar {
 ///     // ...
 /// # fn observe_event<'a>(&self, _: &'a Event<'a>) {}
-/// # fn enter(&self, _: &SpanRef) {}
-/// # fn exit(&self, _: &SpanRef) {}
+/// # fn enter(&self, _: &Span) {}
+/// # fn exit(&self, _: &Span) {}
 /// # fn close(&self, _: &SpanRef) {}
 /// # fn filter(&self) -> &dyn Filter { &NoFilter}
 /// }
@@ -261,17 +262,17 @@ where
     }
 
     #[inline]
-    fn enter<'a>(&self, span: &SpanRef<'a>) {
+    fn enter(&self, span: &Span) {
         self.inner.enter(span)
     }
 
     #[inline]
-    fn exit<'a>(&self, span: &SpanRef<'a>) {
+    fn exit(&self, span: &Span) {
         self.inner.exit(span)
     }
 
     #[inline]
-    fn close<'a>(&self, span: &SpanRef<'a>) {
+    fn close(&self, span: &SpanRef) {
         self.inner.close(span)
     }
 
@@ -307,17 +308,17 @@ where
         self.b.observe_event(event);
     }
 
-    fn enter<'a>(&self, span: &SpanRef<'a>) {
+    fn enter(&self, span: &Span) {
         self.a.enter(span);
         self.b.enter(span);
     }
 
-    fn exit<'a>(&self, span: &SpanRef<'a>) {
+    fn exit(&self, span: &Span) {
         self.a.exit(span);
         self.b.exit(span);
     }
 
-    fn close<'a>(&self, span: &SpanRef<'a>) {
+    fn close(&self, span: &SpanRef) {
         self.a.close(span);
         self.b.close(span);
     }
@@ -354,21 +355,21 @@ where
         }
     }
 
-    fn enter<'a>(&self, span: &SpanRef<'a>) {
+    fn enter(&self, span: &Span) {
         match self {
             Either::A(a) => a.enter(span),
             Either::B(b) => b.enter(span),
         }
     }
 
-    fn exit<'a>(&self, span: &SpanRef<'a>) {
+    fn exit(&self, span: &Span) {
         match self {
             Either::A(a) => a.exit(span),
             Either::B(b) => b.exit(span),
         }
     }
 
-    fn close<'a>(&self, span: &SpanRef<'a>) {
+    fn close(&self, span: &SpanRef) {
         match self {
             Either::A(a) => a.close(span),
             Either::B(b) => b.close(span),
@@ -399,11 +400,11 @@ where
 impl Observe for NoObserver {
     fn observe_event<'a>(&self, _event: &'a Event<'a>) {}
 
-    fn enter<'a>(&self, _span: &SpanRef<'a>) {}
+    fn enter(&self, _span: &Span) {}
 
-    fn exit<'a>(&self, _span: &SpanRef<'a>) {}
+    fn exit(&self, _span: &Span) {}
 
-    fn close<'a>(&self, _span: &SpanRef<'a>) {}
+    fn close(&self, _span: &SpanRef) {}
 
     fn filter(&self) -> &dyn Filter {
         self

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -1,9 +1,9 @@
 use {
-    registry::SpanRef,
     filter::{self, Filter},
+    registry::SpanRef,
 };
 
-use tokio_trace::{Event, Span, Meta};
+use tokio_trace::{Event, Meta, Span};
 
 /// The notification processing portion of the [`Subscriber`] trait.
 ///

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,4 +1,7 @@
-use tokio_trace::span::{self, Attributes, Id, SpanAttributes};
+use tokio_trace::{
+    subscriber,
+    span::{self, Attributes, Id, Span, SpanAttributes},
+};
 
 use std::{
     cmp,
@@ -67,6 +70,12 @@ pub trait RegisterSpan {
     fn with_span<F>(&self, id: &Id, f: F)
     where
         F: for<'a> Fn(&'a SpanRef<'a>);
+
+    fn enter(&self, span: Span) -> Span;
+
+    fn exit(&self, span: Span) -> Span;
+
+    fn current_span(&self) -> &Span;
 
     /// Notifies the subscriber that a [`Span`] handle with the given [`Id`] has
     /// been cloned.
@@ -145,14 +154,24 @@ impl<'a> cmp::Eq for SpanRef<'a> {}
 //     Id::from_u64(next as u64)
 // }
 
-#[derive(Default)]
 pub struct IncreasingCounter {
     next_id: AtomicUsize,
     spans: Mutex<HashMap<Id, SpanAttributes>>,
+    current: subscriber::CurrentSpanPerThread,
 }
 
 pub fn increasing_counter() -> IncreasingCounter {
     IncreasingCounter::default()
+}
+
+impl Default for IncreasingCounter {
+    fn default() -> Self {
+        Self {
+            next_id: AtomicUsize::new(0),
+            spans: Mutex::new(HashMap::new()),
+            current: subscriber::CurrentSpanPerThread::new(),
+        }
+    }
 }
 
 impl RegisterSpan for IncreasingCounter {
@@ -179,6 +198,18 @@ impl RegisterSpan for IncreasingCounter {
 
     fn prior_spans(&self, _span: &Id) -> Self::PriorSpans {
         unimplemented!();
+    }
+
+    fn enter(&self, span: Span) -> Span {
+        self.current.set_current(span)
+    }
+
+    fn exit(&self, span: Span) -> Span {
+        self.current.set_current(span)
+    }
+
+    fn current_span(&self) -> &Span {
+        self.current.span()
     }
 
     fn with_span<F>(&self, id: &Id, f: F)

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,6 +1,6 @@
 use tokio_trace::{
-    subscriber,
     span::{self, Attributes, Id, Span, SpanAttributes},
+    subscriber,
 };
 
 use std::{

--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -7,6 +7,8 @@ fn main() {
     env_logger::Builder::new().parse("trace").init();
     let subscriber = tokio_trace_log::TraceLogger::builder()
         .with_parent_fields(true)
+        .with_span_entry(true)
+        .with_span_exits(true)
         .finish();
 
     tokio_trace::Dispatch::new(subscriber).as_default(|| {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -48,7 +48,6 @@ struct Span {
 }
 
 struct Event {
-    id: Id,
     level: tokio_trace::Level,
     target: String,
     message: String,
@@ -86,10 +85,9 @@ impl Span {
 }
 
 impl Event {
-    fn new(attrs: tokio_trace::Attributes, id: Id) -> Self {
+    fn new(attrs: tokio_trace::Attributes) -> Self {
         let meta = attrs.metadata();
         Self {
-            id,
             target: meta.target.to_owned(),
             level: meta.level,
             message: String::new(),
@@ -169,7 +167,7 @@ impl Subscriber for SloggishSubscriber {
         self.events
             .lock()
             .unwrap()
-            .insert(id.clone(), Event::new(span, id.clone()));
+            .insert(id.clone(), Event::new(span));
         id
     }
 

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -13,7 +13,11 @@
 extern crate ansi_term;
 extern crate humantime;
 use self::ansi_term::{Color, Style};
-use super::tokio_trace::{self, subscriber::{self, Subscriber}, Id, Level, SpanAttributes};
+use super::tokio_trace::{
+    self,
+    subscriber::{self, Subscriber},
+    Id, Level, SpanAttributes,
+};
 
 use std::{
     collections::HashMap,

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -195,15 +195,20 @@ impl Subscriber for SloggishSubscriber {
     }
 
     #[inline]
-    fn enter(&self, span: tokio_trace::Id) {
+    fn enter(&self, span: tokio_trace::Span) -> tokio_trace::Span {
         let mut stderr = self.stderr.lock();
         let mut stack = self.stack.lock().unwrap();
         let spans = self.spans.lock().unwrap();
-        let data = spans.get(&span);
+        let span_id = if let Some(id) = span.id() {
+            id
+        } else {
+            unimplemented!()
+        };
+        let data = spans.get(&span_id);
         let parent = data.and_then(|span| span.attrs.parent());
-        if stack.iter().any(|id| id == &span) {
+        if stack.iter().any(|id| id == &span_id) {
             // We are already in this span, do nothing.
-            return;
+            return span;
         } else {
             let indent = if let Some(idx) = stack
                 .iter()
@@ -217,17 +222,24 @@ impl Subscriber for SloggishSubscriber {
                 0
             };
             self.print_indent(&mut stderr, indent).unwrap();
-            stack.push(span);
+            stack.push(span_id);
             if let Some(data) = data {
                 self.print_kvs(&mut stderr, data.kvs.iter().map(|(k, v)| (k, v)), "")
                     .unwrap();
             }
             write!(&mut stderr, "\n").unwrap();
         }
+        unimplemented!()
     }
 
     #[inline]
-    fn exit(&self, _span: tokio_trace::Id) {}
+    fn exit(&self, _span: tokio_trace::Id, parent: tokio_trace::Span) -> tokio_trace::Span {
+        unimplemented!("TODO: update examples!")
+    }
+
+    fn current_span(&self) -> &tokio_trace::Span {
+        unimplemented!("TODO: update examples!")
+    }
 
     #[inline]
     fn close(&self, id: tokio_trace::Id) {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -212,7 +212,7 @@ impl Subscriber for SloggishSubscriber {
         let parent = data.and_then(|span| span.attrs.parent());
         if stack.iter().any(|id| id == &span_id) {
             // We are already in this span, do nothing.
-            return span;
+            return self.current.set_current(span);
         } else {
             let indent = if let Some(idx) = stack
                 .iter()

--- a/tokio-trace/src/dispatcher.rs
+++ b/tokio-trace/src/dispatcher.rs
@@ -9,44 +9,52 @@ mod tests {
     fn dispatcher_is_sticky() {
         // Test ensuring that entire trace trees are collected by the same
         // dispatcher, even across dispatcher context switches.
-        let subscriber1 = subscriber::mock()
+        let (subscriber1, handle1) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("bar")))
             .exit(span::mock().named(Some("bar")))
+            .close(span::mock().named(Some("bar")))
             .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
             .done()
-            .run();
+            .run_with_handle();
         let mut foo = Dispatch::new(subscriber1).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
             foo
         });
         Dispatch::new(subscriber::mock().done().run())
-            .as_default(move || foo.enter(|| span!("bar").enter(|| {})))
+            .as_default(move || foo.enter(|| span!("bar").enter(|| {})));
+
+        handle1.assert_finished();
     }
 
     #[test]
     fn dispatcher_isnt_too_sticky() {
         // Test ensuring that new trace trees are collected by the current
         // dispatcher.
-        let subscriber1 = subscriber::mock()
+        let (subscriber1, handle1) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("bar")))
             .exit(span::mock().named(Some("bar")))
+            .close(span::mock().named(Some("bar")))
             .exit(span::mock().named(Some("foo")))
+            .close(span::mock().named(Some("foo")))
             .done()
-            .run();
-        let subscriber2 = subscriber::mock()
+            .run_with_handle();
+        let (subscriber2, handle2) = subscriber::mock()
             .enter(span::mock().named(Some("baz")))
             .enter(span::mock().named(Some("quux")))
             .exit(span::mock().named(Some("quux")))
+            .close(span::mock().named(Some("quux")))
             .exit(span::mock().named(Some("baz")))
+            .close(span::mock().named(Some("baz")))
             .done()
-            .run();
+            .run_with_handle();
 
         let mut foo = Dispatch::new(subscriber1).as_default(|| {
             let mut foo = span!("foo");
@@ -54,10 +62,13 @@ mod tests {
             foo
         });
         let mut baz = Dispatch::new(subscriber2).as_default(|| span!("baz"));
-        Dispatch::new(subscriber::mock().run()).as_default(move || {
+        Dispatch::new(subscriber::mock().done().run()).as_default(move || {
             foo.enter(|| span!("bar").enter(|| {}));
             baz.enter(|| span!("quux").enter(|| {}))
-        })
+        });
+
+        handle1.assert_finished();
+        handle2.assert_finished();
     }
 
 }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -950,6 +950,7 @@ mod tests {
                 .exit(span::mock().named(Some("bar")))
                 .close(span::mock().named(Some("bar")))
                 .exit(span::mock().named(Some("foo")))
+                .close(span::mock().named(Some("foo")))
                 .done()
                 .run_with_handle();
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -610,39 +610,43 @@ mod tests {
 
     #[test]
     fn span_closes_on_drop() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
             span.enter(|| {});
             drop(span);
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn span_closes_after_event() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .event()
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             span!("foo").enter(|| {
                 Span::current().close();
                 event!(::Level::Debug, {}, "my event!");
             });
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn new_span_after_event() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .event()
             .exit(span::mock().named(Some("foo")))
@@ -651,7 +655,7 @@ mod tests {
             .exit(span::mock().named(Some("bar")))
             .close(span::mock().named(Some("bar")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             span!("foo").enter(|| {
                 Span::current().close();
@@ -660,74 +664,84 @@ mod tests {
             span!("bar").enter(|| {
                 Span::current().close();
             });
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn event_outside_of_span() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .event()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             debug!("my event!");
             span!("foo").enter(|| {
                 Span::current().close();
             });
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn dropping_a_span_calls_drop_span() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
             span.enter(|| {});
             drop(span);
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn span_current_calls_clone_span() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .clone_span(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
             let _span2 = span.enter(|| Span::current());
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn drop_span_when_exiting_dispatchers_context() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .clone_span(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
             let _span2 = span.enter(|| Span::current());
             drop(span);
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn clone_and_drop_span_always_go_to_the_subscriber_that_tagged_the_span() {
-        let subscriber1 = subscriber::mock()
+        let (subscriber1, handle1) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("foo")))
@@ -735,8 +749,9 @@ mod tests {
             .clone_span(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
-            .done();
-        let subscriber1 = Dispatch::new(subscriber1.run());
+            .done()
+            .run_with_handle();
+        let subscriber1 = Dispatch::new(subscriber1);
         let subscriber2 = Dispatch::new(subscriber::mock().done().run());
 
         let mut foo = subscriber1.as_default(|| {
@@ -751,11 +766,13 @@ mod tests {
             drop(foo);
             drop(foo2);
         });
+
+        handle1.assert_finished();
     }
 
     #[test]
     fn span_closes_when_idle() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             // A second span is entered so that the mock subscriber will
@@ -765,7 +782,7 @@ mod tests {
             .exit(span::mock().named(Some("bar")))
             .close(span::mock().named(Some("bar")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
@@ -776,17 +793,19 @@ mod tests {
             });
 
             assert!(foo.is_closed());
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
     fn entering_a_closed_span_is_a_no_op() {
-        let subscriber = subscriber::mock()
+        let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .close(span::mock().named(Some("foo")))
             .done()
-            .run();
+            .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
             foo.enter(|| {});
@@ -798,7 +817,9 @@ mod tests {
                 // exit.
             });
             assert!(foo.is_closed());
-        })
+        });
+
+        handle.assert_finished();
     }
 
     #[test]
@@ -815,13 +836,15 @@ mod tests {
 
         #[test]
         fn span_closes_on_drop() {
-            let subscriber = subscriber::mock()
+            let (subscriber, handle) = subscriber::mock()
                 .enter(span::mock().named(Some("foo")))
                 .exit(span::mock().named(Some("foo")))
                 .close(span::mock().named(Some("foo")))
                 .done()
-                .run();
-            Dispatch::new(subscriber).as_default(|| span!("foo").into_shared().enter(|| {}))
+                .run_with_handle();
+            Dispatch::new(subscriber).as_default(|| span!("foo").into_shared().enter(|| {}));
+
+            handle.assert_finished();
         }
 
         #[test]
@@ -835,13 +858,13 @@ mod tests {
 
         #[test]
         fn shared_only_calls_drop_span_when_the_last_handle_is_dropped() {
-            let subscriber = subscriber::mock()
+            let (subscriber, handle) = subscriber::mock()
                 .enter(span::mock().named(Some("foo")))
                 .exit(span::mock().named(Some("foo")))
                 .close(span::mock().named(Some("foo")))
                 .drop_span(span::mock().named(Some("foo")))
                 .done()
-                .run();
+                .run_with_handle();
             Dispatch::new(subscriber).as_default(|| {
                 let span = span!("foo").into_shared();
                 let foo1 = span.clone();
@@ -849,7 +872,9 @@ mod tests {
                 drop(foo1);
                 drop(span);
                 foo2.enter(|| {})
-            })
+            });
+
+            handle.assert_finished();
         }
 
         #[test]
@@ -858,7 +883,7 @@ mod tests {
             // threads are still executing inside that span.
             use std::sync::{Arc, Barrier};
 
-            let subscriber = subscriber::mock()
+            let (subscriber, handle) = subscriber::mock()
                 .enter(span::mock().named(Some("baz")))
                 // Main thread enters "quux".
                 .enter(span::mock().named(Some("quux")))
@@ -876,7 +901,7 @@ mod tests {
                 .exit(span::mock().named(Some("baz")))
                 .close(span::mock().named(Some("baz")))
                 .done()
-                .run();
+                .run_with_handle();
 
             Dispatch::new(subscriber).as_default(|| {
                 let barrier1 = Arc::new(Barrier::new(2));
@@ -910,13 +935,15 @@ mod tests {
                     handle.join().unwrap();
                 });
             });
+
+            handle.assert_finished();
         }
 
         #[test]
         fn exit_doesnt_finish_while_handles_still_exist() {
             // Test that exiting a span only marks it as "done" when no handles
             // that can re-enter the span exist.
-            let subscriber = subscriber::mock()
+            let (subscriber, handle) = subscriber::mock()
                 .enter(span::mock().named(Some("foo")))
                 .enter(span::mock().named(Some("bar")))
                 // The first time we exit "bar", there will be another handle with
@@ -930,7 +957,7 @@ mod tests {
                 .close(span::mock().named(Some("bar")))
                 .exit(span::mock().named(Some("foo")))
                 .done()
-                .run();
+                .run_with_handle();
 
             Dispatch::new(subscriber).as_default(|| {
                 span!("foo").enter(|| {
@@ -944,6 +971,8 @@ mod tests {
                     bar.enter(|| {});
                 });
             });
+
+            handle.assert_finished();
         }
     }
 }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -693,9 +693,8 @@ mod tests {
         let (subscriber, handle) = subscriber::mock()
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
-            .close(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
-            .done()
+            .drop_span(span::mock().named(Some("foo")))
             .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut span = span!("foo");
@@ -745,11 +744,10 @@ mod tests {
             .enter(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("foo")))
             .enter(span::mock().named(Some("foo")))
-            .exit(span::mock().named(Some("foo")))
             .clone_span(span::mock().named(Some("foo")))
+            .exit(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
             .drop_span(span::mock().named(Some("foo")))
-            .done()
             .run_with_handle();
         let subscriber1 = Dispatch::new(subscriber1);
         let subscriber2 = Dispatch::new(subscriber::mock().done().run());
@@ -780,8 +778,6 @@ mod tests {
             .enter(span::mock().named(Some("bar")))
             .close(span::mock().named(Some("foo")))
             .exit(span::mock().named(Some("bar")))
-            .close(span::mock().named(Some("bar")))
-            .done()
             .run_with_handle();
         Dispatch::new(subscriber).as_default(|| {
             let mut foo = span!("foo");
@@ -861,9 +857,7 @@ mod tests {
             let (subscriber, handle) = subscriber::mock()
                 .enter(span::mock().named(Some("foo")))
                 .exit(span::mock().named(Some("foo")))
-                .close(span::mock().named(Some("foo")))
                 .drop_span(span::mock().named(Some("foo")))
-                .done()
                 .run_with_handle();
             Dispatch::new(subscriber).as_default(|| {
                 let span = span!("foo").into_shared();

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -1,11 +1,7 @@
 pub use tokio_trace_core::subscriber::*;
 
+use std::{cell::UnsafeCell, default::Default, thread};
 use {Id, Span};
-use std::{
-    cell::UnsafeCell,
-    default::Default,
-    thread,
-};
 
 #[derive(Clone)]
 pub struct CurrentSpanPerThread {
@@ -22,11 +18,13 @@ impl CurrentSpanPerThread {
     }
 
     pub fn span(&self) -> &Span {
-        self.current.with(|current| unsafe { &*(current.get() as *const _) })
+        self.current
+            .with(|current| unsafe { &*(current.get() as *const _) })
     }
 
     pub fn set_current(&self, span: Span) -> Span {
-        self.current.with(|current| unsafe { current.get().replace(span) })
+        self.current
+            .with(|current| unsafe { current.get().replace(span) })
     }
 }
 
@@ -35,9 +33,7 @@ impl Default for CurrentSpanPerThread {
         thread_local! {
             static CURRENT: UnsafeCell<Span> = UnsafeCell::new(Span::new_disabled());
         };
-        Self {
-            current: &CURRENT,
-        }
+        Self { current: &CURRENT }
     }
 }
 

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -16,7 +16,6 @@ impl CurrentSpanPerThread {
         thread_local! {
             static CURRENT: UnsafeCell<Span> = UnsafeCell::new(Span::new_disabled());
         };
-        println!("current per thread new");
         Self {
             current: &CURRENT,
         }

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -249,26 +249,14 @@ mod tests {
         let count = Arc::new(AtomicUsize::new(0));
         let count2 = count.clone();
 
-        let (subscriber, handle) = subscriber::mock()
-            .enter(span::mock().named(Some("emily")))
-            .exit(span::mock().named(Some("emily")))
-            .enter(span::mock().named(Some("emily")))
-            .exit(span::mock().named(Some("emily")))
-            .enter(span::mock().named(Some("frank")))
-            .exit(span::mock().named(Some("frank")))
-            .enter(span::mock().named(Some("emily")))
-            .exit(span::mock().named(Some("emily")))
-            .enter(span::mock().named(Some("frank")))
-            .exit(span::mock().named(Some("frank")))
-            .enter(span::mock().named(Some("emily")))
-            .exit(span::mock().named(Some("emily")))
+        let subscriber = subscriber::mock()
             .with_filter(move |meta| match meta.name {
                 Some("emily") | Some("frank") => {
                     count2.fetch_add(1, Ordering::Relaxed);
                     true
                 }
                 _ => false,
-            }).run_with_handle();
+            }).run();
 
         Dispatch::new(subscriber).as_default(|| {
             // Call the function once. The filter should be re-evaluated.
@@ -291,7 +279,5 @@ mod tests {
             assert!(my_great_function());
             assert_eq!(count.load(Ordering::Relaxed), 2);
         });
-
-        handle.assert_finished();
     }
 }

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -3,7 +3,6 @@ pub use tokio_trace_core::subscriber::*;
 use std::{cell::UnsafeCell, default::Default, thread};
 use {Id, Span};
 
-
 /// Tracks the currently executing span on a per-thread basis.
 ///
 /// This is intended for use by `Subscriber` implementations.

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -2,8 +2,9 @@ pub use tokio_trace_core::subscriber::*;
 
 use {Id, Span};
 use std::{
-    thread,
     cell::UnsafeCell,
+    default::Default,
+    thread,
 };
 
 #[derive(Clone)]
@@ -13,12 +14,7 @@ pub struct CurrentSpanPerThread {
 
 impl CurrentSpanPerThread {
     pub fn new() -> Self {
-        thread_local! {
-            static CURRENT: UnsafeCell<Span> = UnsafeCell::new(Span::new_disabled());
-        };
-        Self {
-            current: &CURRENT,
-        }
+        Self::default()
     }
 
     pub fn id(&self) -> Option<Id> {
@@ -31,6 +27,17 @@ impl CurrentSpanPerThread {
 
     pub fn set_current(&self, span: Span) -> Span {
         self.current.with(|current| unsafe { current.get().replace(span) })
+    }
+}
+
+impl Default for CurrentSpanPerThread {
+    fn default() -> Self {
+        thread_local! {
+            static CURRENT: UnsafeCell<Span> = UnsafeCell::new(Span::new_disabled());
+        };
+        Self {
+            current: &CURRENT,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #60.

This branch moves the responsibility for tracking the current span out
of `core` and onto the `Subscriber` trait. This makes core responsible
for less and allows subscriber implementations to choose how this should
be tracked,

This change ended up being fairly large. In order to make subscribers
responsible for tracking the current span, the subscriber API needed to
change. Furthermore, several changes to the span entry, exit, and
closure logic were required. Additionally, the test changes I wrote to
verify this branch caught a few additional issues in the span closure
logic, so I've fixed those as well.

I've added a type that tracks the current thread using a thread-local in
the `tokio-trace` crate. This implements approximately the same
behaviour that core provided before this change, and subscribers may use
that type to avoid having to re-implement this behaviour.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>