### PR TITLE
Remove some unneeded APIs

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -96,7 +96,6 @@ pub fn reset_registry() {
 
 impl Callsite + 'static {
     /// Returns an `Identifier` unique to this `Callsite`.
-    // TODO: can this just be public API?
     pub(crate) fn id(&'static self) -> Identifier {
         Identifier::from_callsite(self)
     }
@@ -106,7 +105,6 @@ impl Callsite + 'static {
 
 impl Identifier {
     /// Returns an `Identifier` unique to the provided `Callsite`.
-    // TODO: can this just be public API?
     pub(crate) fn from_callsite(callsite: &'static Callsite) -> Self {
         Identifier(callsite)
     }

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -87,12 +87,6 @@ impl Key {
         self.fields.id()
     }
 
-    /// Return a `usize` representing the index into an array whose indices are
-    /// ordered the same as the set of fields that generated this `key`.
-    pub fn as_usize(&self) -> usize {
-        self.i
-    }
-
     /// Returns a string representing the name of the field, or `None` if the
     /// field does not exist.
     pub fn name(&self) -> Option<&'static str> {
@@ -167,7 +161,7 @@ impl Fields {
 
     /// Returns `true` if `self` contains a field for the given `key`.
     pub fn contains_key(&self, key: &Key) -> bool {
-        key.id() == self.id() && key.as_usize() <= self.names.len()
+        key.id() == self.id() && key.i <= self.names.len()
     }
 
     /// Returns an iterator over the `Key`s to this set of `Fields`.

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -93,7 +93,3 @@ pub use self::{
     span::Span,
     subscriber::{Interest, Subscriber},
 };
-
-mod sealed {
-    pub trait Sealed {}
-}

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -93,7 +93,10 @@ pub trait Subscriber {
     /// callsite, if another subscriber expressed interest in it.
     /// [metadata]: ::Meta [`enabled`]: ::Subscriber::enabled
     fn register_callsite(&self, metadata: &Meta) -> Interest {
-        Interest::from_filter(self.enabled(metadata))
+        match self.enabled(metadata) {
+            true => Interest::ALWAYS,
+            false => Interest::NEVER,
+        }
     }
 
     /// Record the construction of a new [`Span`], returning a new ID
@@ -317,14 +320,6 @@ enum InterestKind {
 }
 
 impl Interest {
-    /// Construct a new `Interest` from the result of evaluating a filter.
-    pub fn from_filter(filter: bool) -> Self {
-        match filter {
-            true => Interest::ALWAYS,
-            false => Interest::NEVER,
-        }
-    }
-
     /// Indicates that the subscriber is never interested in being notified
     /// about a callsite.
     ///


### PR DESCRIPTION
This branch removes unneeded and unused code from `tokio-trace-core`'s
API. In particular, I've removed `field::Key::as_usize`,
`subscriber::Interest::from_filter`, and the dead code `Sealed` trait.

Closes #148.
Closes #143.
Closes #145.
Closes #148.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>