### PR TITLE
Remove unneeded derived traits

### DIFF
--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -42,7 +42,7 @@ use std::{
 /// field across all instances of a given span or event with the same metadata.
 /// Thus, when a subscriber observes a new span or event, it need only access a
 /// field by name _once_, and use the key for that name for all other accesses.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Key {
     i: usize,
     fields: Fields,
@@ -50,7 +50,6 @@ pub struct Key {
 
 /// Describes the fields present on a span.
 // TODO: When `const fn` is stable, make this type's fields private.
-#[derive(Clone)]
 pub struct Fields {
     /// The names of each field on the described span.
     ///
@@ -131,6 +130,18 @@ impl Hash for Key {
     }
 }
 
+impl Clone for Key {
+    fn clone(&self) -> Self {
+        Key {
+            i: self.i,
+            fields: Fields {
+                names: self.fields.names,
+                callsite: self.fields.callsite,
+            }
+        }
+    }
+}
+
 // ===== impl Fields =====
 
 impl Fields {
@@ -147,7 +158,10 @@ impl Fields {
         let name = &name.borrow();
         self.names.iter().position(|f| f == name).map(|i| Key {
             i,
-            fields: self.clone(),
+            fields: Fields {
+                names: self.names,
+                callsite: self.callsite,
+            }
         })
     }
 
@@ -161,7 +175,10 @@ impl Fields {
         let idxs = 0..self.names.len();
         Iter {
             idxs,
-            fields: self.clone(),
+            fields: Fields {
+                names: self.names,
+                callsite: self.callsite,
+            }
         }
     }
 }
@@ -189,7 +206,10 @@ impl Iterator for Iter {
         let i = self.idxs.next()?;
         Some(Key {
             i,
-            fields: self.fields.clone(),
+            fields: Fields {
+                names: self.fields.names,
+                callsite: self.fields.callsite,
+            }
         })
     }
 }

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -137,7 +137,7 @@ impl Clone for Key {
             fields: Fields {
                 names: self.fields.names,
                 callsite: self.fields.callsite,
-            }
+            },
         }
     }
 }
@@ -161,7 +161,7 @@ impl Fields {
             fields: Fields {
                 names: self.names,
                 callsite: self.callsite,
-            }
+            },
         })
     }
 
@@ -178,7 +178,7 @@ impl Fields {
             fields: Fields {
                 names: self.names,
                 callsite: self.callsite,
-            }
+            },
         }
     }
 }
@@ -209,7 +209,7 @@ impl Iterator for Iter {
             fields: Fields {
                 names: self.fields.names,
                 callsite: self.fields.callsite,
-            }
+            },
         })
     }
 }

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -31,7 +31,6 @@ use std::fmt;
 /// [`Meta::id()`]: ::metadata::Meta::id
 /// [callsite identifier]: ::callsite::Identifier
 // TODO: When `const fn` is stable, make this type's fields private.
-#[derive(Clone)]
 pub struct Meta<'a> {
     /// The name of the span described by this metadata.
     ///

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -140,7 +140,7 @@ pub struct Meta<'a> {
 }
 
 /// Describes the level of verbosity of a `Span` or `Event`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Level(LevelInner);
 
 /// Indicates whether a set of [metadata] describes a [`Span`] or an [`Event`].
@@ -148,7 +148,7 @@ pub struct Level(LevelInner);
 /// [metadata]: ::Meta
 /// [`Span`]: ::span::Span
 /// [`Event`]: ::Event
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Kind(KindInner);
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -230,8 +230,8 @@ impl<'a> Meta<'a> {
     }
 
     /// Returns the level of verbosity of the described span or event.
-    pub fn level(&self) -> Level {
-        self.level
+    pub fn level(&self) -> &Level {
+        &self.level
     }
 
     /// Returns the name of the span.

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -148,7 +148,7 @@ pub struct Level(LevelInner);
 /// [metadata]: ::Meta
 /// [`Span`]: ::span::Span
 /// [`Event`]: ::Event
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Kind(KindInner);
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -306,7 +306,7 @@ pub trait Subscriber {
 }
 
 /// Indicates a `Subscriber`'s interest in a particular callsite.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Interest(InterestKind);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -348,6 +348,33 @@ impl Interest {
     /// If any subscriber expresses that it is `ALWAYS` interested in a given
     /// callsite, then the callsite will always be enabled.
     pub const ALWAYS: Interest = Interest(InterestKind::Always);
+
+    /// Returns `true` if the subscriber is never interested in being notified
+    /// about this callsite.
+    pub fn is_never(&self) -> bool {
+        match self.0 {
+            InterestKind::Never => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the subscriber is sometimes interested in being notified
+    /// about this callsite.
+    pub fn is_sometimes(&self) -> bool {
+        match self.0 {
+            InterestKind::Sometimes => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the subscriber is always interested in being notified
+    /// about this callsite.
+    pub fn is_always(&self) -> bool {
+        match self.0 {
+            InterestKind::Always => true,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -330,7 +330,7 @@ impl EventLineBuilder {
         }
         Self {
             ref_count: 1,
-            level: meta.level,
+            level: meta.level.clone(),
             file: meta.file.map(|s| s.to_owned()),
             line: meta.line,
             module_path: meta.module_path.map(|s| s.to_owned()),

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -88,7 +88,7 @@ impl Event {
     fn new(meta: &tokio_trace::Meta) -> Self {
         Self {
             target: meta.target.to_owned(),
-            level: meta.level,
+            level: meta.level.clone(),
             message: String::new(),
             kvs: Vec::new(),
         }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -259,11 +259,11 @@ impl Span {
     where
         F: FnOnce(&mut Span),
     {
-        if interest == Interest::NEVER {
+        if interest.is_never() {
             return Span::new_disabled();
         }
         let mut span = dispatcher::with_current(|dispatch| {
-            if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
+            if interest.is_sometimes() && !dispatch.enabled(meta) {
                 return Span {
                     inner: None,
                     is_closed: false,
@@ -430,11 +430,11 @@ impl<'a> Event<'a> {
     where
         F: FnOnce(&mut Self),
     {
-        if interest == Interest::NEVER {
+        if interest.is_never() {
             return Self { inner: None };
         }
         let mut event = dispatcher::with_current(|dispatch| {
-            if interest == Interest::SOMETIMES && !dispatch.enabled(meta) {
+            if interest.is_sometimes() && !dispatch.enabled(meta) {
                 return Self { inner: None };
             }
             let id = dispatch.new_id(meta);


### PR DESCRIPTION
This branch removes several unnecessary derived traits from types in
`tokio-trace-core`:
+ `Interest` no longer derives `Copy`, `Eq`, `PartialEq`, `Ord`, and
  `PartialOrd` (#146). New `is_never`/`is_sometimes`/`is_always` 
  methods allow  checking an `Interest` without using equality, 
  although this interface is admittedly somewhat more cumbersome.
+ `Fields` no longer derives `Clone` (#139).
+ `metadata::Level` no longer derives `Copy` and `Hash`.
+ `metadata::Kind` no longer derives `Copy`, `Hash`, `PartialEq`,
  and `Eq` (as it has `is_span`/`is_event` methods already).

@carllerche, do you think this is sufficient to close #147, or are
there more derived traits that you think ought to be removed?

Closes #146.
Closes #139.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>