### PR TITLE
Make `Level` a struct rather than an enum

### DIFF
--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -81,30 +81,8 @@ extern crate lazy_static;
 use std::borrow::Borrow;
 
 /// Describes the level of verbosity of a `Span` or `Event`.
-#[repr(usize)]
-#[derive(Copy, Eq, Debug, Hash)]
-pub enum Level {
-    /// The "error" level.
-    ///
-    /// Designates very serious errors.
-    Error = 1, // This way these line up with the discriminants for LevelFilter below
-    /// The "warn" level.
-    ///
-    /// Designates hazardous situations.
-    Warn,
-    /// The "info" level.
-    ///
-    /// Designates useful information.
-    Info,
-    /// The "debug" level.
-    ///
-    /// Designates lower priority information.
-    Debug,
-    /// The "trace" level.
-    ///
-    /// Designates very low priority, often extremely verbose, information.
-    Trace,
-}
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Level(LevelInner);
 
 pub mod callsite;
 pub mod dispatcher;
@@ -288,18 +266,52 @@ impl<'a> PartialEq for Meta<'a> {
 
 // ===== impl Level =====
 
-impl Clone for Level {
-    #[inline]
-    fn clone(&self) -> Level {
-        *self
-    }
+impl Level {
+    /// The "error" level.
+    ///
+    /// Designates very serious errors.
+    pub const ERROR: Level = Level(LevelInner::Error);
+    /// The "warn" level.
+    ///
+    /// Designates hazardous situations.
+    pub const WARN: Level = Level(LevelInner::Warn);
+    /// The "info" level.
+    ///
+    /// Designates useful information.
+    pub const INFO: Level = Level(LevelInner::Info);
+    /// The "debug" level.
+    ///
+    /// Designates lower priority information.
+    pub const DEBUG: Level = Level(LevelInner::Debug);
+    /// The "trace" level.
+    ///
+    /// Designates very low priority, often extremely verbose, information.
+    pub const TRACE: Level = Level(LevelInner::Trace);
 }
 
-impl PartialEq for Level {
-    #[inline]
-    fn eq(&self, other: &Level) -> bool {
-        *self as usize == *other as usize
-    }
+#[repr(usize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+enum LevelInner {
+    /// The "error" level.
+    ///
+    /// Designates very serious errors.
+    Error = 1, // This way these line up with the discriminants for LevelFilter below
+    /// The "warn" level.
+    ///
+    /// Designates hazardous situations.
+    Warn,
+    /// The "info" level.
+    ///
+    /// Designates useful information.
+    Info,
+    /// The "debug" level.
+    ///
+    /// Designates lower priority information.
+    Debug,
+    /// The "trace" level.
+    ///
+    /// Designates very low priority, often extremely verbose, information.
+    Trace,
 }
 
 // ===== impl MetaKind =====

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -90,11 +90,11 @@ impl AsLog for tokio_trace::Level {
     type Log = log::Level;
     fn as_log(&self) -> log::Level {
         match self {
-            tokio_trace::Level::Error => log::Level::Error,
-            tokio_trace::Level::Warn => log::Level::Warn,
-            tokio_trace::Level::Info => log::Level::Info,
-            tokio_trace::Level::Debug => log::Level::Debug,
-            tokio_trace::Level::Trace => log::Level::Trace,
+            &tokio_trace::Level::ERROR => log::Level::Error,
+            &tokio_trace::Level::WARN => log::Level::Warn,
+            &tokio_trace::Level::INFO => log::Level::Info,
+            &tokio_trace::Level::DEBUG => log::Level::Debug,
+            &tokio_trace::Level::TRACE => log::Level::Trace,
         }
     }
 }
@@ -103,11 +103,11 @@ impl AsTrace for log::Level {
     type Trace = tokio_trace::Level;
     fn as_trace(&self) -> tokio_trace::Level {
         match self {
-            log::Level::Error => tokio_trace::Level::Error,
-            log::Level::Warn => tokio_trace::Level::Warn,
-            log::Level::Info => tokio_trace::Level::Info,
-            log::Level::Debug => tokio_trace::Level::Debug,
-            log::Level::Trace => tokio_trace::Level::Trace,
+            log::Level::Error => tokio_trace::Level::ERROR,
+            log::Level::Warn => tokio_trace::Level::WARN,
+            log::Level::Info => tokio_trace::Level::INFO,
+            log::Level::Debug => tokio_trace::Level::DEBUG,
+            log::Level::Trace => tokio_trace::Level::TRACE,
         }
     }
 }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -59,11 +59,11 @@ struct ColorLevel(Level);
 impl fmt::Display for ColorLevel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            Level::Trace => Color::Purple.paint("TRACE"),
-            Level::Debug => Color::Blue.paint("DEBUG"),
-            Level::Info => Color::Green.paint("INFO"),
-            Level::Warn => Color::Yellow.paint("WARN "),
-            Level::Error => Color::Red.paint("ERROR"),
+            Level::TRACE => Color::Purple.paint("TRACE"),
+            Level::DEBUG => Color::Blue.paint("DEBUG"),
+            Level::INFO => Color::Green.paint("INFO"),
+            Level::WARN => Color::Yellow.paint("WARN "),
+            Level::ERROR => Color::Red.paint("ERROR"),
         }.fmt(f)
     }
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -7,7 +7,7 @@ macro_rules! callsite {
         callsite!(@ $crate::Meta {
             name: Some($name),
             target: module_path!(),
-            level: $crate::Level::Trace,
+            level: $crate::Level::TRACE,
             module_path: Some(module_path!()),
             file: Some(file!()),
             line: Some(line!()),
@@ -173,50 +173,50 @@ macro_rules! event {
 #[macro_export]
 macro_rules! trace {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Trace, { $($k $( = $val)* ),* }, $($arg)+)
+        event!(target: module_path!(), $crate::Level::TRACE, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Trace, {}, $($arg)+)
+        event!(target: module_path!(), $crate::Level::TRACE, {}, $($arg)+)
     );
 }
 
 #[macro_export]
 macro_rules! debug {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Debug, { $($k $( = $val)* ),* }, $($arg)+)
+        event!(target: module_path!(), $crate::Level::DEBUG, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Debug, {}, $($arg)+)
+        event!(target: module_path!(), $crate::Level::DEBUG, {}, $($arg)+)
     );
 }
 
 #[macro_export]
 macro_rules! info {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Info, { $($k $( = $val)* ),* }, $($arg)+)
+        event!(target: module_path!(), $crate::Level::INFO, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Info, {}, $($arg)+)
+        event!(target: module_path!(), $crate::Level::INFO, {}, $($arg)+)
     );
 }
 
 #[macro_export]
 macro_rules! warn {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Warn, { $($k $( = $val)* ),* }, $($arg)+)
+        event!(target: module_path!(), $crate::Level::WARN, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Warn, {}, $($arg)+)
+        event!(target: module_path!(), $crate::Level::WARN, {}, $($arg)+)
     );
 }
 
 #[macro_export]
 macro_rules! error {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Error, { $($k $( = $val)* ),* }, $($arg)+)
+        event!(target: module_path!(), $crate::Level::ERROR, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::Error, {}, $($arg)+)
+        event!(target: module_path!(), $crate::Level::ERROR, {}, $($arg)+)
     );
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -1010,7 +1010,7 @@ mod tests {
             .run_with_handle();
         dispatcher::with_default(Dispatch::new(subscriber), || {
             span!("foo").enter(|| {
-                event!(::Level::Debug, {}, "my event!");
+                event!(::Level::DEBUG, {}, "my event!");
             });
         });
 
@@ -1031,7 +1031,7 @@ mod tests {
             .run_with_handle();
         dispatcher::with_default(Dispatch::new(subscriber), || {
             span!("foo").enter(|| {
-                event!(::Level::Debug, {}, "my event!");
+                event!(::Level::DEBUG, {}, "my event!");
             });
             span!("bar").enter(|| {});
         });


### PR DESCRIPTION
Closes #118 

This branch replaces the public `Level` enum with a struct so that the
variants can be changed without causing a breaking change. The variants
are now represented as associated constants (similarly to `Interest`) so
that they may still be used in a static context.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>