### PR TITLE
Replace `record_fmt` with `record_debug`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -86,8 +86,8 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record_fmt(&self, span: &Span, field: &field::Key, value: fmt::Arguments) {
-        self.subscriber.record_fmt(span, field, value)
+    fn record_debug(&self, span: &Span, field: &field::Key, value: &fmt::Debug) {
+        self.subscriber.record_debug(span, field, value)
     }
 
     #[inline]
@@ -127,7 +127,7 @@ impl Subscriber for NoSubscriber {
         Span::from_u64(0)
     }
 
-    fn record_fmt(&self, _span: &Span, _key: &field::Key, _value: fmt::Arguments) {}
+    fn record_debug(&self, _span: &Span, _field: &field::Key, _value: &fmt::Debug) {}
 
     fn add_follows_from(&self, _span: &Span, _follows: Span) {}
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -148,7 +148,7 @@ pub trait Subscriber {
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
     fn record_i64(&self, span: &Span, field: &field::Key, value: i64) {
-        self.record_fmt(span, field, format_args!("{}", value))
+        self.record_debug(span, field, &value)
     }
 
     /// Record an umsigned 64-bit integer value.
@@ -161,7 +161,7 @@ pub trait Subscriber {
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
     fn record_u64(&self, span: &Span, field: &field::Key, value: u64) {
-        self.record_fmt(span, field, format_args!("{}", value))
+        self.record_debug(span, field, &value)
     }
 
     /// Record a boolean value.
@@ -174,7 +174,7 @@ pub trait Subscriber {
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
     fn record_bool(&self, span: &Span, field: &field::Key, value: bool) {
-        self.record_fmt(span, field, format_args!("{}", value))
+        self.record_debug(span, field, &value)
     }
 
     /// Record a string value.
@@ -187,15 +187,15 @@ pub trait Subscriber {
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
     fn record_str(&self, span: &Span, field: &field::Key, value: &str) {
-        self.record_fmt(span, field, format_args!("{}", value))
+        self.record_debug(span, field, &value)
     }
 
-    /// Record a set of pre-compiled format arguments.
+    /// Record a value implementing `fmt::Debug`.
     ///
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_fmt(&self, span: &Span, field: &field::Key, value: fmt::Arguments);
+    fn record_debug(&self, span: &Span, field: &field::Key, value: &fmt::Debug);
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -385,6 +385,7 @@ mod test_support {
 
     use std::{
         collections::{HashMap, VecDeque},
+        fmt,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc, Mutex,
@@ -510,7 +511,7 @@ mod test_support {
             (self.filter)(meta)
         }
 
-        fn record_fmt(&self, _id: &Span, _field: &field::Key, _value: ::std::fmt::Arguments) {
+        fn record_debug(&self, span: &Span, field: &field::Key, value: &fmt::Debug) {
             // TODO: it would be nice to be able to expect field values...
         }
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -287,7 +287,12 @@ impl SpanLineBuilder {
     }
 
     fn record(&mut self, key: &field::Key, value: &fmt::Debug) -> fmt::Result {
-        write!(&mut self.fields, "{}={:?}; ", key.name().unwrap_or("???"), value)
+        write!(
+            &mut self.fields,
+            "{}={:?}; ",
+            key.name().unwrap_or("???"),
+            value
+        )
     }
 
     fn finish(self) {
@@ -342,7 +347,12 @@ impl EventLineBuilder {
         if key.name() == Some("message") {
             write!(&mut self.message, "{:?}", value)
         } else {
-            write!(&mut self.log_line, "{}={:?}; ", key.name().unwrap_or("???"), value)
+            write!(
+                &mut self.log_line,
+                "{}={:?}; ",
+                key.name().unwrap_or("???"),
+                value
+            )
         }
     }
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -286,10 +286,8 @@ impl SpanLineBuilder {
         }
     }
 
-    fn record(&mut self, key: &field::Key, val: fmt::Arguments) -> fmt::Result {
-        write!(&mut self.fields, "{}=", key.name().unwrap_or("???"))?;
-        self.fields.write_fmt(val)?;
-        self.fields.write_str("; ")
+    fn record(&mut self, key: &field::Key, value: &fmt::Debug) -> fmt::Result {
+        write!(&mut self.fields, "{}={:?}; ", key.name().unwrap_or("???"), value)
     }
 
     fn finish(self) {
@@ -340,13 +338,11 @@ impl EventLineBuilder {
         }
     }
 
-    fn record(&mut self, key: &field::Key, val: fmt::Arguments) -> fmt::Result {
+    fn record(&mut self, key: &field::Key, value: &fmt::Debug) -> fmt::Result {
         if key.name() == Some("message") {
-            self.message.write_fmt(val)
+            write!(&mut self.message, "{:?}", value)
         } else {
-            write!(&mut self.log_line, "{}=", key.name().unwrap_or("???"))?;
-            self.log_line.write_fmt(val)?;
-            self.log_line.write_str("; ")
+            write!(&mut self.log_line, "{}={:?}; ", key.name().unwrap_or("???"), value)
         }
     }
 
@@ -407,16 +403,16 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn record_fmt(&self, span: &Id, key: &field::Key, val: fmt::Arguments) {
+    fn record_debug(&self, span: &Id, key: &field::Key, value: &fmt::Debug) {
         let mut in_progress = self.in_progress.lock().unwrap();
         if let Some(span) = in_progress.spans.get_mut(span) {
-            if let Err(_e) = span.record(key, val) {
+            if let Err(_e) = span.record(key, value) {
                 eprintln!("error formatting span");
             }
             return;
         }
         if let Some(event) = in_progress.events.get_mut(span) {
-            if let Err(_e) = event.record(key, val) {
+            if let Err(_e) = event.record(key, value) {
                 eprintln!("error formatting event");
             }
         }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,5 +1,6 @@
 use tokio_trace::{field, subscriber::Subscriber, Id, Meta};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub struct Composed<F, O, R> {
@@ -102,7 +103,7 @@ where
         self.registry.new_id(meta)
     }
 
-    fn record_fmt(&self, _span: &Id, _name: &field::Key, _value: ::std::fmt::Arguments) {
+    fn record_debug(&self, _span: &Id, _name: &field::Key, _value: &fmt::Debug) {
         unimplemented!()
     }
 

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,6 +1,6 @@
+use std::fmt;
 use tokio_trace::{field, subscriber::Subscriber, Id, Meta};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
-use std::fmt;
 
 #[derive(Debug, Clone)]
 pub struct Composed<F, O, R> {

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -69,14 +69,7 @@ impl Subscriber for CounterSubscriber {
         };
     }
 
-    /// Adds a new field to an existing span observed by this `Subscriber`.
-    ///
-    /// This is expected to return an error under the following conditions:
-    /// - The span ID does not correspond to a span which currently exists.
-    /// - The span does not have a field with the given name.
-    /// - The span has a field with the given name, but the value has already
-    ///   been set.
-    fn record_fmt(&self, _id: &Id, _field: &field::Key, _value: ::std::fmt::Arguments) {}
+    fn record_debug(&self, _id: &Id, _field: &field::Key, _value: &::std::fmt::Debug) {}
 
     fn enabled(&self, metadata: &Meta) -> bool {
         if !metadata.is_span() {

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -180,18 +180,18 @@ impl Subscriber for SloggishSubscriber {
         id
     }
 
-    fn record_fmt(
+    fn record_debug(
         &self,
         span: &tokio_trace::Id,
         name: &tokio_trace::field::Key,
-        value: fmt::Arguments,
+        value: &fmt::Debug,
     ) {
         if let Some(event) = self.events.lock().expect("mutex poisoned!").get_mut(span) {
-            return event.record(name, value);
+            return event.record(name, format_args!("{:?}", value));
         };
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         if let Some(span) = spans.get_mut(span) {
-            span.record(name, value)
+            span.record(name, format_args!("{:?}", value))
         }
     }
 

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -20,43 +20,27 @@ pub trait AsKey {
 
 pub trait Record {
     /// Record a signed 64-bit integer value.
-    ///
-    /// This defaults to calling `self.record_fmt()`; implementations wishing to
-    /// provide behaviour specific to signed integers may override the default
-    /// implementation.
     fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
         Q: AsKey;
 
     /// Record an umsigned 64-bit integer value.
-    ///
-    /// This defaults to calling `self.record_fmt()`; implementations wishing to
-    /// provide behaviour specific to unsigned integers may override the default
-    /// implementation.
     fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
         Q: AsKey;
 
     /// Record a boolean value.
-    ///
-    /// This defaults to calling `self.record_fmt()`; implementations wishing to
-    /// provide behaviour specific to booleans may override the default
-    /// implementation.
     fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
         Q: AsKey;
 
     /// Record a string value.
-    ///
-    /// This defaults to calling `self.record_str()`; implementations wishing to
-    /// provide behaviour specific to strings may override the default
-    /// implementation.
     fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
         Q: AsKey;
 
-    /// Record a set of pre-compiled format arguments.
-    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments)
+    /// Record a value implementing `fmt::Debug`.
+    fn record_debug<Q: ?Sized>(&mut self, field: &Q, value: &fmt::Debug)
     where
         Q: AsKey;
 }
@@ -221,7 +205,7 @@ where
         Q: AsKey,
         R: Record,
     {
-        recorder.record_fmt(key, format_args!("{}", self.0))
+        recorder.record_debug(key, &format_args!("{}", self.0))
     }
 }
 
@@ -236,6 +220,6 @@ where
         Q: AsKey,
         R: Record,
     {
-        recorder.record_fmt(key, format_args!("{:?}", self.0))
+        recorder.record_debug(key, &self.0)
     }
 }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -451,7 +451,7 @@ impl<'a> Event<'a> {
     /// Adds a formattable message describing the event that occurred.
     pub fn message(&mut self, key: &field::Key, message: fmt::Arguments) -> &mut Self {
         if let Some(ref mut inner) = self.inner {
-            inner.subscriber.record_fmt(&inner.id, key, message);
+            inner.subscriber.record_debug(&inner.id, key, &message);
         }
         self
     }
@@ -580,9 +580,9 @@ impl<'a> Inner<'a> {
         self.subscriber.record_str(&self.id, field, value)
     }
 
-    /// Record a precompiled set of format arguments value.
-    fn record_value_fmt(&self, field: &field::Key, value: fmt::Arguments) {
-        self.subscriber.record_fmt(&self.id, field, value)
+    /// Record a value implementing `fmt::Debug`.
+    fn record_value_debug(&self, field: &field::Key, value: &fmt::Debug) {
+        self.subscriber.record_debug(&self.id, field, value)
     }
 
     fn new(id: Id, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {
@@ -666,12 +666,12 @@ impl<'a> field::Record for Inner<'a> {
     }
 
     #[inline]
-    fn record_fmt<Q: ?Sized>(&mut self, field: &Q, value: fmt::Arguments)
+    fn record_debug<Q: ?Sized>(&mut self, field: &Q, value: &fmt::Debug)
     where
         Q: field::AsKey,
     {
         if let Some(key) = field.as_key(self.metadata()) {
-            self.record_value_fmt(&key, value);
+            self.record_value_debug(&key, value);
         }
     }
 }


### PR DESCRIPTION
This branch replaces the `record_fmt` method, which accepts an arbitrary
`fmt::Arguments`, with a `record_debug` function, which accepts a 
`&dyn fmt::Debug` trait object. Hopefully, this will make it a little easier
on `Subscriber` implementors.

Note that the `field::display` wrapper _still works_, as
`fmt::Arguments` implements `fmt::Debug` by actually formatting the
arguments. This is just hidden from the user now.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>