### PR TITLE
Core API naming pass

### DIFF
--- a/tokio-trace-core/src/callsite.rs
+++ b/tokio-trace-core/src/callsite.rs
@@ -9,7 +9,7 @@ use std::{
 use {
     dispatcher::{self, Dispatch},
     subscriber::{Interest, Subscriber},
-    Meta,
+    Metadata,
 };
 
 lazy_static! {
@@ -44,8 +44,8 @@ pub trait Callsite: Sync {
 
     /// Returns the [metadata] associated with the callsite.
     ///
-    /// [metadata]: ::Meta
-    fn metadata(&self) -> &Meta;
+    /// [metadata]: ::Metadata
+    fn metadata(&self) -> &Metadata;
 }
 
 /// Uniquely identifies a [`Callsite`](::callsite::Callsite).

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -66,27 +66,27 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn record_i64(&self, span: &Span, field: &field::Key, value: i64) {
+    fn record_i64(&self, span: &Span, field: &field::Field, value: i64) {
         self.subscriber.record_i64(span, field, value)
     }
 
     #[inline]
-    fn record_u64(&self, span: &Span, field: &field::Key, value: u64) {
+    fn record_u64(&self, span: &Span, field: &field::Field, value: u64) {
         self.subscriber.record_u64(span, field, value)
     }
 
     #[inline]
-    fn record_bool(&self, span: &Span, field: &field::Key, value: bool) {
+    fn record_bool(&self, span: &Span, field: &field::Field, value: bool) {
         self.subscriber.record_bool(span, field, value)
     }
 
     #[inline]
-    fn record_str(&self, span: &Span, field: &field::Key, value: &str) {
+    fn record_str(&self, span: &Span, field: &field::Field, value: &str) {
         self.subscriber.record_str(span, field, value)
     }
 
     #[inline]
-    fn record_debug(&self, span: &Span, field: &field::Key, value: &fmt::Debug) {
+    fn record_debug(&self, span: &Span, field: &field::Field, value: &fmt::Debug) {
         self.subscriber.record_debug(span, field, value)
     }
 
@@ -127,7 +127,7 @@ impl Subscriber for NoSubscriber {
         Span::from_u64(0)
     }
 
-    fn record_debug(&self, _span: &Span, _field: &field::Key, _value: &fmt::Debug) {}
+    fn record_debug(&self, _span: &Span, _field: &field::Field, _value: &fmt::Debug) {}
 
     fn add_follows_from(&self, _span: &Span, _follows: Span) {}
 

--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -1,7 +1,7 @@
 use {
     callsite, field,
     subscriber::{self, Subscriber},
-    Meta, Span,
+    Metadata, Span,
 };
 
 use std::{
@@ -51,17 +51,17 @@ impl fmt::Debug for Dispatch {
 
 impl Subscriber for Dispatch {
     #[inline]
-    fn register_callsite(&self, metadata: &Meta) -> subscriber::Interest {
+    fn register_callsite(&self, metadata: &Metadata) -> subscriber::Interest {
         self.subscriber.register_callsite(metadata)
     }
 
     #[inline]
-    fn new_static(&self, metadata: &'static Meta<'static>) -> Span {
+    fn new_static(&self, metadata: &'static Metadata<'static>) -> Span {
         self.subscriber.new_static(metadata)
     }
 
     #[inline]
-    fn new_span(&self, metadata: &Meta) -> Span {
+    fn new_span(&self, metadata: &Metadata) -> Span {
         self.subscriber.new_span(metadata)
     }
 
@@ -96,7 +96,7 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         self.subscriber.enabled(metadata)
     }
 
@@ -123,7 +123,7 @@ impl Subscriber for Dispatch {
 
 struct NoSubscriber;
 impl Subscriber for NoSubscriber {
-    fn new_span(&self, _meta: &Meta) -> Span {
+    fn new_span(&self, _meta: &Metadata) -> Span {
         Span::from_u64(0)
     }
 
@@ -131,7 +131,7 @@ impl Subscriber for NoSubscriber {
 
     fn add_follows_from(&self, _span: &Span, _follows: Span) {}
 
-    fn enabled(&self, _metadata: &Meta) -> bool {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
         false
     }
 
@@ -140,7 +140,7 @@ impl Subscriber for NoSubscriber {
 }
 
 impl Registrar {
-    pub(crate) fn try_register(&self, metadata: &Meta) -> Option<subscriber::Interest> {
+    pub(crate) fn try_register(&self, metadata: &Metadata) -> Option<subscriber::Interest> {
         self.0.upgrade().map(|s| s.register_callsite(metadata))
     }
 }

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -145,7 +145,7 @@ impl FieldSet {
 
     /// Returns the [`Field`](::field::Field) named `name`, or `None` if no such
     /// field exists.
-    pub fn key_for<Q>(&self, name: &Q) -> Option<Field>
+    pub fn field_named<Q>(&self, name: &Q) -> Option<Field>
     where
         Q: Borrow<str>,
     {
@@ -160,7 +160,13 @@ impl FieldSet {
     }
 
     /// Returns `true` if `self` contains the given `field`.
-    pub fn contains_key(&self, field: &Field) -> bool {
+    ///
+    /// **Note**: If `field` shares a name with a field in this `FieldSet`, but
+    /// was created by a `FieldSet` with a different callsite, this `FieldSet`
+    /// does _not_ contain it. This is so that if two separate span callsites
+    /// define a field named "foo", the `Field` corresponding to "foo" for each
+    /// of those callsites are not equivalent.
+    pub fn contains(&self, field: &Field) -> bool {
         field.callsite() == self.callsite() && field.i <= self.names.len()
     }
 

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -45,19 +45,19 @@ use std::{
 #[derive(Debug)]
 pub struct Field {
     i: usize,
-    fields: Fields,
+    fields: FieldSet,
 }
 
 /// Describes the fields present on a span.
 // TODO: When `const fn` is stable, make this type's fields private.
-pub struct Fields {
+pub struct FieldSet {
     /// The names of each field on the described span.
     ///
     /// **Warning**: The fields on this type are currently `pub` because it must be able
     /// to be constructed statically by macros. However, when `const fn`s are
     /// available on stable Rust, this will no longer be necessary. Thus, these
     /// fields are *not* considered stable public API, and they may change
-    /// warning. Do not rely on any fields on `Fields`!
+    /// warning. Do not rely on any fields on `FieldSet`!
     #[doc(hidden)]
     pub names: &'static [&'static str],
     /// The callsite where the described span originates.
@@ -66,7 +66,7 @@ pub struct Fields {
     /// to be constructed statically by macros. However, when `const fn`s are
     /// available on stable Rust, this will no longer be necessary. Thus, these
     /// fields are *not* considered stable public API, and they may change
-    /// warning. Do not rely on any fields on `Fields`!
+    /// warning. Do not rely on any fields on `FieldSet`!
     #[doc(hidden)]
     pub callsite: callsite::Identifier,
 }
@@ -74,7 +74,7 @@ pub struct Fields {
 /// An iterator over a set of fields.
 pub struct Iter {
     idxs: Range<usize>,
-    fields: Fields,
+    fields: FieldSet,
 }
 
 // ===== impl Field =====
@@ -128,7 +128,7 @@ impl Clone for Field {
     fn clone(&self) -> Self {
         Field {
             i: self.i,
-            fields: Fields {
+            fields: FieldSet {
                 names: self.fields.names,
                 callsite: self.fields.callsite(),
             },
@@ -136,9 +136,9 @@ impl Clone for Field {
     }
 }
 
-// ===== impl Fields =====
+// ===== impl FieldSet =====
 
-impl Fields {
+impl FieldSet {
     pub(crate) fn callsite(&self) -> callsite::Identifier {
         callsite::Identifier(self.callsite.0)
     }
@@ -152,7 +152,7 @@ impl Fields {
         let name = &name.borrow();
         self.names.iter().position(|f| f == name).map(|i| Field {
             i,
-            fields: Fields {
+            fields: FieldSet {
                 names: self.names,
                 callsite: self.callsite(),
             },
@@ -164,12 +164,12 @@ impl Fields {
         key.callsite() == self.callsite() && key.i <= self.names.len()
     }
 
-    /// Returns an iterator over the `Field`s to this set of `Fields`.
+    /// Returns an iterator over the `Field`s to this set of `FieldSet`.
     pub fn iter(&self) -> Iter {
         let idxs = 0..self.names.len();
         Iter {
             idxs,
-            fields: Fields {
+            fields: FieldSet {
                 names: self.names,
                 callsite: self.callsite(),
             },
@@ -177,7 +177,7 @@ impl Fields {
     }
 }
 
-impl<'a> IntoIterator for &'a Fields {
+impl<'a> IntoIterator for &'a FieldSet {
     type IntoIter = Iter;
     type Item = Field;
     #[inline]
@@ -186,7 +186,7 @@ impl<'a> IntoIterator for &'a Fields {
     }
 }
 
-impl fmt::Debug for Fields {
+impl fmt::Debug for FieldSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_set().entries(self).finish()
     }
@@ -200,7 +200,7 @@ impl Iterator for Iter {
         let i = self.idxs.next()?;
         Some(Field {
             i,
-            fields: Fields {
+            fields: FieldSet {
                 names: self.fields.names,
                 callsite: self.fields.callsite(),
             },

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -43,7 +43,7 @@ use std::{
 /// subscriber observes a new span, it need only access a field by name _once_,
 /// and use the key for that name for all other accesses.
 #[derive(Debug)]
-pub struct Key {
+pub struct Field {
     i: usize,
     fields: Fields,
 }
@@ -77,9 +77,9 @@ pub struct Iter {
     fields: Fields,
 }
 
-// ===== impl Key =====
+// ===== impl Field =====
 
-impl Key {
+impl Field {
     /// Returns an [`Identifier`](::metadata::Identifier) that uniquely
     /// identifies the callsite that defines the field this key refers to.
     #[inline]
@@ -94,27 +94,27 @@ impl Key {
     }
 }
 
-impl fmt::Display for Key {
+impl fmt::Display for Field {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad(self.name().unwrap_or("???"))
     }
 }
 
-impl AsRef<str> for Key {
+impl AsRef<str> for Field {
     fn as_ref(&self) -> &str {
         self.name().unwrap_or("???")
     }
 }
 
-impl PartialEq for Key {
+impl PartialEq for Field {
     fn eq(&self, other: &Self) -> bool {
         self.callsite() == other.callsite() && self.i == other.i
     }
 }
 
-impl Eq for Key {}
+impl Eq for Field {}
 
-impl Hash for Key {
+impl Hash for Field {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
@@ -124,9 +124,9 @@ impl Hash for Key {
     }
 }
 
-impl Clone for Key {
+impl Clone for Field {
     fn clone(&self) -> Self {
-        Key {
+        Field {
             i: self.i,
             fields: Fields {
                 names: self.fields.names,
@@ -143,14 +143,14 @@ impl Fields {
         callsite::Identifier(self.callsite.0)
     }
 
-    /// Returns a [`Key`](::field::Key) to the field corresponding to `name`, if
+    /// Returns a [`Field`](::field::Field) to the field corresponding to `name`, if
     /// one exists, or `None` if no such field exists.
-    pub fn key_for<Q>(&self, name: &Q) -> Option<Key>
+    pub fn key_for<Q>(&self, name: &Q) -> Option<Field>
     where
         Q: Borrow<str>,
     {
         let name = &name.borrow();
-        self.names.iter().position(|f| f == name).map(|i| Key {
+        self.names.iter().position(|f| f == name).map(|i| Field {
             i,
             fields: Fields {
                 names: self.names,
@@ -160,11 +160,11 @@ impl Fields {
     }
 
     /// Returns `true` if `self` contains a field for the given `key`.
-    pub fn contains_key(&self, key: &Key) -> bool {
+    pub fn contains_key(&self, key: &Field) -> bool {
         key.callsite() == self.callsite() && key.i <= self.names.len()
     }
 
-    /// Returns an iterator over the `Key`s to this set of `Fields`.
+    /// Returns an iterator over the `Field`s to this set of `Fields`.
     pub fn iter(&self) -> Iter {
         let idxs = 0..self.names.len();
         Iter {
@@ -179,7 +179,7 @@ impl Fields {
 
 impl<'a> IntoIterator for &'a Fields {
     type IntoIter = Iter;
-    type Item = Key;
+    type Item = Field;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -195,10 +195,10 @@ impl fmt::Debug for Fields {
 // ===== impl Iter =====
 
 impl Iterator for Iter {
-    type Item = Key;
-    fn next(&mut self) -> Option<Key> {
+    type Item = Field;
+    fn next(&mut self) -> Option<Field> {
         let i = self.idxs.next()?;
-        Some(Key {
+        Some(Field {
             i,
             fields: Fields {
                 names: self.fields.names,

--- a/tokio-trace-core/src/field.rs
+++ b/tokio-trace-core/src/field.rs
@@ -143,8 +143,8 @@ impl FieldSet {
         callsite::Identifier(self.callsite.0)
     }
 
-    /// Returns a [`Field`](::field::Field) to the field corresponding to `name`, if
-    /// one exists, or `None` if no such field exists.
+    /// Returns the [`Field`](::field::Field) named `name`, or `None` if no such
+    /// field exists.
     pub fn key_for<Q>(&self, name: &Q) -> Option<Field>
     where
         Q: Borrow<str>,
@@ -159,12 +159,12 @@ impl FieldSet {
         })
     }
 
-    /// Returns `true` if `self` contains a field for the given `key`.
-    pub fn contains_key(&self, key: &Field) -> bool {
-        key.callsite() == self.callsite() && key.i <= self.names.len()
+    /// Returns `true` if `self` contains the given `field`.
+    pub fn contains_key(&self, field: &Field) -> bool {
+        field.callsite() == self.callsite() && field.i <= self.names.len()
     }
 
-    /// Returns an iterator over the `Field`s to this set of `FieldSet`.
+    /// Returns an iterator over the `Field`s in this `FieldSet`.
     pub fn iter(&self) -> Iter {
         let idxs = 0..self.names.len();
         Iter {

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! metadata {
             file: Some(file!()),
             line: Some(line!()),
             module_path: Some(module_path!()),
-            fields: field::Fields {
+            fields: field::FieldSet {
                 names: $fields,
                 callsite: identify_callsite!($callsite),
             },

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod subscriber;
 pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
-    field::Key,
+    field::Field,
     metadata::{Level, Meta},
     span::Span,
     subscriber::{Interest, Subscriber},

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -22,10 +22,10 @@ macro_rules! identify_callsite {
 /// Statically constructs a set of span [metadata].
 ///
 /// This may be used in contexts, such as static initializers, where the
-/// [`Meta::new`] function is not currently usable.
+/// [`Metadata::new`] function is not currently usable.
 ///
-/// [metadata]: ::metadata::Meta
-/// [`Meta::new`]: ::metadata::Meta::new
+/// [metadata]: ::metadata::Metadata
+/// [`Metadata::new`]: ::metadata::Metadata::new
 #[macro_export]
 macro_rules! metadata {
     (
@@ -50,7 +50,7 @@ macro_rules! metadata {
         fields: $fields:expr,
         callsite: $callsite:expr,
     ) => {
-        metadata::Meta {
+        metadata::Metadata {
             name: $name,
             target: $target,
             level: $level,
@@ -76,7 +76,7 @@ pub use self::{
     callsite::Callsite,
     dispatcher::Dispatch,
     field::Field,
-    metadata::{Level, Meta},
+    metadata::{Level, Metadata},
     span::Span,
     subscriber::{Interest, Subscriber},
 };

--- a/tokio-trace-core/src/lib.rs
+++ b/tokio-trace-core/src/lib.rs
@@ -19,7 +19,7 @@ macro_rules! identify_callsite {
     };
 }
 
-/// Statically constructs a set of span [metadata].
+/// Statically constructs new span [metadata].
 ///
 /// This may be used in contexts, such as static initializers, where the
 /// [`Metadata::new`] function is not currently usable.

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -7,8 +7,8 @@ use std::fmt;
 
 /// Metadata describing a [`Span`].
 ///
-/// This includes the source code location where the span occurred, the
-/// names of its fields, et cetera.
+/// This includes the source code location where the span occurred, the names of
+/// its fields, et cetera.
 ///
 /// Metadata is used by [`Subscriber`]s when filtering spans and events, and it
 /// may also be used as part of their data payload.
@@ -16,14 +16,13 @@ use std::fmt;
 /// When created by the `event!` or `span!` macro, the metadata describing a
 /// particular event or span is constructed statically and exists as a single
 /// static instance. Thus, the overhead of creating the metadata is
-/// _significantly_ lower than that of creating the actual span.
-/// Therefore, filtering is based on metadata, rather than  on the constructed
-/// span.
+/// _significantly_ lower than that of creating the actual span. Therefore,
+/// filtering is based on metadata, rather than  on the constructed span.
 ///
 /// **Note**: Although instances of `Metadata` cannot be compared directly, they
 /// provide a method [`Metadata::id()`] which returns an an opaque [callsite
 /// identifier] which uniquely identifies the callsite where the metadata
-/// originated. This can be used for determining if two `Metadata`s correspond to
+/// originated. This can be used for determining if two Metadata correspond to
 /// the same callsite.
 ///
 /// [`Span`]: ::span::Span
@@ -38,14 +37,14 @@ pub struct Metadata<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
     #[doc(hidden)]
     pub name: &'a str,
 
-    /// The part of the system that the span that this metadata
-    /// describes occurred in.
+    /// The part of the system that the span that this metadata describes
+    /// occurred in.
     ///
     /// Typically, this is the module path, but alternate targets may be set
     /// when spans or events are constructed.
@@ -54,9 +53,9 @@ pub struct Metadata<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
     #[doc(hidden)]
     pub target: &'a str,
 
@@ -66,48 +65,48 @@ pub struct Metadata<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
     #[doc(hidden)]
     pub level: Level,
 
-    /// The name of the Rust module where the span occurred, or `None`
-    /// if this could not be determined.
+    /// The name of the Rust module where the span occurred, or `None` if this
+    /// could not be determined.
     ///
     /// **Warning**: The fields on this type are currently `pub` because it must
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
     #[doc(hidden)]
     pub module_path: Option<&'a str>,
 
-    /// The name of the source code file where the span occurred, or
+    /// The name of the source code file where the span occurred, or `None` if
+    /// this could not be determined.
+    ///
+    /// **Warning**: The fields on this type are currently `pub` because it must
+    /// be able to be constructed statically by macros. However, when `const
+    /// fn`s are available on stable Rust, this will no longer be necessary.
+    /// Thus, these fields are *not* considered stable public API, and they may
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
+    #[doc(hidden)]
+    pub file: Option<&'a str>,
+
+    /// The line number in the source code file where the span occurred, or
     /// `None` if this could not be determined.
     ///
     /// **Warning**: The fields on this type are currently `pub` because it must
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
-    #[doc(hidden)]
-    pub file: Option<&'a str>,
-
-    /// The line number in the source code file where the span
-    /// occurred, or `None` if this could not be determined.
-    ///
-    /// **Warning**: The fields on this type are currently `pub` because it must
-    /// be able to be constructed statically by macros. However, when `const
-    /// fn`s are available on stable Rust, this will no longer be necessary.
-    /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
     #[doc(hidden)]
     pub line: Option<u32>,
 
@@ -118,11 +117,9 @@ pub struct Metadata<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Metadata`. When constructing
-    /// new
-    ///
-    /// `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
-    /// `Metadata::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When
+    /// constructing new `Metadata`, use the `metadata!` macro or the
+    /// `Metadata::new` constructor instead!
     #[doc(hidden)]
     pub fields: field::FieldSet,
 }

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -20,27 +20,27 @@ use std::fmt;
 /// Therefore, filtering is based on metadata, rather than  on the constructed
 /// span.
 ///
-/// **Note**: Although instances of `Meta` cannot be compared directly, they
-/// provide a method [`Meta::id()`] which returns an an opaque [callsite
+/// **Note**: Although instances of `Metadata` cannot be compared directly, they
+/// provide a method [`Metadata::id()`] which returns an an opaque [callsite
 /// identifier] which uniquely identifies the callsite where the metadata
-/// originated. This can be used for determining if two `Meta`s correspond to
+/// originated. This can be used for determining if two `Metadata`s correspond to
 /// the same callsite.
 ///
 /// [`Span`]: ::span::Span
 /// [`Subscriber`]: ::Subscriber
-/// [`Meta::id()`]: ::metadata::Meta::id
+/// [`Metadata::id()`]: ::metadata::Metadata::id
 /// [callsite identifier]: ::callsite::Identifier
 // TODO: When `const fn` is stable, make this type's fields private.
-pub struct Meta<'a> {
+pub struct Metadata<'a> {
     /// The name of the span described by this metadata.
     ///
     /// **Warning**: The fields on this type are currently `pub` because it must
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
-    /// new `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
+    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub name: &'a str,
 
@@ -54,9 +54,9 @@ pub struct Meta<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
-    /// new `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
+    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub target: &'a str,
 
@@ -66,9 +66,9 @@ pub struct Meta<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
-    /// new `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
+    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub level: Level,
 
@@ -79,9 +79,9 @@ pub struct Meta<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
-    /// new `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
+    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub module_path: Option<&'a str>,
 
@@ -92,9 +92,9 @@ pub struct Meta<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
-    /// new `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
+    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub file: Option<&'a str>,
 
@@ -105,9 +105,9 @@ pub struct Meta<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
-    /// new `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
+    /// new `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub line: Option<u32>,
 
@@ -118,11 +118,11 @@ pub struct Meta<'a> {
     /// be able to be constructed statically by macros. However, when `const
     /// fn`s are available on stable Rust, this will no longer be necessary.
     /// Thus, these fields are *not* considered stable public API, and they may
-    /// change warning. Do not rely on any fields on `Meta`. When constructing
+    /// change warning. Do not rely on any fields on `Metadata`. When constructing
     /// new
     ///
-    /// `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
-    /// `Meta::new_event` constructors instead!
+    /// `Metadata`s, use the `metadata!` macro or the `Metadata::new_span` and
+    /// `Metadata::new_event` constructors instead!
     #[doc(hidden)]
     pub fields: field::FieldSet,
 }
@@ -131,9 +131,9 @@ pub struct Meta<'a> {
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Level(LevelInner);
 
-// ===== impl Meta =====
+// ===== impl Metadata =====
 
-impl<'a> Meta<'a> {
+impl<'a> Metadata<'a> {
     /// Construct new metadata for a span, with a name, target, level, field
     /// names, and optional source code location.
     pub fn new(
@@ -146,7 +146,7 @@ impl<'a> Meta<'a> {
         field_names: &'static [&'static str],
         callsite: &'static Callsite,
     ) -> Self {
-        Self {
+        Metadata {
             name,
             target,
             level,
@@ -210,9 +210,9 @@ impl<'a> Meta<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Meta<'a> {
+impl<'a> fmt::Debug for Metadata<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Meta")
+        f.debug_struct("Metadata")
             .field("name", &self.name)
             .field("target", &self.target)
             .field("level", &self.level)

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -124,7 +124,7 @@ pub struct Meta<'a> {
     /// `Meta`s, use the `metadata!` macro or the `Meta::new_span` and
     /// `Meta::new_event` constructors instead!
     #[doc(hidden)]
-    pub fields: field::Fields,
+    pub fields: field::FieldSet,
 }
 
 /// Describes the level of verbosity of a `Span`.
@@ -153,7 +153,7 @@ impl<'a> Meta<'a> {
             module_path,
             file,
             line,
-            fields: field::Fields {
+            fields: field::FieldSet {
                 names: field_names,
                 callsite: callsite::Identifier(callsite),
             },
@@ -161,7 +161,7 @@ impl<'a> Meta<'a> {
     }
 
     /// Returns the set of fields on the described span.
-    pub fn fields(&self) -> &field::Fields {
+    pub fn fields(&self) -> &field::FieldSet {
         &self.fields
     }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -1,5 +1,5 @@
 //! Subscribers collect and record trace data.
-use {field, Meta, Span};
+use {field, Metadata, Span};
 
 use std::fmt;
 
@@ -91,8 +91,8 @@ pub trait Subscriber {
     /// **Note**: If a subscriber returns `Interest::Never` for a particular
     /// callsite, it _may_ still see spans and events originating from that
     /// callsite, if another subscriber expressed interest in it.
-    /// [metadata]: ::Meta [`enabled`]: ::Subscriber::enabled
-    fn register_callsite(&self, metadata: &Meta) -> Interest {
+    /// [metadata]: ::Metadata [`enabled`]: ::Subscriber::enabled
+    fn register_callsite(&self, metadata: &Metadata) -> Interest {
         match self.enabled(metadata) {
             true => Interest::ALWAYS,
             false => Interest::NEVER,
@@ -114,8 +114,8 @@ pub trait Subscriber {
     ///
     /// [`Span`]: ::span::Span
     /// [`new_span`]: ::subscriber::Subscriber::new_span
-    /// [metadata]: ::metadata::Meta
-    fn new_static(&self, metadata: &'static Meta<'static>) -> Span {
+    /// [metadata]: ::metadata::Metadata
+    fn new_static(&self, metadata: &'static Metadata<'static>) -> Span {
         self.new_span(metadata)
     }
 
@@ -136,7 +136,7 @@ pub trait Subscriber {
     /// from all calls to this function, if they so choose.
     ///
     /// [`Span`]: ::span::Span
-    fn new_span(&self, metadata: &Meta) -> Span;
+    fn new_span(&self, metadata: &Metadata) -> Span;
 
     /// Record a signed 64-bit integer value.
     ///
@@ -225,8 +225,8 @@ pub trait Subscriber {
     /// This is used by the dispatcher to avoid allocating for span construction
     /// if the span would be discarded anyway.
     ///
-    /// [metadata]: ::Meta
-    fn enabled(&self, metadata: &Meta) -> bool;
+    /// [metadata]: ::Metadata
+    fn enabled(&self, metadata: &Metadata) -> bool;
 
     // === Notification methods ===============================================
 
@@ -381,7 +381,7 @@ mod test_support {
 
     use super::*;
     use span::MockSpan;
-    use {field, Meta, Span};
+    use {field, Metadata, Span};
 
     use std::{
         collections::{HashMap, VecDeque},
@@ -410,30 +410,30 @@ mod test_support {
 
     enum SpanOrEvent {
         Span {
-            span: &'static Meta<'static>,
+            span: &'static Metadata<'static>,
             refs: usize,
         },
         Event,
     }
 
-    struct Running<F: Fn(&Meta) -> bool> {
+    struct Running<F: Fn(&Metadata) -> bool> {
         spans: Mutex<HashMap<Span, SpanOrEvent>>,
         expected: Arc<Mutex<VecDeque<Expect>>>,
         ids: AtomicUsize,
         filter: F,
     }
 
-    pub struct MockSubscriber<F: Fn(&Meta) -> bool> {
+    pub struct MockSubscriber<F: Fn(&Metadata) -> bool> {
         expected: VecDeque<Expect>,
         filter: F,
     }
 
     pub struct MockHandle(Arc<Mutex<VecDeque<Expect>>>);
 
-    pub fn mock() -> MockSubscriber<fn(&Meta) -> bool> {
+    pub fn mock() -> MockSubscriber<fn(&Metadata) -> bool> {
         MockSubscriber {
             expected: VecDeque::new(),
-            filter: (|_: &Meta| true) as for<'r, 's> fn(&'r Meta<'s>) -> _,
+            filter: (|_: &Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
         }
     }
 
@@ -446,7 +446,7 @@ mod test_support {
         }
     }
 
-    impl<F: Fn(&Meta) -> bool> MockSubscriber<F> {
+    impl<F: Fn(&Metadata) -> bool> MockSubscriber<F> {
         pub fn enter(mut self, span: MockSpan) -> Self {
             self.expected.push_back(Expect::Enter(span));
             self
@@ -480,7 +480,7 @@ mod test_support {
 
         pub fn with_filter<G>(self, filter: G) -> MockSubscriber<G>
         where
-            G: Fn(&Meta) -> bool,
+            G: Fn(&Metadata) -> bool,
         {
             MockSubscriber {
                 filter,
@@ -506,8 +506,8 @@ mod test_support {
         }
     }
 
-    impl<F: Fn(&Meta) -> bool> Subscriber for Running<F> {
-        fn enabled(&self, meta: &Meta) -> bool {
+    impl<F: Fn(&Metadata) -> bool> Subscriber for Running<F> {
+        fn enabled(&self, meta: &Metadata) -> bool {
             (self.filter)(meta)
         }
 
@@ -519,7 +519,7 @@ mod test_support {
             // TODO: it should be possible to expect spans to follow from other spans
         }
 
-        fn new_span(&self, _attrs: &Meta) -> Span {
+        fn new_span(&self, _attrs: &Metadata) -> Span {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Span::from_u64(id as u64);
             println!("new_span: id={:?};", id);
@@ -530,7 +530,7 @@ mod test_support {
             id
         }
 
-        fn new_static(&self, span: &'static Meta<'static>) -> Span {
+        fn new_static(&self, span: &'static Metadata<'static>) -> Span {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Span::from_u64(id as u64);
             println!("new_static: {}; id={:?};", span.name, id);

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -147,7 +147,7 @@ pub trait Subscriber {
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_i64(&self, span: &Span, field: &field::Key, value: i64) {
+    fn record_i64(&self, span: &Span, field: &field::Field, value: i64) {
         self.record_debug(span, field, &value)
     }
 
@@ -160,7 +160,7 @@ pub trait Subscriber {
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_u64(&self, span: &Span, field: &field::Key, value: u64) {
+    fn record_u64(&self, span: &Span, field: &field::Field, value: u64) {
         self.record_debug(span, field, &value)
     }
 
@@ -173,7 +173,7 @@ pub trait Subscriber {
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_bool(&self, span: &Span, field: &field::Key, value: bool) {
+    fn record_bool(&self, span: &Span, field: &field::Field, value: bool) {
         self.record_debug(span, field, &value)
     }
 
@@ -186,7 +186,7 @@ pub trait Subscriber {
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_str(&self, span: &Span, field: &field::Key, value: &str) {
+    fn record_str(&self, span: &Span, field: &field::Field, value: &str) {
         self.record_debug(span, field, &value)
     }
 
@@ -195,7 +195,7 @@ pub trait Subscriber {
     /// If recording the field is invalid (i.e. the span ID doesn't exist, the
     /// field has already been recorded, and so on), the subscriber may silently
     /// do nothing.
-    fn record_debug(&self, span: &Span, field: &field::Key, value: &fmt::Debug);
+    fn record_debug(&self, span: &Span, field: &field::Field, value: &fmt::Debug);
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -511,7 +511,7 @@ mod test_support {
             (self.filter)(meta)
         }
 
-        fn record_debug(&self, span: &Span, field: &field::Key, value: &fmt::Debug) {
+        fn record_debug(&self, span: &Span, field: &field::Field, value: &fmt::Debug) {
             // TODO: it would be nice to be able to expect field values...
         }
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -90,7 +90,7 @@ impl<'a> AsTrace for log::Record<'a> {
                     module_path: None,
                     file: None,
                     line: None,
-                    fields: field::Fields {
+                    fields: field::FieldSet {
                         names: &["message"],
                         callsite: callsite::Identifier(&LogCallsite),
                     },

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -36,7 +36,7 @@ use tokio_trace::{
     callsite::{self, Callsite},
     field,
     subscriber::{self, Subscriber},
-    Id, Meta,
+    Id, Metadata,
 };
 
 /// Format a log record as a trace event in the current span.
@@ -63,7 +63,7 @@ pub trait AsTrace {
     fn as_trace(&self) -> Self::Trace;
 }
 
-impl<'a> AsLog for Meta<'a> {
+impl<'a> AsLog for Metadata<'a> {
     type Log = log::Metadata<'a>;
     fn as_log(&self) -> Self::Log {
         log::Metadata::builder()
@@ -74,16 +74,16 @@ impl<'a> AsLog for Meta<'a> {
 }
 
 impl<'a> AsTrace for log::Record<'a> {
-    type Trace = Meta<'a>;
+    type Trace = Metadata<'a>;
     fn as_trace(&self) -> Self::Trace {
         struct LogCallsite;
         impl Callsite for LogCallsite {
             fn add_interest(&self, _interest: subscriber::Interest) {}
             fn remove_interest(&self) {}
-            fn metadata(&self) -> &Meta {
+            fn metadata(&self) -> &Metadata {
                 // Since we never register the log callsite, this method is
                 // never actually called. So it's okay to return mostly empty metadata.
-                static EMPTY_META: Meta<'static> = Meta {
+                static EMPTY_META: Metadata<'static> = Metadata {
                     name: "log record",
                     target: "log",
                     level: tokio_trace::Level::TRACE,
@@ -98,7 +98,7 @@ impl<'a> AsTrace for log::Record<'a> {
                 &EMPTY_META
             }
         }
-        Meta::new(
+        Metadata::new(
             "log record",
             self.target(),
             self.level().as_trace(),
@@ -258,7 +258,7 @@ impl TraceLoggerBuilder {
 struct SpanLineBuilder {
     parent: Option<Id>,
     ref_count: usize,
-    meta: &'static Meta<'static>,
+    meta: &'static Metadata<'static>,
     log_line: String,
     fields: String,
 }
@@ -266,7 +266,7 @@ struct SpanLineBuilder {
 impl SpanLineBuilder {
     fn new(
         parent: Option<Id>,
-        meta: &'static Meta<'static>,
+        meta: &'static Metadata<'static>,
         fields: String,
         id: Id,
         settings: &TraceLoggerBuilder,
@@ -325,7 +325,7 @@ struct EventLineBuilder {
 }
 
 impl EventLineBuilder {
-    fn new(meta: &Meta, id: Id, settings: &TraceLoggerBuilder) -> Self {
+    fn new(meta: &Metadata, id: Id, settings: &TraceLoggerBuilder) -> Self {
         let mut log_line = String::new();
         if settings.log_ids {
             write!(&mut log_line, "event={:?}; ", id,).expect("write to string shouldn't fail");
@@ -380,11 +380,11 @@ impl EventLineBuilder {
 }
 
 impl Subscriber for TraceLogger {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         log::logger().enabled(&metadata.as_log())
     }
 
-    fn new_static(&self, new_span: &'static Meta<'static>) -> Id {
+    fn new_static(&self, new_span: &'static Metadata<'static>) -> Id {
         let id = self.next_id();
         let mut in_progress = self.in_progress.lock().unwrap();
         let mut fields = String::new();
@@ -403,7 +403,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn new_span(&self, new_span: &Meta) -> Id {
+    fn new_span(&self, new_span: &Metadata) -> Id {
         let id = self.next_id();
         self.in_progress.lock().unwrap().events.insert(
             id.clone(),
@@ -627,11 +627,11 @@ impl Subscriber for TraceLogger {
 // }
 
 impl tokio_trace_subscriber::Filter for TraceLogger {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         <Self as Subscriber>::enabled(&self, metadata)
     }
 
-    fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, _metadata: &Metadata) -> bool {
         false
     }
 }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -42,7 +42,7 @@ use tokio_trace::{
 /// Format a log record as a trace event in the current span.
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let meta = record.as_trace();
-    let k = meta.fields().key_for(&"message").unwrap();
+    let k = meta.fields().field_named(&"message").unwrap();
     drop(tokio_trace::Event::new(
         subscriber::Interest::SOMETIMES,
         &meta,

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -285,7 +285,7 @@ impl SpanLineBuilder {
         }
     }
 
-    fn record(&mut self, key: &field::Key, value: &fmt::Debug) -> fmt::Result {
+    fn record(&mut self, key: &field::Field, value: &fmt::Debug) -> fmt::Result {
         write!(
             &mut self.fields,
             "{}={:?}; ",
@@ -342,7 +342,7 @@ impl EventLineBuilder {
         }
     }
 
-    fn record(&mut self, key: &field::Key, value: &fmt::Debug) -> fmt::Result {
+    fn record(&mut self, key: &field::Field, value: &fmt::Debug) -> fmt::Result {
         if key.name() == Some("message") {
             write!(&mut self.message, "{:?}", value)
         } else {
@@ -412,7 +412,7 @@ impl Subscriber for TraceLogger {
         id
     }
 
-    fn record_debug(&self, span: &Id, key: &field::Key, value: &fmt::Debug) {
+    fn record_debug(&self, span: &Id, key: &field::Field, value: &fmt::Debug) {
         let mut in_progress = self.in_progress.lock().unwrap();
         if let Some(span) = in_progress.spans.get_mut(span) {
             if let Err(_e) = span.record(key, value) {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use tokio_trace::{field, subscriber::Subscriber, Id, Meta};
+use tokio_trace::{field, subscriber::Subscriber, Id, Metadata};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -91,15 +91,15 @@ where
     O: Observe,
     R: RegisterSpan,
 {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_static(&self, meta: &'static Meta<'static>) -> Id {
+    fn new_static(&self, meta: &'static Metadata<'static>) -> Id {
         self.registry.new_span(meta)
     }
 
-    fn new_span(&self, meta: &Meta) -> Id {
+    fn new_span(&self, meta: &Metadata) -> Id {
         self.registry.new_id(meta)
     }
 

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -103,7 +103,7 @@ where
         self.registry.new_id(meta)
     }
 
-    fn record_debug(&self, _span: &Id, _name: &field::Key, _value: &fmt::Debug) {
+    fn record_debug(&self, _span: &Id, _name: &field::Field, _value: &fmt::Debug) {
         unimplemented!()
     }
 

--- a/tokio-trace-subscriber/src/observe.rs
+++ b/tokio-trace-subscriber/src/observe.rs
@@ -3,7 +3,7 @@ use {
     registry::SpanRef,
 };
 
-use tokio_trace::{Event, Meta};
+use tokio_trace::{Event, Metadata};
 
 /// The notification processing portion of the [`Subscriber`] trait.
 ///
@@ -32,7 +32,7 @@ pub trait ObserveExt: Observe {
     /// extern crate tokio_trace_subscriber;
     /// use tokio_trace_subscriber::{registry, Event, Observe, ObserveExt, SpanRef};
     /// # use tokio_trace_subscriber::filter::{Filter, NoFilter};
-    /// # use tokio_trace::{Level, Meta, Span};
+    /// # use tokio_trace::{Level, Metadata, Span};
     /// # fn main() {
     ///
     /// struct Foo {
@@ -106,12 +106,12 @@ pub trait ObserveExt: Observe {
     /// extern crate tokio_trace_log;
     /// extern crate tokio_trace_subscriber;
     /// use tokio_trace_subscriber::{registry, filter, Observe, ObserveExt, SpanRef};
-    /// # use tokio_trace::{Level, Meta, Span};
+    /// # use tokio_trace::{Level, Metadata, Span};
     /// # fn main() {
     ///
     /// let observer = tokio_trace_log::TraceLogger::new()
     ///     // Subscribe *only* to spans named "foo".
-    ///     .with_filter(|meta: &Meta| {
+    ///     .with_filter(|meta: &Metadata| {
     ///         meta.name == Some("foo")
     ///     });
     ///
@@ -240,12 +240,12 @@ where
     F: Filter,
 {
     #[inline]
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         self.filter.enabled(metadata) && self.inner.filter().enabled(metadata)
     }
 
     #[inline]
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, metadata: &Metadata) -> bool {
         self.filter.should_invalidate_filter(metadata)
             || self.inner.filter().should_invalidate_filter(metadata)
     }
@@ -333,11 +333,11 @@ where
     A: Observe,
     B: Observe,
 {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         self.a.filter().enabled(metadata) || self.b.filter().enabled(metadata)
     }
 
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, metadata: &Metadata) -> bool {
         self.a.filter().should_invalidate_filter(metadata)
             || self.b.filter().should_invalidate_filter(metadata)
     }
@@ -382,14 +382,14 @@ where
     A: Observe,
     B: Observe,
 {
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         match self {
             Either::A(a) => a.filter().enabled(metadata),
             Either::B(b) => b.filter().enabled(metadata),
         }
     }
 
-    fn should_invalidate_filter(&self, metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, metadata: &Metadata) -> bool {
         match self {
             Either::A(a) => a.filter().should_invalidate_filter(metadata),
             Either::B(b) => b.filter().should_invalidate_filter(metadata),
@@ -412,11 +412,11 @@ impl Observe for NoObserver {
 }
 
 impl Filter for NoObserver {
-    fn enabled(&self, _metadata: &Meta) -> bool {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
         false
     }
 
-    fn should_invalidate_filter(&self, _metadata: &Meta) -> bool {
+    fn should_invalidate_filter(&self, _metadata: &Metadata) -> bool {
         false
     }
 }

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -125,7 +125,7 @@ impl<'a, 'b> cmp::PartialEq<SpanRef<'b>> for SpanRef<'a> {
 impl<'a> cmp::Eq for SpanRef<'a> {}
 
 // impl<'a> IntoIterator for &'a SpanRef<'a> {
-//     type Item = (field::Key<'a>, &'a OwnedValue);
+//     type Item = (field::Field<'a>, &'a OwnedValue);
 //     type IntoIter = Box<Iterator<Item = Self::Item> + 'a>; // TODO: unbox
 //     fn into_iter(self) -> Self::IntoIter {
 //         self.data

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,4 +1,4 @@
-use tokio_trace::{span::Id, Meta};
+use tokio_trace::{span::Id, Metadata};
 
 use std::{
     cmp,
@@ -34,11 +34,11 @@ pub trait RegisterSpan {
     /// from all calls to this function, if they so choose.
     ///
     /// [span ID]: ../span/struct.Id.html
-    fn new_span(&self, new_span: &'static Meta<'static>) -> Id {
+    fn new_span(&self, new_span: &'static Metadata<'static>) -> Id {
         self.new_id(new_span)
     }
 
-    fn new_id(&self, new_id: &Meta) -> Id;
+    fn new_id(&self, new_id: &Metadata) -> Id;
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -106,7 +106,7 @@ pub trait RegisterSpan {
 #[derive(Debug)]
 pub struct SpanRef<'a> {
     pub id: &'a Id,
-    pub data: Option<&'a Meta<'a>>,
+    pub data: Option<&'a Metadata<'a>>,
     // TODO: the registry can still have a concept of span states...
 }
 
@@ -147,7 +147,7 @@ impl<'a> cmp::Eq for SpanRef<'a> {}
 
 pub struct IncreasingCounter {
     next_id: AtomicUsize,
-    spans: Mutex<HashMap<Id, &'static Meta<'static>>>,
+    spans: Mutex<HashMap<Id, &'static Metadata<'static>>>,
 }
 
 pub fn increasing_counter() -> IncreasingCounter {
@@ -166,7 +166,7 @@ impl Default for IncreasingCounter {
 impl RegisterSpan for IncreasingCounter {
     type PriorSpans = iter::Empty<Id>;
 
-    fn new_span(&self, new_span: &'static Meta<'static>) -> Id {
+    fn new_span(&self, new_span: &'static Metadata<'static>) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         if let Ok(mut spans) = self.spans.lock() {
@@ -175,7 +175,7 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn new_id(&self, _new: &Meta) -> Id {
+    fn new_id(&self, _new: &Metadata) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         id

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -6,7 +6,7 @@ extern crate test;
 use test::Bencher;
 
 use std::sync::Mutex;
-use tokio_trace::{field, span, Id, Meta};
+use tokio_trace::{field, span, Id, Metadata};
 
 /// A subscriber that is enabled but otherwise does nothing.
 struct EnabledSubscriber;
@@ -25,7 +25,7 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         let _ = (span, follows);
     }
 
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         let _ = metadata;
         true
     }
@@ -64,7 +64,7 @@ impl tokio_trace::Subscriber for Record {
         let _ = (span, follows);
     }
 
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         let _ = metadata;
         true
     }

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -17,7 +17,7 @@ impl tokio_trace::Subscriber for EnabledSubscriber {
         Id::from_u64(0)
     }
 
-    fn record_fmt(&self, span: &Id, field: &field::Key, value: ::std::fmt::Arguments) {
+    fn record_fmt(&self, span: &Id, field: &field::Field, value: ::std::fmt::Arguments) {
         let _ = (span, field, value);
     }
 
@@ -56,7 +56,7 @@ impl tokio_trace::Subscriber for Record {
         Id::from_u64(0)
     }
 
-    fn record_fmt(&self, _span: &Id, _field: &field::Key, value: ::std::fmt::Arguments) {
+    fn record_fmt(&self, _span: &Id, _field: &field::Field, value: ::std::fmt::Arguments) {
         let _ = ::std::fmt::format(value);
     }
 

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -4,7 +4,7 @@ extern crate tokio_trace;
 use tokio_trace::{
     field, span,
     subscriber::{self, Subscriber},
-    Id, Meta,
+    Id, Metadata,
 };
 
 use std::{
@@ -24,7 +24,7 @@ struct CounterSubscriber {
 }
 
 impl Subscriber for CounterSubscriber {
-    fn register_callsite(&self, meta: &tokio_trace::Meta) -> subscriber::Interest {
+    fn register_callsite(&self, meta: &tokio_trace::Metadata) -> subscriber::Interest {
         let mut interest = subscriber::Interest::NEVER;
         for key in meta.fields() {
             if let Some(name) = key.name() {
@@ -42,7 +42,7 @@ impl Subscriber for CounterSubscriber {
         interest
     }
 
-    fn new_span(&self, _new_span: &Meta) -> Id {
+    fn new_span(&self, _new_span: &Metadata) -> Id {
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
         Id::from_u64(id as u64)
     }
@@ -71,7 +71,7 @@ impl Subscriber for CounterSubscriber {
 
     fn record_debug(&self, _id: &Id, _field: &field::Field, _value: &::std::fmt::Debug) {}
 
-    fn enabled(&self, metadata: &Meta) -> bool {
+    fn enabled(&self, metadata: &Metadata) -> bool {
         metadata
             .fields()
             .iter()

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -51,7 +51,7 @@ impl Subscriber for CounterSubscriber {
         // unimplemented
     }
 
-    fn record_i64(&self, _id: &Id, field: &field::Key, value: i64) {
+    fn record_i64(&self, _id: &Id, field: &field::Field, value: i64) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             if value > 0 {
@@ -62,14 +62,14 @@ impl Subscriber for CounterSubscriber {
         };
     }
 
-    fn record_u64(&self, _id: &Id, field: &field::Key, value: u64) {
+    fn record_u64(&self, _id: &Id, field: &field::Field, value: u64) {
         let registry = self.counters.0.read().unwrap();
         if let Some(counter) = field.name().and_then(|name| registry.get(name)) {
             counter.fetch_add(value as usize, Ordering::Release);
         };
     }
 
-    fn record_debug(&self, _id: &Id, _field: &field::Key, _value: &::std::fmt::Debug) {}
+    fn record_debug(&self, _id: &Id, _field: &field::Field, _value: &::std::fmt::Debug) {}
 
     fn enabled(&self, metadata: &Meta) -> bool {
         metadata

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -69,7 +69,7 @@ impl fmt::Display for ColorLevel {
 }
 
 impl Span {
-    fn new(parent: Option<Id>, _meta: &'static tokio_trace::Meta<'static>) -> Self {
+    fn new(parent: Option<Id>, _meta: &'static tokio_trace::Metadata<'static>) -> Self {
         Self {
             parent,
             kvs: Vec::new(),
@@ -85,7 +85,7 @@ impl Span {
 }
 
 impl Event {
-    fn new(meta: &tokio_trace::Meta) -> Self {
+    fn new(meta: &tokio_trace::Metadata) -> Self {
         Self {
             target: meta.target.to_owned(),
             level: meta.level.clone(),
@@ -156,11 +156,11 @@ impl SloggishSubscriber {
 }
 
 impl Subscriber for SloggishSubscriber {
-    fn enabled(&self, _metadata: &tokio_trace::Meta) -> bool {
+    fn enabled(&self, _metadata: &tokio_trace::Metadata) -> bool {
         true
     }
 
-    fn new_span(&self, span: &tokio_trace::Meta) -> tokio_trace::Id {
+    fn new_span(&self, span: &tokio_trace::Metadata) -> tokio_trace::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         let id = tokio_trace::Id::from_u64(next);
         self.events
@@ -170,7 +170,7 @@ impl Subscriber for SloggishSubscriber {
         id
     }
 
-    fn new_static(&self, span: &'static tokio_trace::Meta<'static>) -> tokio_trace::Id {
+    fn new_static(&self, span: &'static tokio_trace::Metadata<'static>) -> tokio_trace::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         let id = tokio_trace::Id::from_u64(next);
         self.spans

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -76,7 +76,7 @@ impl Span {
         }
     }
 
-    fn record(&mut self, key: &tokio_trace::field::Key, value: fmt::Arguments) {
+    fn record(&mut self, key: &tokio_trace::field::Field, value: fmt::Arguments) {
         // TODO: shouldn't have to alloc the key...
         let k = key.name().unwrap_or("???").to_owned();
         let v = fmt::format(value);
@@ -94,7 +94,7 @@ impl Event {
         }
     }
 
-    fn record(&mut self, key: &tokio_trace::field::Key, value: fmt::Arguments) {
+    fn record(&mut self, key: &tokio_trace::field::Field, value: fmt::Arguments) {
         if key.name() == Some("message") {
             self.message = fmt::format(value);
             return;
@@ -183,7 +183,7 @@ impl Subscriber for SloggishSubscriber {
     fn record_debug(
         &self,
         span: &tokio_trace::Id,
-        name: &tokio_trace::field::Key,
+        name: &tokio_trace::field::Field,
         value: &fmt::Debug,
     ) {
         if let Some(event) = self.events.lock().expect("mutex poisoned!").get_mut(span) {

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -5,44 +5,44 @@ use Meta;
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
-/// **Note**: Although this is implemented for both the [`Key`] type *and* any
-/// type that can be borrowed as an `&str`, only `Key` allows _O_(1) access.
+/// **Note**: Although this is implemented for both the [`Field`] type *and* any
+/// type that can be borrowed as an `&str`, only `Field` allows _O_(1) access.
 /// Indexing a field with a string results in an iterative search that performs
 /// string comparisons. Thus, if possible, once the key for a field is known, it
 /// should be used whenever possible.
-pub trait AsKey {
-    /// Attempts to convert `&self` into a `Key` with the specified `metadata`.
+pub trait AsField {
+    /// Attempts to convert `&self` into a `Field` with the specified `metadata`.
     ///
     /// If `metadata` defines a key corresponding to this field, then the key is
     /// returned. Otherwise, this function returns `None`.
-    fn as_key(&self, metadata: &Meta) -> Option<Key>;
+    fn as_key(&self, metadata: &Meta) -> Option<Field>;
 }
 
 pub trait Record {
     /// Record a signed 64-bit integer value.
     fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
-        Q: AsKey;
+        Q: AsField;
 
     /// Record an umsigned 64-bit integer value.
     fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
-        Q: AsKey;
+        Q: AsField;
 
     /// Record a boolean value.
     fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
-        Q: AsKey;
+        Q: AsField;
 
     /// Record a string value.
     fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
-        Q: AsKey;
+        Q: AsField;
 
     /// Record a value implementing `fmt::Debug`.
     fn record_debug<Q: ?Sized>(&mut self, field: &Q, value: &fmt::Debug)
     where
-        Q: AsKey;
+        Q: AsField;
 }
 
 /// A field value of an erased type.
@@ -54,7 +54,7 @@ pub trait Value {
     /// Records this value with the given `Subscriber`.
     fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
-        Q: AsKey,
+        Q: AsField,
         R: Record;
 }
 
@@ -103,7 +103,7 @@ macro_rules! impl_value {
                     recorder: &mut R,
                 )
                 where
-                    Q: $crate::field::AsKey,
+                    Q: $crate::field::AsField,
                     R: $crate::field::Record,
                 {
                     recorder.$record(key, *self)
@@ -120,7 +120,7 @@ macro_rules! impl_value {
                     recorder: &mut R,
                 )
                 where
-                    Q: $crate::field::AsKey,
+                    Q: $crate::field::AsField,
                     R: $crate::field::Record,
                 {
                     recorder.$record(key, *self as $as_ty)
@@ -130,11 +130,11 @@ macro_rules! impl_value {
     };
 }
 
-// ===== impl AsKey =====
+// ===== impl AsField =====
 
-impl AsKey for Key {
+impl AsField for Field {
     #[inline]
-    fn as_key(&self, metadata: &Meta) -> Option<Key> {
+    fn as_key(&self, metadata: &Meta) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some(self.clone())
         } else {
@@ -143,9 +143,9 @@ impl AsKey for Key {
     }
 }
 
-impl<'a> AsKey for &'a Key {
+impl<'a> AsField for &'a Field {
     #[inline]
-    fn as_key(&self, metadata: &Meta) -> Option<Key> {
+    fn as_key(&self, metadata: &Meta) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some((*self).clone())
         } else {
@@ -154,9 +154,9 @@ impl<'a> AsKey for &'a Key {
     }
 }
 
-impl AsKey for str {
+impl AsField for str {
     #[inline]
-    fn as_key(&self, metadata: &Meta) -> Option<Key> {
+    fn as_key(&self, metadata: &Meta) -> Option<Field> {
         metadata.fields().key_for(&self)
     }
 }
@@ -174,7 +174,7 @@ impl_values! {
 impl Value for str {
     fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
-        Q: AsKey,
+        Q: AsField,
         R: Record,
     {
         recorder.record_str(key, &self)
@@ -187,7 +187,7 @@ where
 {
     fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
-        Q: AsKey,
+        Q: AsField,
         R: Record,
     {
         (*self).record(key, recorder)
@@ -202,7 +202,7 @@ where
 {
     fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
-        Q: AsKey,
+        Q: AsField,
         R: Record,
     {
         recorder.record_debug(key, &format_args!("{}", self.0))
@@ -217,7 +217,7 @@ where
 {
     fn record<Q: ?Sized, R>(&self, key: &Q, recorder: &mut R)
     where
-        Q: AsKey,
+        Q: AsField,
         R: Record,
     {
         recorder.record_debug(key, &self.0)

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -157,7 +157,7 @@ impl<'a> AsField for &'a Field {
 impl AsField for str {
     #[inline]
     fn as_key(&self, metadata: &Meta) -> Option<Field> {
-        metadata.fields().key_for(&self)
+        metadata.fields().field_named(&self)
     }
 }
 

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -13,9 +13,9 @@ use Meta;
 pub trait AsField {
     /// Attempts to convert `&self` into a `Field` with the specified `metadata`.
     ///
-    /// If `metadata` defines a key corresponding to this field, then the key is
-    /// returned. Otherwise, this function returns `None`.
-    fn as_key(&self, metadata: &Meta) -> Option<Field>;
+    /// If `metadata` defines this field, then the field is returned. Otherwise,
+    /// this returns `None`.
+    fn as_field(&self, metadata: &Meta) -> Option<Field>;
 }
 
 pub trait Record {
@@ -134,7 +134,7 @@ macro_rules! impl_value {
 
 impl AsField for Field {
     #[inline]
-    fn as_key(&self, metadata: &Meta) -> Option<Field> {
+    fn as_field(&self, metadata: &Meta) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some(self.clone())
         } else {
@@ -145,7 +145,7 @@ impl AsField for Field {
 
 impl<'a> AsField for &'a Field {
     #[inline]
-    fn as_key(&self, metadata: &Meta) -> Option<Field> {
+    fn as_field(&self, metadata: &Meta) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some((*self).clone())
         } else {
@@ -156,7 +156,7 @@ impl<'a> AsField for &'a Field {
 
 impl AsField for str {
     #[inline]
-    fn as_key(&self, metadata: &Meta) -> Option<Field> {
+    fn as_field(&self, metadata: &Meta) -> Option<Field> {
         metadata.fields().field_named(&self)
     }
 }

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -1,7 +1,7 @@
 pub use tokio_trace_core::field::*;
 
 use std::fmt;
-use Meta;
+use Metadata;
 
 /// Trait implemented to allow a type to be used as a field key.
 ///
@@ -15,7 +15,7 @@ pub trait AsField {
     ///
     /// If `metadata` defines this field, then the field is returned. Otherwise,
     /// this returns `None`.
-    fn as_field(&self, metadata: &Meta) -> Option<Field>;
+    fn as_field(&self, metadata: &Metadata) -> Option<Field>;
 }
 
 pub trait Record {
@@ -134,7 +134,7 @@ macro_rules! impl_value {
 
 impl AsField for Field {
     #[inline]
-    fn as_field(&self, metadata: &Meta) -> Option<Field> {
+    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some(self.clone())
         } else {
@@ -145,7 +145,7 @@ impl AsField for Field {
 
 impl<'a> AsField for &'a Field {
     #[inline]
-    fn as_field(&self, metadata: &Meta) -> Option<Field> {
+    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
         if self.callsite() == metadata.callsite() {
             Some((*self).clone())
         } else {
@@ -156,7 +156,7 @@ impl<'a> AsField for &'a Field {
 
 impl AsField for str {
     #[inline]
-    fn as_field(&self, metadata: &Meta) -> Option<Field> {
+    fn as_field(&self, metadata: &Metadata) -> Option<Field> {
         metadata.fields().field_named(&self)
     }
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -71,7 +71,7 @@
 //! [`enter`]: subscriber/trait.Subscriber.html#tymethod.enter
 //! [`exit`]: subscriber/trait.Subscriber.html#tymethod.exit
 //! [`enabled`]: subscriber/trait.Subscriber.html#tymethod.enabled
-//! [metadata]: struct.Meta.html
+//! [metadata]: struct.Metadata.html
 extern crate tokio_trace_core;
 
 // Somehow this `use` statement is necessary for us to re-export the `core`
@@ -86,7 +86,7 @@ pub use self::{
     subscriber::Subscriber,
     tokio_trace_core::{
         callsite::{self, Callsite},
-        metadata, Level, Meta,
+        metadata, Level, Metadata,
     },
 };
 
@@ -118,9 +118,9 @@ macro_rules! callsite {
         fields: $field_names:expr
     ) => ({
         use std::sync::{Once, atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering}};
-        use $crate::{callsite, Meta, subscriber::Interest};
+        use $crate::{callsite, Metadata, subscriber::Interest};
         struct MyCallsite;
-        static META: Meta<'static> = {
+        static META: Metadata<'static> = {
             use $crate::*;
             metadata! {
                 name: $name,
@@ -165,7 +165,7 @@ macro_rules! callsite {
             fn remove_interest(&self) {
                 INTEREST.store(0, Ordering::Relaxed);
             }
-            fn metadata(&self) -> &Meta {
+            fn metadata(&self) -> &Metadata {
                 &META
             }
         }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -208,7 +208,7 @@ macro_rules! span {
     ($name:expr, $($k:ident $( = $val:expr )* ) ,*) => {
         {
             #[allow(unused_imports)]
-            use $crate::{callsite, field::{Value, AsKey}, Span};
+            use $crate::{callsite, field::{Value, AsField}, Span};
             use $crate::callsite::Callsite;
             let callsite = callsite! { span: $name, $( $k ),* };
             // Depending on how many fields are generated, this may or may
@@ -237,7 +237,7 @@ macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => ({
         {
             #[allow(unused_imports)]
-            use $crate::{callsite, Id, Subscriber, Event, field::{Value, AsKey}};
+            use $crate::{callsite, Id, Subscriber, Event, field::{Value, AsField}};
             use $crate::callsite::Callsite;
             let callsite = callsite! { event:
                 $lvl,

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -311,9 +311,9 @@ impl Span {
         }
     }
 
-    /// Returns a [`Key`](::field::Key) for the field with the given `name`, if
+    /// Returns a [`Field`](::field::Field) for the field with the given `name`, if
     /// one exists,
-    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Key>
+    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Field>
     where
         Q: Borrow<str>,
     {
@@ -323,10 +323,10 @@ impl Span {
     }
 
     /// Returns true if this `Span` has a field for the given
-    /// [`Key`](::field::Key) or field name.
+    /// [`Field`](::field::Field) or field name.
     pub fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         self.metadata()
             .and_then(|meta| field.as_key(meta))
@@ -336,7 +336,7 @@ impl Span {
     /// Records that the field described by `field` has the value `value`.
     pub fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> &mut Self
     where
-        Q: field::AsKey,
+        Q: field::AsField,
         V: field::Value,
     {
         if let Some(ref mut inner) = self.inner {
@@ -449,16 +449,16 @@ impl<'a> Event<'a> {
     }
 
     /// Adds a formattable message describing the event that occurred.
-    pub fn message(&mut self, key: &field::Key, message: fmt::Arguments) -> &mut Self {
+    pub fn message(&mut self, key: &field::Field, message: fmt::Arguments) -> &mut Self {
         if let Some(ref mut inner) = self.inner {
             inner.subscriber.record_debug(&inner.id, key, &message);
         }
         self
     }
 
-    /// Returns a [`Key`](::field::Key) for the field with the given `name`, if
+    /// Returns a [`Field`](::field::Field) for the field with the given `name`, if
     /// one exists,
-    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Key>
+    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Field>
     where
         Q: Borrow<str>,
     {
@@ -468,10 +468,10 @@ impl<'a> Event<'a> {
     }
 
     /// Returns true if this `Event` has a field for the given
-    /// [`Key`](::field::Key) or field name.
+    /// [`Field`](::field::Field) or field name.
     pub fn has_field<Q: ?Sized>(&self, field: &Q) -> bool
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         self.metadata()
             .and_then(|meta| field.as_key(meta))
@@ -481,7 +481,7 @@ impl<'a> Event<'a> {
     /// Records that the field described by `field` has the value `value`.
     pub fn record<Q: ?Sized, V: ?Sized>(&mut self, field: &Q, value: &V) -> &mut Self
     where
-        Q: field::AsKey,
+        Q: field::AsField,
         V: field::Value,
     {
         if let Some(ref mut inner) = self.inner {
@@ -561,27 +561,27 @@ impl<'a> Inner<'a> {
     }
 
     /// Record a signed 64-bit integer value.
-    fn record_value_i64(&self, field: &field::Key, value: i64) {
+    fn record_value_i64(&self, field: &field::Field, value: i64) {
         self.subscriber.record_i64(&self.id, field, value)
     }
 
     /// Record an unsigned 64-bit integer value.
-    fn record_value_u64(&self, field: &field::Key, value: u64) {
+    fn record_value_u64(&self, field: &field::Field, value: u64) {
         self.subscriber.record_u64(&self.id, field, value)
     }
 
     /// Record a boolean value.
-    fn record_value_bool(&self, field: &field::Key, value: bool) {
+    fn record_value_bool(&self, field: &field::Field, value: bool) {
         self.subscriber.record_bool(&self.id, field, value)
     }
 
     /// Record a string value.
-    fn record_value_str(&self, field: &field::Key, value: &str) {
+    fn record_value_str(&self, field: &field::Field, value: &str) {
         self.subscriber.record_str(&self.id, field, value)
     }
 
     /// Record a value implementing `fmt::Debug`.
-    fn record_value_debug(&self, field: &field::Key, value: &fmt::Debug) {
+    fn record_value_debug(&self, field: &field::Field, value: &fmt::Debug) {
         self.subscriber.record_debug(&self.id, field, value)
     }
 
@@ -628,7 +628,7 @@ impl<'a> field::Record for Inner<'a> {
     #[inline]
     fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         if let Some(key) = field.as_key(self.metadata()) {
             self.record_value_i64(&key, value);
@@ -638,7 +638,7 @@ impl<'a> field::Record for Inner<'a> {
     #[inline]
     fn record_u64<Q: ?Sized>(&mut self, field: &Q, value: u64)
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         if let Some(key) = field.as_key(self.metadata()) {
             self.record_value_u64(&key, value);
@@ -648,7 +648,7 @@ impl<'a> field::Record for Inner<'a> {
     #[inline]
     fn record_bool<Q: ?Sized>(&mut self, field: &Q, value: bool)
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         if let Some(key) = field.as_key(self.metadata()) {
             self.record_value_bool(&key, value);
@@ -658,7 +658,7 @@ impl<'a> field::Record for Inner<'a> {
     #[inline]
     fn record_str<Q: ?Sized>(&mut self, field: &Q, value: &str)
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         if let Some(key) = field.as_key(self.metadata()) {
             self.record_value_str(&key, value);
@@ -668,7 +668,7 @@ impl<'a> field::Record for Inner<'a> {
     #[inline]
     fn record_debug<Q: ?Sized>(&mut self, field: &Q, value: &fmt::Debug)
     where
-        Q: field::AsKey,
+        Q: field::AsField,
     {
         if let Some(key) = field.as_key(self.metadata()) {
             self.record_value_debug(&key, value);

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -313,13 +313,13 @@ impl Span {
 
     /// Returns a [`Field`](::field::Field) for the field with the given `name`, if
     /// one exists,
-    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Field>
+    pub fn field_named<Q>(&self, name: &Q) -> Option<field::Field>
     where
         Q: Borrow<str>,
     {
         self.inner
             .as_ref()
-            .and_then(|inner| inner.meta.fields().key_for(name))
+            .and_then(|inner| inner.meta.fields().field_named(name))
     }
 
     /// Returns true if this `Span` has a field for the given
@@ -458,13 +458,13 @@ impl<'a> Event<'a> {
 
     /// Returns a [`Field`](::field::Field) for the field with the given `name`, if
     /// one exists,
-    pub fn key_for<Q>(&self, name: &Q) -> Option<field::Field>
+    pub fn field_named<Q>(&self, name: &Q) -> Option<field::Field>
     where
         Q: Borrow<str>,
     {
         self.inner
             .as_ref()
-            .and_then(|inner| inner.meta.fields().key_for(name))
+            .and_then(|inner| inner.meta.fields().field_named(name))
     }
 
     /// Returns true if this `Event` has a field for the given

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -324,7 +324,7 @@ impl Span {
 
     /// Returns true if this `Span` has a field for the given
     /// [`Field`](::field::Field) or field name.
-    pub fn has_field_for<Q: ?Sized>(&self, field: &Q) -> bool
+    pub fn has_field<Q: ?Sized>(&self, field: &Q) -> bool
     where
         Q: field::AsField,
     {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -329,7 +329,7 @@ impl Span {
         Q: field::AsField,
     {
         self.metadata()
-            .and_then(|meta| field.as_key(meta))
+            .and_then(|meta| field.as_field(meta))
             .is_some()
     }
 
@@ -474,7 +474,7 @@ impl<'a> Event<'a> {
         Q: field::AsField,
     {
         self.metadata()
-            .and_then(|meta| field.as_key(meta))
+            .and_then(|meta| field.as_field(meta))
             .is_some()
     }
 
@@ -630,7 +630,7 @@ impl<'a> field::Record for Inner<'a> {
     where
         Q: field::AsField,
     {
-        if let Some(key) = field.as_key(self.metadata()) {
+        if let Some(key) = field.as_field(self.metadata()) {
             self.record_value_i64(&key, value);
         }
     }
@@ -640,7 +640,7 @@ impl<'a> field::Record for Inner<'a> {
     where
         Q: field::AsField,
     {
-        if let Some(key) = field.as_key(self.metadata()) {
+        if let Some(key) = field.as_field(self.metadata()) {
             self.record_value_u64(&key, value);
         }
     }
@@ -650,7 +650,7 @@ impl<'a> field::Record for Inner<'a> {
     where
         Q: field::AsField,
     {
-        if let Some(key) = field.as_key(self.metadata()) {
+        if let Some(key) = field.as_field(self.metadata()) {
             self.record_value_bool(&key, value);
         }
     }
@@ -660,7 +660,7 @@ impl<'a> field::Record for Inner<'a> {
     where
         Q: field::AsField,
     {
-        if let Some(key) = field.as_key(self.metadata()) {
+        if let Some(key) = field.as_field(self.metadata()) {
             self.record_value_str(&key, value);
         }
     }
@@ -670,7 +670,7 @@ impl<'a> field::Record for Inner<'a> {
     where
         Q: field::AsField,
     {
-        if let Some(key) = field.as_key(self.metadata()) {
+        if let Some(key) = field.as_field(self.metadata()) {
             self.record_value_debug(&key, value);
         }
     }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -150,7 +150,7 @@ use {
     dispatcher::{self, Dispatch},
     field,
     subscriber::{Interest, Subscriber},
-    Meta,
+    Metadata,
 };
 
 /// A handle representing a span, with the capability to enter the span if it
@@ -216,7 +216,7 @@ pub(crate) struct Inner<'a> {
     /// possible.
     closed: bool,
 
-    meta: &'a Meta<'a>,
+    meta: &'a Metadata<'a>,
 }
 
 /// When an `Inner` corresponds to a `Span` rather than an `Event`, it can be
@@ -256,7 +256,7 @@ impl Span {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(interest: Interest, meta: &'static Meta<'static>, if_enabled: F) -> Span
+    pub fn new<F>(interest: Interest, meta: &'static Metadata<'static>, if_enabled: F) -> Span
     where
         F: FnOnce(&mut Span),
     {
@@ -391,8 +391,8 @@ impl Span {
         self.inner.as_ref().map(Enter::id)
     }
 
-    /// Returns this span's `Meta`, if it is enabled.
-    pub fn metadata(&self) -> Option<&'static Meta<'static>> {
+    /// Returns this span's `Metadata`, if it is enabled.
+    pub fn metadata(&self) -> Option<&'static Metadata<'static>> {
         self.inner.as_ref().map(|inner| inner.metadata())
     }
 }
@@ -427,7 +427,7 @@ impl<'a> Event<'a> {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(interest: Interest, meta: &'a Meta<'a>, if_enabled: F) -> Self
+    pub fn new<F>(interest: Interest, meta: &'a Metadata<'a>, if_enabled: F) -> Self
     where
         F: FnOnce(&mut Self),
     {
@@ -522,8 +522,8 @@ impl<'a> Event<'a> {
         self.inner.as_ref().map(Enter::id)
     }
 
-    /// Returns this span's `Meta`, if it is enabled.
-    pub fn metadata(&self) -> Option<&'a Meta<'a>> {
+    /// Returns this span's `Metadata`, if it is enabled.
+    pub fn metadata(&self) -> Option<&'a Metadata<'a>> {
         self.inner.as_ref().map(|inner| inner.metadata())
     }
 }
@@ -556,7 +556,7 @@ impl<'a> Inner<'a> {
     }
 
     /// Returns the span's metadata.
-    fn metadata(&self) -> &'a Meta<'a> {
+    fn metadata(&self) -> &'a Metadata<'a> {
         self.meta
     }
 
@@ -585,7 +585,7 @@ impl<'a> Inner<'a> {
         self.subscriber.record_debug(&self.id, field, value)
     }
 
-    fn new(id: Id, subscriber: &Dispatch, meta: &'a Meta<'a>) -> Self {
+    fn new(id: Id, subscriber: &Dispatch, meta: &'a Metadata<'a>) -> Self {
         Self {
             id,
             subscriber: subscriber.clone(),


### PR DESCRIPTION
This branch renames some types and functions in `tokio-trace-core` and
`tokio-trace`:

+ Rename `field::Key` to `field::Field`.
+ Rename `tokio-trace::AsKey` to `tokio-trace::AsField`, and rename 
  functions whose names refer to "key"s to refer to "field"s instead.
+ Rename `field::Fields` to `FieldSet`.
+ Rename `Meta` to `Metadata`.

I've also updated some docs and comments to read better with the new 
names.

Closes: #142 
Closes: #144
Refs: #72

Signed-off-by: Eliza Weisman <eliza@buoyant.io>