### PR TITLE
Add `metadata!` macro and update naming

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -61,7 +61,8 @@ pub struct Identifier(
     /// constructing new `Identifier`s, use the `identify_callsite!` macro or
     /// the `Callsite::id` function instead.
     // TODO: When `Callsite::id` is a const fn, this need no longer be `pub`.
-    #[doc(hidden)] pub &'static Callsite
+    #[doc(hidden)]
+    pub &'static Callsite,
 );
 
 /// Register a new `Callsite` with the global registry.

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -52,7 +52,7 @@ pub trait Callsite: Sync {
 ///
 /// Two `Identifier`s are equal if they both refer to the same callsite.
 #[derive(Clone)]
-pub struct Identifier(&'static Callsite);
+pub struct Identifier(pub &'static Callsite);
 
 /// Register a new `Callsite` with the global registry.
 ///

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -105,14 +105,16 @@ pub fn reset_registry() {
 
 // ===== impl Callsite =====
 
+// TODO: when `const fn` is stable, we should add this and deprecate the
+// `identify_callsite!` macro.
+/*
 impl Callsite + 'static {
     /// Returns an `Identifier` unique to this `Callsite`.
-    ///
-    // TODO: when `const fn` is stable, this should be a `const fn`.
-    pub fn id(&'static self) -> Identifier {
+    pub const fn id(&'static self) -> Identifier {
         Identifier(self)
     }
 }
+*/
 
 // ===== impl Identifier =====
 

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -96,19 +96,12 @@ pub fn reset_registry() {
 
 impl Callsite + 'static {
     /// Returns an `Identifier` unique to this `Callsite`.
-    pub(crate) fn id(&'static self) -> Identifier {
-        Identifier::from_callsite(self)
+    pub fn id(&'static self) -> Identifier {
+        Identifier(self)
     }
 }
 
 // ===== impl Identifier =====
-
-impl Identifier {
-    /// Returns an `Identifier` unique to the provided `Callsite`.
-    pub(crate) fn from_callsite(callsite: &'static Callsite) -> Self {
-        Identifier(callsite)
-    }
-}
 
 impl PartialEq for Identifier {
     fn eq(&self, other: &Identifier) -> bool {

--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -52,7 +52,17 @@ pub trait Callsite: Sync {
 ///
 /// Two `Identifier`s are equal if they both refer to the same callsite.
 #[derive(Clone)]
-pub struct Identifier(pub &'static Callsite);
+pub struct Identifier(
+    /// **Warning**: The fields on this type are currently `pub` because it must
+    /// be able to be constructed statically by macros. However, when `const
+    /// fn`s are available on stable Rust, this will no longer be necessary.
+    /// Thus, these fields are *not* considered stable public API, and they may
+    /// change warning. Do not rely on any fields on `Identifier`. When
+    /// constructing new `Identifier`s, use the `identify_callsite!` macro or
+    /// the `Callsite::id` function instead.
+    // TODO: When `Callsite::id` is a const fn, this need no longer be `pub`.
+    #[doc(hidden)] pub &'static Callsite
+);
 
 /// Register a new `Callsite` with the global registry.
 ///
@@ -96,6 +106,8 @@ pub fn reset_registry() {
 
 impl Callsite + 'static {
     /// Returns an `Identifier` unique to this `Callsite`.
+    ///
+    // TODO: when `const fn` is stable, this should be a `const fn`.
     pub fn id(&'static self) -> Identifier {
         Identifier(self)
     }

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -68,7 +68,7 @@ pub struct Fields {
     /// fields are *not* considered stable public API, and they may change
     /// warning. Do not rely on any fields on `Fields`!
     #[doc(hidden)]
-    pub callsite: &'static Callsite,
+    pub callsite: callsite::Identifier,
 }
 
 /// An iterator over a set of fields.
@@ -130,7 +130,7 @@ impl Clone for Key {
             i: self.i,
             fields: Fields {
                 names: self.fields.names,
-                callsite: self.fields.callsite,
+                callsite: self.fields.id(),
             },
         }
     }
@@ -140,7 +140,7 @@ impl Clone for Key {
 
 impl Fields {
     pub(crate) fn id(&self) -> callsite::Identifier {
-        self.callsite.id()
+        callsite::Identifier(self.callsite.0)
     }
 
     /// Returns a [`Key`](::field::Key) to the field corresponding to `name`, if
@@ -154,7 +154,7 @@ impl Fields {
             i,
             fields: Fields {
                 names: self.names,
-                callsite: self.callsite,
+                callsite: self.id(),
             },
         })
     }
@@ -171,7 +171,7 @@ impl Fields {
             idxs,
             fields: Fields {
                 names: self.names,
-                callsite: self.callsite,
+                callsite: self.id(),
             },
         }
     }
@@ -202,7 +202,7 @@ impl Iterator for Iter {
             i,
             fields: Fields {
                 names: self.fields.names,
-                callsite: self.fields.callsite,
+                callsite: self.fields.id(),
             },
         })
     }

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -26,7 +26,7 @@
 //! about. For example, we might record integers by incrementing counters for
 //! their field names, rather than printing them.
 //!
-use callsite::{self, Callsite};
+use callsite;
 use std::{
     borrow::Borrow,
     fmt,
@@ -83,8 +83,8 @@ impl Key {
     /// Returns an [`Identifier`](::metadata::Identifier) that uniquely
     /// identifies the callsite that defines the field this key refers to.
     #[inline]
-    pub fn id(&self) -> callsite::Identifier {
-        self.fields.id()
+    pub fn callsite(&self) -> callsite::Identifier {
+        self.fields.callsite()
     }
 
     /// Returns a string representing the name of the field, or `None` if the
@@ -108,7 +108,7 @@ impl AsRef<str> for Key {
 
 impl PartialEq for Key {
     fn eq(&self, other: &Self) -> bool {
-        self.id() == other.id() && self.i == other.i
+        self.callsite() == other.callsite() && self.i == other.i
     }
 }
 
@@ -119,7 +119,7 @@ impl Hash for Key {
     where
         H: Hasher,
     {
-        self.id().hash(state);
+        self.callsite().hash(state);
         self.i.hash(state);
     }
 }
@@ -130,7 +130,7 @@ impl Clone for Key {
             i: self.i,
             fields: Fields {
                 names: self.fields.names,
-                callsite: self.fields.id(),
+                callsite: self.fields.callsite(),
             },
         }
     }
@@ -139,7 +139,7 @@ impl Clone for Key {
 // ===== impl Fields =====
 
 impl Fields {
-    pub(crate) fn id(&self) -> callsite::Identifier {
+    pub(crate) fn callsite(&self) -> callsite::Identifier {
         callsite::Identifier(self.callsite.0)
     }
 
@@ -154,14 +154,14 @@ impl Fields {
             i,
             fields: Fields {
                 names: self.names,
-                callsite: self.id(),
+                callsite: self.callsite(),
             },
         })
     }
 
     /// Returns `true` if `self` contains a field for the given `key`.
     pub fn contains_key(&self, key: &Key) -> bool {
-        key.id() == self.id() && key.i <= self.names.len()
+        key.callsite() == self.callsite() && key.i <= self.names.len()
     }
 
     /// Returns an iterator over the `Key`s to this set of `Fields`.
@@ -171,7 +171,7 @@ impl Fields {
             idxs,
             fields: Fields {
                 names: self.names,
-                callsite: self.id(),
+                callsite: self.callsite(),
             },
         }
     }
@@ -202,7 +202,7 @@ impl Iterator for Iter {
             i,
             fields: Fields {
                 names: self.fields.names,
-                callsite: self.fields.id(),
+                callsite: self.fields.callsite(),
             },
         })
     }

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -14,7 +14,9 @@ extern crate lazy_static;
 /// [`Callsite::id`]: ::callsite::Callsite::id
 #[macro_export]
 macro_rules! identify_callsite {
-    ($callsite:expr) => ($crate::callsite::Identifier($callsite))
+    ($callsite:expr) => {
+        $crate::callsite::Identifier($callsite)
+    };
 }
 
 /// Statically constructs a set of span [metadata].
@@ -48,19 +50,17 @@ macro_rules! metadata {
         fields: $fields:expr,
         callsite: $callsite:expr,
     ) => {
-        {
-            metadata::Meta {
-                name: $name,
-                target: $target,
-                level: $level,
-                file: Some(file!()),
-                line: Some(line!()),
-                module_path: Some(module_path!()),
-                fields: field::Fields {
-                    names: $fields,
-                    callsite: identify_callsite!($callsite),
-                },
-            }
+        metadata::Meta {
+            name: $name,
+            target: $target,
+            level: $level,
+            file: Some(file!()),
+            line: Some(line!()),
+            module_path: Some(module_path!()),
+            fields: field::Fields {
+                names: $fields,
+                callsite: identify_callsite!($callsite),
+            },
         }
     };
 }

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -12,7 +12,7 @@ macro_rules! metadata {
         level: $level:expr,
         fields: $field:expr,
         callsite: $callsite:expr
-    ) => (
+    ) => {
         metadata! {
             name: $name,
             target: $target,
@@ -20,7 +20,7 @@ macro_rules! metadata {
             fields: $fields,
             callsite: $callsite,
         }
-    );
+    };
     (
         name: $name:expr,
         target: $target:expr,
@@ -38,9 +38,9 @@ macro_rules! metadata {
             fields: $crate::field::Fields {
                 names: $fields,
                 callsite: $crate::callsite::Identifier($callsite),
-            }
+            },
         }
-    }
+    };
 }
 
 pub mod callsite;

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -49,7 +49,6 @@ macro_rules! metadata {
         callsite: $callsite:expr,
     ) => {
         {
-            use $crate::*;
             metadata::Meta {
                 name: $name,
                 target: $target,

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -6,17 +6,24 @@ extern crate lazy_static;
 
 /// Statically constructs an [`Identifier`] for the provided [`Callsite`].
 ///
-/// This may be used in contexts, such as static initializers,  where the
-/// [`Callsite::id()`] function is not currently usable.
+/// This may be used in contexts, such as static initializers, where the
+/// [`Callsite::id`] function is not currently usable.
 ///
 /// [`Identifier`]: ::callsite::Identifier
 /// [`Callsite`]: ::callsite::Callsite
-/// [`Callsite::id()`]: ::callsite::Callsite::id
+/// [`Callsite::id`]: ::callsite::Callsite::id
 #[macro_export]
 macro_rules! identify_callsite {
     ($callsite:expr) => ($crate::callsite::Identifier($callsite))
 }
 
+/// Statically constructs a set of span [metadata].
+///
+/// This may be used in contexts, such as static initializers, where the
+/// [`Meta::new`] function is not currently usable.
+///
+/// [metadata]: ::metadata::Meta
+/// [`Meta::new`]: ::metadata::Meta::new
 #[macro_export]
 macro_rules! metadata {
     (

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -4,6 +4,19 @@
 #[macro_use]
 extern crate lazy_static;
 
+/// Statically constructs an [`Identifier`] for the provided [`Callsite`].
+///
+/// This may be used in contexts, such as static initializers,  where the
+/// [`Callsite::id()`] function is not currently usable.
+///
+/// [`Identifier`]: ::callsite::Identifier
+/// [`Callsite`]: ::callsite::Callsite
+/// [`Callsite::id()`]: ::callsite::Callsite::id
+#[macro_export]
+macro_rules! identify_callsite {
+    ($callsite:expr) => ($crate::callsite::Identifier($callsite))
+}
+
 #[macro_export]
 macro_rules! metadata {
     (
@@ -28,17 +41,20 @@ macro_rules! metadata {
         fields: $fields:expr,
         callsite: $callsite:expr,
     ) => {
-        $crate::metadata::Meta {
-            name: $name,
-            target: $target,
-            level: $level,
-            file: Some(file!()),
-            line: Some(line!()),
-            module_path: Some(module_path!()),
-            fields: $crate::field::Fields {
-                names: $fields,
-                callsite: $crate::callsite::Identifier($callsite),
-            },
+        {
+            use $crate::*;
+            metadata::Meta {
+                name: $name,
+                target: $target,
+                level: $level,
+                file: Some(file!()),
+                line: Some(line!()),
+                module_path: Some(module_path!()),
+                fields: field::Fields {
+                    names: $fields,
+                    callsite: identify_callsite!($callsite),
+                },
+            }
         }
     };
 }

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -4,6 +4,45 @@
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_export]
+macro_rules! metadata {
+    (
+        name: $name:expr,
+        target: $target:expr,
+        level: $level:expr,
+        fields: $field:expr,
+        callsite: $callsite:expr
+    ) => (
+        metadata! {
+            name: $name,
+            target: $target,
+            level: $level,
+            fields: $fields,
+            callsite: $callsite,
+        }
+    );
+    (
+        name: $name:expr,
+        target: $target:expr,
+        level: $level:expr,
+        fields: $fields:expr,
+        callsite: $callsite:expr,
+    ) => {
+        $crate::metadata::Meta {
+            name: $name,
+            target: $target,
+            level: $level,
+            file: Some(file!()),
+            line: Some(line!()),
+            module_path: Some(module_path!()),
+            fields: $crate::field::Fields {
+                names: $fields,
+                callsite: $crate::callsite::Identifier($callsite),
+            }
+        }
+    }
+}
+
 pub mod callsite;
 pub mod dispatcher;
 pub mod field;

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -205,8 +205,8 @@ impl<'a> Meta<'a> {
     /// Returns an opaque `Identifier` that uniquely identifies the callsite
     /// this `Metadata` originated from.
     #[inline]
-    pub fn id(&self) -> callsite::Identifier {
-        self.fields.id()
+    pub fn callsite(&self) -> callsite::Identifier {
+        self.fields.callsite()
     }
 }
 

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -155,7 +155,7 @@ impl<'a> Meta<'a> {
             line,
             fields: field::Fields {
                 names: field_names,
-                callsite,
+                callsite: callsite::Identifier(callsite),
             },
         }
     }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -33,7 +33,7 @@ use std::{
     },
 };
 use tokio_trace::{
-    callsite::Callsite,
+    callsite::{self, Callsite},
     field,
     subscriber::{self, Subscriber},
     Id, Meta,
@@ -92,7 +92,7 @@ impl<'a> AsTrace for log::Record<'a> {
                     line: None,
                     fields: field::Fields {
                         names: &["message"],
-                        callsite: &LogCallsite,
+                        callsite: callsite::Identifier(&LogCallsite),
                     },
                 };
                 &EMPTY_META

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -151,7 +151,7 @@ macro_rules! impl_value {
 impl AsKey for Key {
     #[inline]
     fn as_key(&self, metadata: &Meta) -> Option<Key> {
-        if self.id() == metadata.id() {
+        if self.callsite() == metadata.callsite() {
             Some(self.clone())
         } else {
             None
@@ -162,7 +162,7 @@ impl AsKey for Key {
 impl<'a> AsKey for &'a Key {
     #[inline]
     fn as_key(&self, metadata: &Meta) -> Option<Key> {
-        if self.id() == metadata.id() {
+        if self.callsite() == metadata.callsite()  {
             Some((*self).clone())
         } else {
             None

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -162,7 +162,7 @@ impl AsKey for Key {
 impl<'a> AsKey for &'a Key {
     #[inline]
     fn as_key(&self, metadata: &Meta) -> Option<Key> {
-        if self.callsite() == metadata.callsite()  {
+        if self.callsite() == metadata.callsite() {
             Some((*self).clone())
         } else {
             None

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -118,14 +118,17 @@ macro_rules! callsite {
         fields: $field_names:expr
     ) => ({
         use std::sync::{Once, atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering}};
-        use $crate::{*, subscriber::Interest};
+        use $crate::{callsite, Meta, subscriber::Interest};
         struct MyCallsite;
-        static META: Meta<'static> = metadata! {
-            name: $name,
-            target: $target,
-            level: $lvl,
-            fields: $field_names,
-            callsite: &MyCallsite,
+        static META: Meta<'static> = {
+            use $crate::*;
+            metadata! {
+                name: $name,
+                target: $target,
+                level: $lvl,
+                fields: $field_names,
+                callsite: &MyCallsite,
+            }
         };
         static INTEREST: AtomicUsize = ATOMIC_USIZE_INIT;
         static REGISTRATION: Once = Once::new();
@@ -205,7 +208,8 @@ macro_rules! span {
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
             #[allow(unused_imports)]
-            use $crate::{*, callsite::Callsite, field::{Value, AsKey}};
+            use $crate::{callsite, field::{Value, AsKey}, Span};
+            use $crate::callsite::Callsite;
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
             // not actually be used, but it doesn't make sense to repeat it.

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -72,6 +72,7 @@
 //! [`exit`]: subscriber/trait.Subscriber.html#tymethod.exit
 //! [`enabled`]: subscriber/trait.Subscriber.html#tymethod.enabled
 //! [metadata]: struct.Meta.html
+#[macro_use]
 extern crate tokio_trace_core;
 
 /// Constructs a new static callsite for a span or event.
@@ -102,19 +103,14 @@ macro_rules! callsite {
         fields: $field_names:expr
     ) => ({
         use std::sync::{Once, atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering}};
-        use $crate::{callsite, Meta, subscriber::{Interest}, field::Fields};
+        use $crate::{callsite, Meta, subscriber::{Interest}};
         struct MyCallsite;
-        static META: Meta<'static> = $crate::Meta {
+        static META: Meta<'static> = metadata! {
             name: $name,
             target: $target,
             level: $lvl,
-            module_path: Some(module_path!()),
-            file: Some(file!()),
-            line: Some(line!()),
-            fields: Fields {
-                names: $field_names,
-                callsite: &MyCallsite,
-            },
+            fields: $field_names,
+            callsite: &MyCallsite,
         };
         static INTEREST: AtomicUsize = ATOMIC_USIZE_INIT;
         static REGISTRATION: Once = Once::new();


### PR DESCRIPTION
This branch adds a `metadata!` macro in `tokio-trace-core` that
constructs a set of metadata, and updates the `callsite!` macro in
`tokio-trace` to use this.

I've also changed `callsite::Identifier` to allow it to be constructed
in a static context. This allows `field::Fields` to hold an `Identifier`
rather than a `Callsite` trait object pointer (#138). I've also changed
methods returning `Identifier`s to be named `.callsite()` rather than
`.id()` (#140). 

Closes #150.
Closes #140.
Closes #138.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>