### PR TITLE
Make `Callsite` less `Interest`ing

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -21,9 +21,6 @@ struct Registry {
 
 /// Trait implemented by callsites.
 pub trait Callsite: Sync {
-    /// Returns the callsite's current Interest.
-    fn interest(&self) -> Interest;
-
     /// Adds the [`Interest`] returned by [registering] the callsite with a
     /// [dispatcher].
     ///

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -348,22 +348,6 @@ impl Interest {
     /// If any subscriber expresses that it is `ALWAYS` interested in a given
     /// callsite, then the callsite will always be enabled.
     pub const ALWAYS: Interest = Interest(InterestKind::Always);
-
-    /// Constructs a new `Interest` from a `usize`.
-    #[inline]
-    pub fn from_usize(u: usize) -> Option<Self> {
-        match u {
-            0 => Some(Interest::NEVER),
-            1 => Some(Interest::SOMETIMES),
-            2 => Some(Interest::ALWAYS),
-            _ => None,
-        }
-    }
-
-    /// Returns an `usize` representing this `Interest`.
-    pub fn as_usize(&self) -> usize {
-        self.0 as usize
-    }
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -42,9 +42,13 @@ use tokio_trace::{
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let meta = record.as_trace();
     let k = meta.key_for(&"message").unwrap();
-    drop(tokio_trace::Event::new(subscriber::Interest::SOMETIMES, &meta, |event| {
-        event.message(&k, record.args().clone());
-    }));
+    drop(tokio_trace::Event::new(
+        subscriber::Interest::SOMETIMES,
+        &meta,
+        |event| {
+            event.message(&k, record.args().clone());
+        },
+    ));
     Ok(())
 }
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -40,29 +40,9 @@ use tokio_trace::{
 
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
-    struct LogCallsite<'a>(tokio_trace::Meta<'a>);
-    impl<'a> tokio_trace::Callsite for LogCallsite<'a> {
-        fn interest(&self) -> tokio_trace::subscriber::Interest {
-            tokio_trace::subscriber::Interest::SOMETIMES
-        }
-
-        fn add_interest(&self, _interest: tokio_trace::subscriber::Interest) {
-            // Since these callsites can't be registered (they're not known to
-            // be valid for the 'static lifetime), we don't need to track
-            // interest --- do nothing.
-        }
-
-        fn remove_interest(&self) {
-            // Again, we don't cache interest for these.
-        }
-
-        fn metadata(&self) -> &Meta {
-            &self.0
-        }
-    }
-    let callsite = LogCallsite(record.as_trace());
-    let k = callsite.0.key_for(&"message").unwrap();
-    drop(tokio_trace::Event::new(&callsite, |event| {
+    let meta = record.as_trace();
+    let k = meta.key_for(&"message").unwrap();
+    drop(tokio_trace::Event::new(subscriber::Interest::SOMETIMES, &meta, |event| {
         event.message(&k, record.args().clone());
     }));
     Ok(())

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -146,7 +146,6 @@ use std::{
     hash::{Hash, Hasher},
 };
 use {
-    callsite::Callsite,
     dispatcher::{self, Dispatch},
     field,
     subscriber::{Interest, Subscriber},
@@ -256,16 +255,14 @@ impl Span {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(callsite: &'static Callsite, if_enabled: F) -> Span
+    pub fn new<F>(interest: Interest, meta: &'static Meta<'static>, if_enabled: F) -> Span
     where
         F: FnOnce(&mut Span),
     {
-        let interest = callsite.interest();
         if interest == Interest::NEVER {
             return Span::new_disabled();
         }
         dispatcher::with_current(|dispatch| {
-            let meta = callsite.metadata();
             if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
                 return Span {
                     inner: None,
@@ -442,16 +439,14 @@ impl<'a> Event<'a> {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(callsite: &'a Callsite, if_enabled: F) -> Self
+    pub fn new<F>(interest: Interest, meta: &'a Meta<'a>, if_enabled: F) -> Self
     where
         F: FnOnce(&mut Self),
     {
-        let interest = callsite.interest();
         if interest == Interest::NEVER {
             return Self { inner: None };
         }
         dispatcher::with_current(|dispatch| {
-            let meta = callsite.metadata();
             if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
                 return Self { inner: None };
             }


### PR DESCRIPTION
Depends on #123.

Closes #115.
Closes #120.
Closes #121.

This branch makes several minor changes to the `Callsite` and 
`Interest` types: 

+ Remove the `Interest::from_usize` and `Interest::as_usize` 
  conversions, as they create a forward-compatibility hazard.
+ Remove the `Callsite::interest` method, as it was not strictly
  necessary.
+ Rename `Callsite::remove_interest` to `clear_interest`, which
  more accurately describes the method's behaviour.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>