### PR TITLE
Support Rust 1.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,21 @@ rust:
 jobs:
   include:
   - stage: test
-    script: |
-      cargo test -p tokio-trace &&
-      cargo test -p tokio-trace-futures &&
-      cargo test -p tokio-trace-subscriber &&
-      cargo test -p tokio-trace-tower &&
-      cargo test -p tokio-trace-tower-http &&
-      cargo test -p tokio-trace-log &&
-      cargo test -p tokio-trace-env-logger
     name: "tests"
+    script:
+    - cargo test -p tokio-trace
+    - cargo test -p tokio-trace-futures
+    - cargo test -p tokio-trace-subscriber
+    - cargo test -p tokio-trace-tower
+    - cargo test -p tokio-trace-tower-http
+    - cargo test -p tokio-trace-log
+    - cargo test -p tokio-trace-env-logger
   # The proc macros crate does _not_ build on Rust 1.26.0, so it is tested
   # in a separate stage.
   - stage: test
+    name: "test proc-macros"
     script:
     - cargo test -p tokio-trace-macros
-    name: "test proc-macros"
     rust: stable
   - script: cargo fmt --all -- --check
     install: rustup component add rustfmt-preview

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ jobs:
   - stage: test
     script: cargo test --all
     name: "tests"
+    rust:
+    # This represents the minimum Rust version supported by Tokio. Updating this
+    # should be done in a dedicated PR and cannot be greater than two 0.x
+    # releases prior to the current stable.
+    - 1.26.0
+    - stable
+    - beta
+    - nightly
   - script: cargo fmt --all -- --check
     install: rustup component add rustfmt-preview
     name: "rustfmt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,19 @@ rust:
 - beta
 - nightly
 
+  script:
+  - cargo test --verbose -p tokio-trace
+  - cargo test --verbose -p tokio-trace-futures
+  - cargo test --verbose -p tokio-trace-subscriber
+  - cargo test --verbose -p tokio-trace-tower
+  - cargo test --verbose -p tokio-trace-tower-http
+  - cargo test --verbose -p tokio-trace-log
+  - cargo test --verbose -p tokio-trace-env-logger
+
 jobs:
   include:
   - stage: test
     name: "tests"
-    script:
-    - cargo test -p tokio-trace
-    - cargo test -p tokio-trace-futures
-    - cargo test -p tokio-trace-subscriber
-    - cargo test -p tokio-trace-tower
-    - cargo test -p tokio-trace-tower-http
-    - cargo test -p tokio-trace-log
-    - cargo test -p tokio-trace-env-logger
   # The proc macros crate does _not_ build on Rust 1.26.0, so it is tested
   # in a separate stage.
   - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ rust:
 - beta
 - nightly
 
-  script:
-  - cargo test --verbose -p tokio-trace
-  - cargo test --verbose -p tokio-trace-futures
-  - cargo test --verbose -p tokio-trace-subscriber
-  - cargo test --verbose -p tokio-trace-tower
-  - cargo test --verbose -p tokio-trace-tower-http
-  - cargo test --verbose -p tokio-trace-log
-  - cargo test --verbose -p tokio-trace-env-logger
+script:
+- cargo test --verbose -p tokio-trace
+- cargo test --verbose -p tokio-trace-futures
+- cargo test --verbose -p tokio-trace-subscriber
+- cargo test --verbose -p tokio-trace-tower
+- cargo test --verbose -p tokio-trace-tower-http
+- cargo test --verbose -p tokio-trace-log
+- cargo test --verbose -p tokio-trace-env-logger
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ script:
 
 jobs:
   include:
-  - stage: test
-    name: "tests"
   # The proc macros crate does _not_ build on Rust 1.26.0, so it is tested
   # in a separate stage.
   - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: rust
 sudo: false
-  rust:
-  # This represents the minimum Rust version supported by Tokio. Updating this
-  # should be done in a dedicated PR and cannot be greater than two 0.x
-  # releases prior to the current stable.
-    - 1.26.0
-    - stable
-    - beta
-    - nightly
+rust:
+# This represents the minimum Rust version supported by Tokio. Updating this
+# should be done in a dedicated PR and cannot be greater than two 0.x
+# releases prior to the current stable.
+- 1.26.0
+- stable
+- beta
+- nightly
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,30 @@ sudo: false
 jobs:
   include:
   - stage: test
-    script: cargo test --all
+    script:
+    - cargo test -p tokio-trace
+    - cargo test -p tokio-trace-futures
+    - cargo test -p tokio-trace-subscriber
+    - cargo test -p tokio-trace-tower
+    - cargo test -p tokio-trace-tower-http
+    - cargo test -p tokio-trace-log
+    - cargo test -p tokio-trace-env-logger
     name: "tests"
     rust:
     # This represents the minimum Rust version supported by Tokio. Updating this
     # should be done in a dedicated PR and cannot be greater than two 0.x
     # releases prior to the current stable.
     - 1.26.0
+    - stable
+    - beta
+    - nightly
+  # The proc macros crate does _not_ build on Rust 1.26.0, so it is tested
+  # in a separate stage.
+  - stage: test
+    script:
+    - cargo test -p tokio-trace-macros
+    name: "test proc-macros"
+    rust:
     - stable
     - beta
     - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: rust
 sudo: false
+  rust:
+  # This represents the minimum Rust version supported by Tokio. Updating this
+  # should be done in a dedicated PR and cannot be greater than two 0.x
+  # releases prior to the current stable.
+    - 1.26.0
+    - stable
+    - beta
+    - nightly
 
 jobs:
   include:
@@ -13,24 +21,13 @@ jobs:
     - cargo test -p tokio-trace-log
     - cargo test -p tokio-trace-env-logger
     name: "tests"
-    rust:
-    # This represents the minimum Rust version supported by Tokio. Updating this
-    # should be done in a dedicated PR and cannot be greater than two 0.x
-    # releases prior to the current stable.
-    - 1.26.0
-    - stable
-    - beta
-    - nightly
   # The proc macros crate does _not_ build on Rust 1.26.0, so it is tested
   # in a separate stage.
   - stage: test
     script:
     - cargo test -p tokio-trace-macros
     name: "test proc-macros"
-    rust:
-    - stable
-    - beta
-    - nightly
+    rust: stable
   - script: cargo fmt --all -- --check
     install: rustup component add rustfmt-preview
     name: "rustfmt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ rust:
 jobs:
   include:
   - stage: test
-    script:
-    - cargo test -p tokio-trace
-    - cargo test -p tokio-trace-futures
-    - cargo test -p tokio-trace-subscriber
-    - cargo test -p tokio-trace-tower
-    - cargo test -p tokio-trace-tower-http
-    - cargo test -p tokio-trace-log
-    - cargo test -p tokio-trace-env-logger
+    script: |
+      cargo test -p tokio-trace &&
+      cargo test -p tokio-trace-futures &&
+      cargo test -p tokio-trace-subscriber &&
+      cargo test -p tokio-trace-tower &&
+      cargo test -p tokio-trace-tower-http &&
+      cargo test -p tokio-trace-log &&
+      cargo test -p tokio-trace-env-logger
     name: "tests"
   # The proc macros crate does _not_ build on Rust 1.26.0, so it is tested
   # in a separate stage.
@@ -31,3 +31,4 @@ jobs:
   - script: cargo fmt --all -- --check
     install: rustup component add rustfmt-preview
     name: "rustfmt"
+    rust: stable

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -15,7 +15,7 @@ lazy_static! {
 }
 
 struct Registry {
-    callsites: Vec<&'static dyn Callsite>,
+    callsites: Vec<&'static Callsite>,
     dispatchers: Vec<dispatcher::Registrar>,
 }
 
@@ -49,7 +49,7 @@ pub trait Callsite: Sync {
 /// Register a new `Callsite` with the global registry.
 ///
 /// This should be called once per callsite after the callsite has been constructed.
-pub fn register(callsite: &'static dyn Callsite) {
+pub fn register(callsite: &'static Callsite) {
     let mut registry = REGISTRY.lock().unwrap();
     let meta = callsite.metadata();
     registry.dispatchers.retain(|registrar| {

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -19,10 +19,10 @@ thread_local! {
 /// `Dispatch` trace data to a [`Subscriber`].
 #[derive(Clone)]
 pub struct Dispatch {
-    subscriber: Arc<dyn Subscriber + Send + Sync>,
+    subscriber: Arc<Subscriber + Send + Sync>,
 }
 
-pub(crate) struct Registrar(Weak<dyn Subscriber + Send + Sync>);
+pub(crate) struct Registrar(Weak<Subscriber + Send + Sync>);
 
 impl Dispatch {
     /// Returns a new `Dispatch` that discards events and spans.

--- a/tokio-trace-core/src/span.rs
+++ b/tokio-trace-core/src/span.rs
@@ -167,7 +167,7 @@ impl Span {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(callsite: &'static dyn Callsite, if_enabled: F) -> Span
+    pub fn new<F>(callsite: &'static Callsite, if_enabled: F) -> Span
     where
         F: FnOnce(&mut Span),
     {
@@ -381,7 +381,7 @@ impl<'a> Event<'a> {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(callsite: &'a dyn Callsite, if_enabled: F) -> Self
+    pub fn new<F>(callsite: &'a Callsite, if_enabled: F) -> Self
     where
         F: FnOnce(&mut Self),
     {

--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -21,7 +21,7 @@ use self::sloggish::SloggishSubscriber;
 use tokio_trace::field;
 use tokio_trace_futures::{Instrument, Instrumented};
 
-type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
     span!(

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate futures;
+#[cfg_attr(test, macro_use)]
 extern crate tokio_trace;
 
 use futures::{Async, Future, Poll, Sink, StartSend, Stream};

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -592,7 +592,7 @@ impl Subscriber for TraceLogger {
 //         }
 //     }
 
-//     fn filter(&self) -> &dyn tokio_trace_subscriber::Filter {
+//     fn filter(&self) -> &tokio_trace_subscriber::Filter {
 //         self
 //     }
 // }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -107,12 +107,7 @@ where
         self.registry.new_id(new_id)
     }
 
-    fn record_fmt(
-        &self,
-        _span: &Id,
-        _name: &field::Key,
-        _value: ::std::fmt::Arguments,
-    ) {
+    fn record_fmt(&self, _span: &Id, _name: &field::Key, _value: ::std::fmt::Arguments) {
         unimplemented!()
     }
 

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,5 @@
 use tokio_trace::{
+    field,
     span::{self, Span},
     subscriber::Subscriber,
     Id, Meta,
@@ -109,7 +110,7 @@ where
     fn record_fmt(
         &self,
         _span: &Id,
-        _name: &tokio_trace::field::Key,
+        _name: &field::Key,
         _value: ::std::fmt::Arguments,
     ) {
         unimplemented!()

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -15,7 +15,7 @@ pub trait Observe {
     fn exit(&self, span: &Span);
     fn close(&self, span: &SpanRef);
 
-    fn filter(&self) -> &dyn Filter {
+    fn filter(&self) -> &Filter {
         &filter::NoFilter
     }
 }
@@ -49,7 +49,7 @@ pub trait ObserveExt: Observe {
     /// # fn enter(&self, _: &Span) {}
     /// # fn exit(&self, _: &Span) {}
     /// # fn close(&self, _: &SpanRef) {}
-    /// # fn filter(&self) -> &dyn Filter { &NoFilter}
+    /// # fn filter(&self) -> &Filter { &NoFilter}
     /// }
     ///
     /// impl Observe for Bar {
@@ -58,7 +58,7 @@ pub trait ObserveExt: Observe {
     /// # fn enter(&self, _: &Span) {}
     /// # fn exit(&self, _: &Span) {}
     /// # fn close(&self, _: &SpanRef) {}
-    /// # fn filter(&self) -> &dyn Filter { &NoFilter}
+    /// # fn filter(&self) -> &Filter { &NoFilter}
     /// }
     ///
     /// let foo = Foo { };
@@ -159,7 +159,7 @@ pub struct NoObserver;
 /// `Observe`.
 ///
 /// This is intended to be used when an observer implementation is chosen
-/// conditionally, and the overhead of `Box<dyn Observe>` is unwanted.
+/// conditionally, and the overhead of `Box<Observe>` is unwanted.
 ///
 /// For example:
 /// ```
@@ -184,7 +184,7 @@ pub struct NoObserver;
 /// # fn enter(&self, _: &Span) {}
 /// # fn exit(&self, _: &Span) {}
 /// # fn close(&self, _: &SpanRef) {}
-/// # fn filter(&self) -> &dyn Filter { &NoFilter}
+/// # fn filter(&self) -> &Filter { &NoFilter}
 /// }
 ///
 /// impl Observe for Bar {
@@ -193,7 +193,7 @@ pub struct NoObserver;
 /// # fn enter(&self, _: &Span) {}
 /// # fn exit(&self, _: &Span) {}
 /// # fn close(&self, _: &SpanRef) {}
-/// # fn filter(&self) -> &dyn Filter { &NoFilter}
+/// # fn filter(&self) -> &Filter { &NoFilter}
 /// }
 ///
 /// fn foo_or_bar(foo: bool) -> observe::Either<Foo, Bar> {
@@ -276,7 +276,7 @@ where
         self.inner.close(span)
     }
 
-    fn filter(&self) -> &dyn Filter {
+    fn filter(&self) -> &Filter {
         self
     }
 }
@@ -323,7 +323,7 @@ where
         self.b.close(span);
     }
 
-    fn filter(&self) -> &dyn Filter {
+    fn filter(&self) -> &Filter {
         self
     }
 }
@@ -406,7 +406,7 @@ impl Observe for NoObserver {
 
     fn close(&self, _span: &SpanRef) {}
 
-    fn filter(&self) -> &dyn Filter {
+    fn filter(&self) -> &Filter {
         self
     }
 }


### PR DESCRIPTION
Closes #108 

This branch adds a Rust 1.26.0 CI build, and changes all the crates
except for `tokio-trace-macros` to work with Rust 1.26.0.

I don't know if it's possible to make the proc macros work with Rust
1.26.0, but since they're not core, it doesn't matter as much. Thus,
they're only built in a separate CI job that builds against stable.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>