### PR TITLE
Remove `Subscriber::new_static`

### DIFF
--- a/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace-core/src/dispatcher.rs
@@ -56,11 +56,6 @@ impl Subscriber for Dispatch {
     }
 
     #[inline]
-    fn new_static(&self, metadata: &'static Metadata<'static>) -> Span {
-        self.subscriber.new_static(metadata)
-    }
-
-    #[inline]
     fn new_span(&self, metadata: &Metadata) -> Span {
         self.subscriber.new_span(metadata)
     }

--- a/tokio-trace-core/src/metadata.rs
+++ b/tokio-trace-core/src/metadata.rs
@@ -41,7 +41,7 @@ pub struct Metadata<'a> {
     /// constructing new `Metadata`, use the `metadata!` macro or the
     /// `Metadata::new` constructor instead!
     #[doc(hidden)]
-    pub name: &'a str,
+    pub name: &'static str,
 
     /// The part of the system that the span that this metadata describes
     /// occurred in.
@@ -134,7 +134,7 @@ impl<'a> Metadata<'a> {
     /// Construct new metadata for a span, with a name, target, level, field
     /// names, and optional source code location.
     pub fn new(
-        name: &'a str,
+        name: &'static str,
         target: &'a str,
         level: Level,
         module_path: Option<&'a str>,
@@ -168,7 +168,7 @@ impl<'a> Metadata<'a> {
     }
 
     /// Returns the name of the span.
-    pub fn name(&self) -> &'a str {
+    pub fn name(&self) -> &'static str {
         self.name
     }
 

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -99,26 +99,6 @@ pub trait Subscriber {
         }
     }
 
-    /// Record the construction of a new [`Span`], returning a new ID
-    /// for the span being constructed.
-    ///
-    /// Unlike [`new_span`], this function is always called with span
-    /// [metadata] which are valid for the `'static` lifetime.
-    ///
-    /// This function defaults to simply calling `self.new_span()`, but if the
-    /// subscriber wishes to do something with the the known-`'static` span
-    /// metadata (such as storing a reference to them in some collection) it
-    /// may override the default implementation to do so. It may then generate a
-    /// new ID for that span, either by calling `new_span`, or through a different
-    /// method from the ID generation for events.
-    ///
-    /// [`Span`]: ::span::Span
-    /// [`new_span`]: ::subscriber::Subscriber::new_span
-    /// [metadata]: ::metadata::Metadata
-    fn new_static(&self, metadata: &'static Metadata<'static>) -> Span {
-        self.new_span(metadata)
-    }
-
     /// Record the construction of a new [`Span`], returning a new ID for the
     /// span being constructed.
     ///
@@ -408,16 +388,13 @@ mod test_support {
         Nothing,
     }
 
-    enum SpanOrEvent {
-        Span {
-            span: &'static Metadata<'static>,
-            refs: usize,
-        },
-        Event,
+    struct SpanState {
+        name: &'static str,
+        refs: usize,
     }
 
     struct Running<F: Fn(&Metadata) -> bool> {
-        spans: Mutex<HashMap<Span, SpanOrEvent>>,
+        spans: Mutex<HashMap<Span, SpanState>>,
         expected: Arc<Mutex<VecDeque<Expect>>>,
         ids: AtomicUsize,
         filter: F,
@@ -434,15 +411,6 @@ mod test_support {
         MockSubscriber {
             expected: VecDeque::new(),
             filter: (|_: &Metadata| true) as for<'r, 's> fn(&'r Metadata<'s>) -> _,
-        }
-    }
-
-    impl SpanOrEvent {
-        fn name(&self) -> &str {
-            match self {
-                SpanOrEvent::Span { span, .. } => span.name,
-                SpanOrEvent::Event => "event",
-            }
         }
     }
 
@@ -519,65 +487,46 @@ mod test_support {
             // TODO: it should be possible to expect spans to follow from other spans
         }
 
-        fn new_span(&self, _attrs: &Metadata) -> Span {
+        fn new_span(&self, meta: &Metadata) -> Span {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Span::from_u64(id as u64);
-            println!("new_span: id={:?};", id);
+            println!("new_span: name={:?}; target={:?}; id={:?};", id, meta.name(), meta.target());
             self.spans
                 .lock()
                 .unwrap()
-                .insert(id.clone(), SpanOrEvent::Event);
-            id
-        }
-
-        fn new_static(&self, span: &'static Metadata<'static>) -> Span {
-            let id = self.ids.fetch_add(1, Ordering::SeqCst);
-            let id = Span::from_u64(id as u64);
-            println!("new_static: {}; id={:?};", span.name, id);
-            self.spans
-                .lock()
-                .unwrap()
-                .insert(id.clone(), SpanOrEvent::Span { span, refs: 1 });
+                .insert(id.clone(), SpanState { name: meta.name(), refs: 1 });
             id
         }
 
         fn enter(&self, id: &Span) {
             let spans = self.spans.lock().unwrap();
-            if let Some(span_or_event) = spans.get(id) {
-                println!("enter: {}; id={:?};", span_or_event.name(), id);
-                match (span_or_event, self.expected.lock().unwrap().pop_front()) {
-                    (_, None) => {}
-                    (SpanOrEvent::Event, _) => panic!("events should never be entered!"),
-                    (SpanOrEvent::Span { span, .. }, Some(Expect::Event(_))) => panic!(
+            if let Some(span) = spans.get(id) {
+                println!("enter: {}; id={:?};", span.name, id);
+                match self.expected.lock().unwrap().pop_front() {
+                    None => {}
+                    Some(Expect::Event(_)) => panic!(
                         "expected an event, but entered span {:?} instead",
                         span.name
                     ),
-                    (SpanOrEvent::Span { span, .. }, Some(Expect::Enter(ref expected_span))) => {
+                    Some(Expect::Enter(ref expected_span)) => {
                         if let Some(name) = expected_span.name {
                             assert_eq!(name, span.name);
                         }
                         // TODO: expect fields
                     }
-                    (SpanOrEvent::Span { span, .. }, Some(Expect::Exit(ref expected_span))) => {
-                        panic!(
-                            "expected to exit {}, but entered span {:?} instead",
-                            expected_span, span.name
-                        )
-                    }
-                    (
-                        SpanOrEvent::Span { span, .. },
-                        Some(Expect::CloneSpan(ref expected_span)),
-                    ) => panic!(
+                    Some(Expect::Exit(ref expected_span)) => panic!(
+                        "expected to exit {}, but entered span {:?} instead",
+                        expected_span, span.name
+                    ),
+                    Some(Expect::CloneSpan(ref expected_span)) => panic!(
                         "expected to clone {}, but entered span {:?} instead",
                         expected_span, span.name
                     ),
-                    (SpanOrEvent::Span { span, .. }, Some(Expect::DropSpan(ref expected_span))) => {
-                        panic!(
-                            "expected to drop {}, but entered span {:?} instead",
-                            expected_span, span.name
-                        )
-                    }
-                    (SpanOrEvent::Span { span, .. }, Some(Expect::Nothing)) => panic!(
+                    Some(Expect::DropSpan(ref expected_span)) => panic!(
+                        "expected to drop {}, but entered span {:?} instead",
+                        expected_span, span.name
+                    ),
+                    Some(Expect::Nothing) => panic!(
                         "expected nothing else to happen, but entered span {:?}",
                         span.name,
                     ),
@@ -590,36 +539,35 @@ mod test_support {
             let span = spans
                 .get(id)
                 .unwrap_or_else(|| panic!("no span for ID {:?}", id));
-            println!("exit: {}; id={:?};", span.name(), id);
-            match (span, self.expected.lock().unwrap().pop_front()) {
-                (_, None) => {}
-                (SpanOrEvent::Event, _) => panic!("events should never be exited!"),
-                (SpanOrEvent::Span { span, .. }, Some(Expect::Event(_))) => {
+            println!("exit: {}; id={:?};", span.name, id);
+            match self.expected.lock().unwrap().pop_front() {
+                None => {}
+                Some(Expect::Event(_)) => {
                     panic!("expected an event, but exited span {:?} instead", span.name)
                 }
-                (SpanOrEvent::Span { span, .. }, Some(Expect::Enter(ref expected_span))) => panic!(
+                Some(Expect::Enter(ref expected_span)) => panic!(
                     "expected to enter {}, but exited span {:?} instead",
                     expected_span, span.name
                 ),
-                (SpanOrEvent::Span { span, .. }, Some(Expect::Exit(ref expected_span))) => {
+               Some(Expect::Exit(ref expected_span)) => {
                     if let Some(name) = expected_span.name {
                         assert_eq!(name, span.name);
                     }
                     // TODO: expect fields
                 }
-                (SpanOrEvent::Span { span, .. }, Some(Expect::CloneSpan(ref expected_span))) => {
+               Some(Expect::CloneSpan(ref expected_span)) => {
                     panic!(
                         "expected to clone {}, but exited span {:?} instead",
                         expected_span, span.name
                     )
                 }
-                (SpanOrEvent::Span { span, .. }, Some(Expect::DropSpan(ref expected_span))) => {
+                Some(Expect::DropSpan(ref expected_span)) => {
                     panic!(
                         "expected to drop {}, but exited span {:?} instead",
                         expected_span, span.name
                     )
                 }
-                (SpanOrEvent::Span { span, .. }, Some(Expect::Nothing)) => panic!(
+                Some(Expect::Nothing) => panic!(
                     "expected nothing else to happen, but exited span {:?}",
                     span.name,
                 ),
@@ -627,20 +575,11 @@ mod test_support {
         }
 
         fn clone_span(&self, id: &Span) -> Span {
-            let name = self.spans.lock().unwrap().get_mut(id).map(|span_or_event| {
-                if let SpanOrEvent::Span {
-                    ref span,
-                    ref mut refs,
-                } = span_or_event
-                {
-                    let name = span.name;
-                    println!("clone_span: {}; id={:?}; refs={:?};", name, id, *refs);
-                    *refs += 1;
-                    name
-                } else {
-                    println!("clone_span: event; id={:?};", id);
-                    "event"
-                }
+            let name = self.spans.lock().unwrap().get_mut(id).map(|span| {
+                let name = span.name;
+                println!("clone_span: {}; id={:?}; refs={:?};", name, id, span.refs);
+                span.refs += 1;
+                name
             });
             if name.is_none() {
                 println!("clone_span: id={:?};", id);
@@ -661,21 +600,11 @@ mod test_support {
         fn drop_span(&self, id: Span) {
             let mut is_event = false;
             let name = if let Ok(mut spans) = self.spans.try_lock() {
-                spans.get_mut(&id).map(|span_or_event| match span_or_event {
-                    SpanOrEvent::Span {
-                        ref span,
-                        ref mut refs,
-                    } => {
-                        let name = span.name;
-                        println!("drop_span: {}; id={:?}; refs={:?};", name, id, *refs);
-                        *refs -= 1;
-                        name
-                    }
-                    SpanOrEvent::Event => {
-                        println!("drop_span: event; id={:?}", id);
-                        is_event = true;
-                        "event"
-                    }
+                spans.get_mut(&id).map(|span| {
+                    let name = span.name;
+                    println!("drop_span: {}; id={:?}; refs={:?};", name, id, span.refs);
+                    span.refs -= 1;
+                    name
                 })
             } else {
                 None

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -490,7 +490,7 @@ mod test_support {
         fn new_span(&self, meta: &Metadata) -> Span {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Span::from_u64(id as u64);
-            println!("new_span: name={:?}; target={:?}; id={:?};", id, meta.name(), meta.target());
+            println!("new_span: name={:?}; target={:?}; id={:?};", meta.name(), meta.target(), id);
             self.spans
                 .lock()
                 .unwrap()
@@ -602,6 +602,9 @@ mod test_support {
             let name = if let Ok(mut spans) = self.spans.try_lock() {
                 spans.get_mut(&id).map(|span| {
                     let name = span.name;
+                    if name.contains("event") {
+                        is_event = true;
+                    }
                     println!("drop_span: {}; id={:?}; refs={:?};", name, id, span.refs);
                     span.refs -= 1;
                     name

--- a/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace-core/src/subscriber.rs
@@ -490,11 +490,19 @@ mod test_support {
         fn new_span(&self, meta: &Metadata) -> Span {
             let id = self.ids.fetch_add(1, Ordering::SeqCst);
             let id = Span::from_u64(id as u64);
-            println!("new_span: name={:?}; target={:?}; id={:?};", meta.name(), meta.target(), id);
-            self.spans
-                .lock()
-                .unwrap()
-                .insert(id.clone(), SpanState { name: meta.name(), refs: 1 });
+            println!(
+                "new_span: name={:?}; target={:?}; id={:?};",
+                meta.name(),
+                meta.target(),
+                id
+            );
+            self.spans.lock().unwrap().insert(
+                id.clone(),
+                SpanState {
+                    name: meta.name(),
+                    refs: 1,
+                },
+            );
             id
         }
 
@@ -549,24 +557,20 @@ mod test_support {
                     "expected to enter {}, but exited span {:?} instead",
                     expected_span, span.name
                 ),
-               Some(Expect::Exit(ref expected_span)) => {
+                Some(Expect::Exit(ref expected_span)) => {
                     if let Some(name) = expected_span.name {
                         assert_eq!(name, span.name);
                     }
                     // TODO: expect fields
                 }
-               Some(Expect::CloneSpan(ref expected_span)) => {
-                    panic!(
-                        "expected to clone {}, but exited span {:?} instead",
-                        expected_span, span.name
-                    )
-                }
-                Some(Expect::DropSpan(ref expected_span)) => {
-                    panic!(
-                        "expected to drop {}, but exited span {:?} instead",
-                        expected_span, span.name
-                    )
-                }
+                Some(Expect::CloneSpan(ref expected_span)) => panic!(
+                    "expected to clone {}, but exited span {:?} instead",
+                    expected_span, span.name
+                ),
+                Some(Expect::DropSpan(ref expected_span)) => panic!(
+                    "expected to drop {}, but exited span {:?} instead",
+                    expected_span, span.name
+                ),
                 Some(Expect::Nothing) => panic!(
                     "expected nothing else to happen, but exited span {:?}",
                     span.name,

--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -23,7 +23,7 @@ use tokio_trace_futures::{Instrument, Instrumented};
 
 type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
-fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
+fn echo(req: Request<Body>) -> Instrumented<'static, BoxFut> {
     span!(
         "request",
         method = &field::debug(req.method()),

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -11,7 +11,7 @@ pub mod executor;
 pub trait Instrument: Sized {
     // TODO: consider renaming to `in_span` for consistency w/
     // `in_current_span`?
-    fn instrument(self, span: Span) -> Instrumented<Self> {
+    fn instrument<'a>(self, span: Span<'a>) -> Instrumented<'a, Self> {
         Instrumented { inner: self, span }
     }
 }
@@ -29,9 +29,9 @@ pub trait WithSubscriber: Sized {
 }
 
 #[derive(Debug)]
-pub struct Instrumented<T> {
+pub struct Instrumented<'a, T> {
     inner: T,
-    span: Span,
+    span: Span<'a>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,7 +42,7 @@ pub struct WithDispatch<T> {
 
 impl<T: Sized> Instrument for T {}
 
-impl<T: Future> Future for Instrumented<T> {
+impl<'a, T: Future> Future for Instrumented<'a, T> {
     type Item = T::Item;
     type Error = T::Error;
 
@@ -61,7 +61,7 @@ impl<T: Future> Future for Instrumented<T> {
     }
 }
 
-impl<T: Stream> Stream for Instrumented<T> {
+impl<'a, T: Stream> Stream for Instrumented<'a, T> {
     type Item = T::Item;
     type Error = T::Error;
 
@@ -81,7 +81,7 @@ impl<T: Stream> Stream for Instrumented<T> {
     }
 }
 
-impl<T: Sink> Sink for Instrumented<T> {
+impl<'a, T: Sink> Sink for Instrumented<'a, T> {
     type SinkItem = T::SinkItem;
     type SinkError = T::SinkError;
 

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -329,7 +329,10 @@ impl SpanLineBuilder {
                     .module_path(self.module_path.as_ref().map(String::as_ref))
                     .file(self.file.as_ref().map(String::as_ref))
                     .line(self.line)
-                    .args(format_args!("{}{}{}{}", self.log_line, before_current, current_span, self.fields))
+                    .args(format_args!(
+                        "{}{}{}{}",
+                        self.log_line, before_current, current_span, self.fields
+                    ))
                     .build(),
             );
         }
@@ -403,7 +406,8 @@ impl Subscriber for TraceLogger {
                                 .args(format_args!(
                                     "enter {}; in={:?}; {}",
                                     span.name, current_id, current_fields
-                                )).build(),
+                                ))
+                                .build(),
                         );
                     } else {
                         logger.log(
@@ -438,7 +442,7 @@ impl Subscriber for TraceLogger {
                             .file(span.file.as_ref().map(String::as_ref))
                             .line(span.line)
                             .args(format_args!("exit {}", span.name))
-                            .build()
+                            .build(),
                     );
                 }
             }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -149,7 +149,7 @@ pub struct LogTracer {
 #[derive(Default)]
 pub struct TraceLogger {
     settings: TraceLoggerBuilder,
-    in_progress: Mutex<InProgress>,
+    in_progress: Mutex<HashMap<Id, SpanLineBuilder>>,
     current: subscriber::CurrentSpanPerThread,
 }
 
@@ -162,11 +162,6 @@ pub struct TraceLoggerBuilder {
     parent_fields: bool,
 }
 
-#[derive(Default)]
-struct InProgress {
-    spans: HashMap<Id, SpanLineBuilder>,
-    events: HashMap<Id, EventLineBuilder>,
-}
 // ===== impl LogTracer =====
 
 impl LogTracer {
@@ -208,10 +203,7 @@ impl TraceLogger {
         Self {
             settings,
             current: subscriber::CurrentSpanPerThread::new(),
-            in_progress: Mutex::new(InProgress {
-                spans: HashMap::new(),
-                events: HashMap::new(),
-            }),
+            in_progress: Mutex::new(HashMap::new()),
         }
     }
 
@@ -258,109 +250,76 @@ impl TraceLoggerBuilder {
 struct SpanLineBuilder {
     parent: Option<Id>,
     ref_count: usize,
-    meta: &'static Metadata<'static>,
     log_line: String,
     fields: String,
+    file: Option<String>,
+    line: Option<u32>,
+    module_path: Option<String>,
+    target: String,
+    level: log::Level,
+    name: String,
+    log_finish: bool,
 }
 
 impl SpanLineBuilder {
     fn new(
         parent: Option<Id>,
-        meta: &'static Metadata<'static>,
+        meta: &Metadata,
         fields: String,
         id: Id,
         settings: &TraceLoggerBuilder,
     ) -> Self {
         let mut log_line = String::new();
-        write!(&mut log_line, "{}", meta.name).expect("write to string shouldn't fail");
+        let name = meta.name();
+        let log_finish = if !name.contains("event") {
+            write!(&mut log_line, "close {}; ", name).expect("write to string shouldn't fail");
+            settings.log_span_closes
+        } else {
+            true
+        };
         if settings.log_ids {
-            write!(&mut log_line, " span={:?}; ", id).expect("write to string shouldn't fail");
+            write!(&mut log_line, "id={:?}; ", id).expect("write to string shouldn't fail");
         }
         Self {
             parent,
             ref_count: 1,
-            meta,
             log_line,
             fields,
-        }
-    }
-
-    fn record(&mut self, key: &field::Field, value: &fmt::Debug) -> fmt::Result {
-        write!(
-            &mut self.fields,
-            "{}={:?}; ",
-            key.name().unwrap_or("???"),
-            value
-        )
-    }
-
-    fn finish(self) {
-        let meta = self.meta;
-        let log_meta = meta.as_log();
-        let logger = log::logger();
-        if logger.enabled(&log_meta) {
-            logger.log(
-                &log::Record::builder()
-                    .metadata(log_meta)
-                    .target(meta.target)
-                    .module_path(meta.module_path)
-                    .file(meta.file)
-                    .line(meta.line)
-                    .args(format_args!("close {}; {}", self.log_line, self.fields))
-                    .build(),
-            );
-        }
-    }
-}
-
-struct EventLineBuilder {
-    ref_count: usize,
-    level: tokio_trace::Level,
-    file: Option<String>,
-    line: Option<u32>,
-    module_path: Option<String>,
-    target: String,
-    message: String,
-    log_line: String,
-}
-
-impl EventLineBuilder {
-    fn new(meta: &Metadata, id: Id, settings: &TraceLoggerBuilder) -> Self {
-        let mut log_line = String::new();
-        if settings.log_ids {
-            write!(&mut log_line, "event={:?}; ", id,).expect("write to string shouldn't fail");
-        }
-        Self {
-            ref_count: 1,
-            level: meta.level.clone(),
-            file: meta.file.map(|s| s.to_owned()),
-            line: meta.line,
-            module_path: meta.module_path.map(|s| s.to_owned()),
-            target: meta.target.to_owned(),
-            message: String::new(),
-            log_line,
+            file: meta.file().map(String::from),
+            line: meta.line(),
+            module_path: meta.module_path().map(String::from),
+            target: String::from(meta.target()),
+            level: meta.level().as_log(),
+            name: String::from(name),
+            log_finish,
         }
     }
 
     fn record(&mut self, key: &field::Field, value: &fmt::Debug) -> fmt::Result {
         if key.name() == Some("message") {
-            write!(&mut self.message, "{:?}", value)
+            write!(&mut self.log_line, "{:?} ", value)
         } else {
             write!(
-                &mut self.log_line,
+                &mut self.fields,
                 "{}={:?}; ",
                 key.name().unwrap_or("???"),
                 value
             )
         }
     }
+    fn log_meta(&self) -> log::Metadata {
+        log::MetadataBuilder::new()
+            .level(self.level)
+            .target(self.target.as_ref())
+            .build()
+    }
 
     fn finish(self, current_span: &str) {
+        if !self.log_finish {
+            return;
+        }
+        let log_meta = self.log_meta();
         let logger = log::logger();
-        let log_meta = log::MetadataBuilder::new()
-            .level(self.level.as_log())
-            .target(self.target.as_ref())
-            .build();
         if logger.enabled(&log_meta) {
             let before_current = if current_span != "" { "; " } else { "" };
             logger.log(
@@ -370,10 +329,7 @@ impl EventLineBuilder {
                     .module_path(self.module_path.as_ref().map(String::as_ref))
                     .file(self.file.as_ref().map(String::as_ref))
                     .line(self.line)
-                    .args(format_args!(
-                        "{}{}{}{}",
-                        self.message, before_current, current_span, self.log_line
-                    ))
+                    .args(format_args!("{}{}{}{}", self.log_line, before_current, current_span, self.fields))
                     .build(),
             );
         }
@@ -385,46 +341,30 @@ impl Subscriber for TraceLogger {
         log::logger().enabled(&metadata.as_log())
     }
 
-    fn new_static(&self, new_span: &'static Metadata<'static>) -> Id {
+    fn new_span(&self, new_span: &Metadata) -> Id {
         let id = self.next_id();
         let mut in_progress = self.in_progress.lock().unwrap();
         let mut fields = String::new();
         let parent = self.current.id();
         if self.settings.parent_fields {
             let mut next_parent = parent.as_ref();
-            while let Some(ref parent) = next_parent.and_then(|p| in_progress.spans.get(&p)) {
+            while let Some(ref parent) = next_parent.and_then(|p| in_progress.get(&p)) {
                 write!(&mut fields, "{}", parent.fields).expect("write to string cannot fail");
                 next_parent = parent.parent.as_ref();
             }
         }
-        in_progress.spans.insert(
-            id.clone(),
-            SpanLineBuilder::new(parent, new_span, fields, id.clone(), &self.settings),
-        );
-        id
-    }
-
-    fn new_span(&self, new_span: &Metadata) -> Id {
-        let id = self.next_id();
-        self.in_progress.lock().unwrap().events.insert(
-            id.clone(),
-            EventLineBuilder::new(new_span, id.clone(), &self.settings),
-        );
+        let span = SpanLineBuilder::new(parent, new_span, fields, id.clone(), &self.settings);
+        in_progress.insert(id.clone(), span);
         id
     }
 
     fn record_debug(&self, span: &Id, key: &field::Field, value: &fmt::Debug) {
         let mut in_progress = self.in_progress.lock().unwrap();
-        if let Some(span) = in_progress.spans.get_mut(span) {
+        if let Some(span) = in_progress.get_mut(span) {
             if let Err(_e) = span.record(key, value) {
                 eprintln!("error formatting span");
             }
             return;
-        }
-        if let Some(event) = in_progress.events.get_mut(span) {
-            if let Err(_e) = event.record(key, value) {
-                eprintln!("error formatting event");
-            }
         }
     }
 
@@ -442,40 +382,38 @@ impl Subscriber for TraceLogger {
         self.current.enter(id.clone());
         let in_progress = self.in_progress.lock().unwrap();
         if self.settings.log_enters {
-            if let Some(span) = in_progress.spans.get(id) {
-                let meta = span.meta;
-                let log_meta = meta.as_log();
+            if let Some(span) = in_progress.get(id) {
+                let log_meta = span.log_meta();
                 let logger = log::logger();
                 if logger.enabled(&log_meta) {
                     let current_id = self.current.id();
                     let current_fields = current_id
                         .as_ref()
-                        .and_then(|id| in_progress.spans.get(&id))
+                        .and_then(|id| in_progress.get(&id))
                         .map(|span| span.fields.as_ref())
                         .unwrap_or("");
                     if self.settings.log_ids {
                         logger.log(
                             &log::Record::builder()
                                 .metadata(log_meta)
-                                .target(meta.target)
-                                .module_path(meta.module_path)
-                                .file(meta.file)
-                                .line(meta.line)
+                                .target(span.target.as_ref())
+                                .module_path(span.module_path.as_ref().map(String::as_ref))
+                                .file(span.file.as_ref().map(String::as_ref))
+                                .line(span.line)
                                 .args(format_args!(
-                                    "enter {}; id={:?}; in={:?}; {}",
-                                    meta.name, id, current_id, current_fields
-                                ))
-                                .build(),
+                                    "enter {}; in={:?}; {}",
+                                    span.name, current_id, current_fields
+                                )).build(),
                         );
                     } else {
                         logger.log(
                             &log::Record::builder()
                                 .metadata(log_meta)
-                                .target(meta.target)
-                                .module_path(meta.module_path)
-                                .file(meta.file)
-                                .line(meta.line)
-                                .args(format_args!("enter {}; {}", meta.name, current_fields))
+                                .target(span.target.as_ref())
+                                .module_path(span.module_path.as_ref().map(String::as_ref))
+                                .file(span.file.as_ref().map(String::as_ref))
+                                .line(span.line)
+                                .args(format_args!("enter {}; {}", span.name, current_fields))
                                 .build(),
                         );
                     }
@@ -484,60 +422,47 @@ impl Subscriber for TraceLogger {
         }
     }
 
-    fn exit(&self, span: &Id) {
+    fn exit(&self, id: &Id) {
         self.current.exit();
         if self.settings.log_exits {
-            let logger = log::logger();
-            logger.log(
-                &log::Record::builder()
-                    .level(log::Level::Trace)
-                    .args(format_args!("exit: id={:?};", span))
-                    .build(),
-            );
+            let in_progress = self.in_progress.lock().unwrap();
+            if let Some(span) = in_progress.get(id) {
+                let log_meta = span.log_meta();
+                let logger = log::logger();
+                if logger.enabled(&log_meta) {
+                    logger.log(
+                        &log::Record::builder()
+                            .metadata(log_meta)
+                            .target(span.target.as_ref())
+                            .module_path(span.module_path.as_ref().map(String::as_ref))
+                            .file(span.file.as_ref().map(String::as_ref))
+                            .line(span.line)
+                            .args(format_args!("exit {}", span.name))
+                            .build()
+                    );
+                }
+            }
         }
     }
 
     fn clone_span(&self, id: &Id) -> Id {
         let mut in_progress = self.in_progress.lock().unwrap();
-        if let Some(span) = in_progress.spans.get_mut(id) {
+        if let Some(span) = in_progress.get_mut(id) {
             span.ref_count += 1;
-            return id.clone();
-        }
-
-        if let Some(event) = in_progress.events.get_mut(id) {
-            event.ref_count += 1;
         }
         id.clone()
     }
 
     fn drop_span(&self, id: Id) {
         let mut in_progress = self.in_progress.lock().unwrap();
-        if in_progress.spans.contains_key(&id) {
-            if in_progress.spans.get(&id).unwrap().ref_count == 1 {
-                let span = in_progress.spans.remove(&id).unwrap();
-                if self.settings.log_span_closes {
-                    span.finish();
-                }
+        if in_progress.contains_key(&id) {
+            if in_progress.get(&id).unwrap().ref_count == 1 {
+                let span = in_progress.remove(&id).unwrap();
+                span.finish("");
             } else {
-                in_progress.spans.get_mut(&id).unwrap().ref_count -= 1;
+                in_progress.get_mut(&id).unwrap().ref_count -= 1;
             }
             return;
-        }
-
-        if in_progress
-            .events
-            .get(&id)
-            .map(|event| event.ref_count == 1)
-            .unwrap_or(false)
-        {
-            let event = in_progress.events.remove(&id).unwrap();
-            if let Some(ref span) = self.current.id().and_then(|id| in_progress.spans.get(&id)) {
-                event.finish(&span.fields);
-            } else {
-                event.finish("");
-            }
-        } else if let Some(ref mut event) = in_progress.events.get_mut(&id) {
-            event.ref_count -= 1;
         }
     }
 }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -95,10 +95,6 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_static(&self, meta: &'static Metadata<'static>) -> Id {
-        self.registry.new_span(meta)
-    }
-
     fn new_span(&self, meta: &Metadata) -> Id {
         self.registry.new_id(meta)
     }

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -15,26 +15,26 @@ use tower_service::Service;
 use tower_util::MakeService;
 
 #[derive(Debug)]
-pub struct InstrumentedHttpService<T> {
+pub struct InstrumentedHttpService<'span, T> {
     inner: T,
-    span: tokio_trace::Span,
+    span: Span<'span>,
 }
 
-impl<T> InstrumentedHttpService<T> {
-    pub fn new(inner: T, span: tokio_trace::Span) -> Self {
+impl<'span, T> InstrumentedHttpService<'span, T> {
+    pub fn new(inner: T, span: Span<'span>) -> Self {
         Self { inner, span }
     }
 }
 
 #[derive(Debug)]
-pub struct InstrumentedMakeService<T, B> {
+pub struct InstrumentedMakeService<'span, T, B> {
     inner: T,
-    span: Span,
+    span: Span<'span>,
     _p: PhantomData<fn() -> B>,
 }
 
-impl<T, B> InstrumentedMakeService<T, B> {
-    pub fn new<Target>(inner: T, span: Span) -> Self
+impl<'span, T, B> InstrumentedMakeService<'span, T, B> {
+    pub fn new<Target>(inner: T, span: Span<'span>) -> Self
     where
         T: MakeService<Target, http::Request<B>>,
     {
@@ -46,13 +46,13 @@ impl<T, B> InstrumentedMakeService<T, B> {
     }
 }
 
-impl<T, Target, B> Service<Target> for InstrumentedMakeService<T, B>
+impl<'span, T, Target, B> Service<Target> for InstrumentedMakeService<'span, T, B>
 where
     T: MakeService<Target, http::Request<B>>,
 {
-    type Response = InstrumentedHttpService<T::Service>;
+    type Response = InstrumentedHttpService<'span, T::Service>;
     type Error = T::MakeError;
-    type Future = InstrumentedMakeServiceFuture<T::Future>;
+    type Future = InstrumentedMakeServiceFuture<'span, T::Future>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready()
@@ -65,16 +65,16 @@ where
     }
 }
 
-pub struct InstrumentedMakeServiceFuture<T> {
+pub struct InstrumentedMakeServiceFuture<'span, T> {
     inner: T,
-    span: tokio_trace::Span,
+    span: Span<'span>,
 }
 
-impl<T> Future for InstrumentedMakeServiceFuture<T>
+impl<'span, T> Future for InstrumentedMakeServiceFuture<'span, T>
 where
     T: Future,
 {
-    type Item = InstrumentedHttpService<T::Item>;
+    type Item = InstrumentedHttpService<'span, T::Item>;
     type Error = T::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let span2 = self.span.clone();
@@ -88,12 +88,12 @@ where
     }
 }
 
-impl<T, B> Service<http::Request<B>> for InstrumentedHttpService<T>
+impl<'span, T, B> Service<http::Request<B>> for InstrumentedHttpService<'span, T>
 where
     T: Service<http::Request<B>>,
 {
     type Response = T::Response;
-    type Future = Instrumented<T::Future>;
+    type Future = Instrumented<'span, T::Future>;
     type Error = T::Error;
 
     fn poll_ready(&mut self) -> futures::Poll<(), Self::Error> {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -37,12 +37,12 @@
 //! # extern crate tokio_trace;
 //! # extern crate futures;
 //! # use futures::{Future, Poll, Async};
-//! struct MyFuture {
+//! struct MyFuture<'a> {
 //!    // data
-//!    span: tokio_trace::Span,
+//!    span: tokio_trace::Span<'a>,
 //! }
 //!
-//! impl Future for MyFuture {
+//! impl<'a> Future for MyFuture<'a> {
 //!     type Item = ();
 //!     type Error = ();
 //!
@@ -774,7 +774,7 @@ mod tests {
     fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
         // Every time time this function is called, it will return a _new
         // instance_ of a span with the same metadata, name, and fields.
-        fn make_span() -> Span {
+        fn make_span() -> Span<'static>{
             span!("foo", bar = 1u64, baz = false)
         }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -160,11 +160,11 @@ use {
 /// span will silently do nothing. Thus, the handle can be used in the same
 /// manner regardless of whether or not the trace is currently being collected.
 #[derive(Clone, PartialEq, Hash)]
-pub struct Span {
+pub struct Span<'a> {
     /// A handle used to enter the span when it is not executing.
     ///
     /// If this is `None`, then the span has either closed or was never enabled.
-    inner: Option<Enter>,
+    inner: Option<Enter<'a>>,
 
     /// Set to `true` when the span closes.
     ///
@@ -193,7 +193,7 @@ pub struct Event<'a> {
     /// A handle used to enter the span when it is not executing.
     ///
     /// If this is `None`, then the span has either closed or was never enabled.
-    inner: Option<Inner<'a>>,
+    inner: Option<Enter<'a>>,
 }
 
 /// A handle representing the capacity to enter a span which is known to exist.
@@ -202,7 +202,7 @@ pub struct Event<'a> {
 /// enabled by the current filter. This type is primarily used for implementing
 /// span handles; users should typically not need to interact with it directly.
 #[derive(Debug)]
-pub(crate) struct Inner<'a> {
+pub(crate) struct Enter<'a> {
     /// The span's ID, as provided by `subscriber`.
     id: Id,
 
@@ -219,10 +219,6 @@ pub(crate) struct Inner<'a> {
     meta: &'a Metadata<'a>,
 }
 
-/// When an `Inner` corresponds to a `Span` rather than an `Event`, it can be
-/// used to enter that span.
-type Enter = Inner<'static>;
-
 /// A guard representing a span which has been entered and is currently
 /// executing.
 ///
@@ -233,13 +229,13 @@ type Enter = Inner<'static>;
 /// typically not need to interact with it directly.
 #[derive(Debug)]
 #[must_use = "once a span has been entered, it should be exited"]
-struct Entered {
-    inner: Enter,
+struct Entered<'a> {
+    inner: Enter<'a>,
 }
 
 // ===== impl Span =====
 
-impl Span {
+impl<'a> Span<'a> {
     /// Constructs a new `Span` originating from the given [`Callsite`].
     ///
     /// The new span will be constructed by the currently-active [`Subscriber`],
@@ -256,7 +252,7 @@ impl Span {
     /// [field values]: ::span::Span::record
     /// [`follows_from` annotations]: ::span::Span::follows_from
     #[inline]
-    pub fn new<F>(interest: Interest, meta: &'static Metadata<'static>, if_enabled: F) -> Span
+    pub fn new<F>(interest: Interest, meta: &'a Metadata<'a>, if_enabled: F) -> Span<'a>
     where
         F: FnOnce(&mut Span),
     {
@@ -284,7 +280,7 @@ impl Span {
     }
 
     /// Constructs a new disabled span.
-    pub fn new_disabled() -> Span {
+    pub fn new_disabled() -> Span<'a> {
         Span {
             inner: None,
             is_closed: false,
@@ -392,12 +388,12 @@ impl Span {
     }
 
     /// Returns this span's `Metadata`, if it is enabled.
-    pub fn metadata(&self) -> Option<&'static Metadata<'static>> {
+    pub fn metadata(&self) -> Option<&'a Metadata<'a>> {
         self.inner.as_ref().map(|inner| inner.metadata())
     }
 }
 
-impl fmt::Debug for Span {
+impl<'a> fmt::Debug for Span<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut span = f.debug_struct("Span");
         if let Some(ref inner) = self.inner {
@@ -440,7 +436,7 @@ impl<'a> Event<'a> {
                 return Self { inner: None };
             }
             let id = dispatch.new_span(meta);
-            let inner = Inner::new(id, dispatch, meta);
+            let inner = Enter::new(id, dispatch, meta);
             Self { inner: Some(inner) }
         });
         if !event.is_disabled() {
@@ -529,9 +525,28 @@ impl<'a> Event<'a> {
     }
 }
 
-// ===== impl Inner =====
+// ===== impl Enter =====
 
-impl<'a> Inner<'a> {
+impl<'a> Enter<'a> {
+    /// Indicates that this handle will not be reused to enter the span again.
+    ///
+    /// After calling `close`, the `Entered` guard returned by `self.enter()`
+    /// will _drop_ this handle when it is exited.
+    fn close(&mut self) {
+        self.closed = true;
+    }
+
+    /// Enters the span, returning a guard that may be used to exit the span and
+    /// re-enter the prior span.
+    ///
+    /// This is used internally to implement `Span::enter`. It may be used for
+    /// writing custom span handles, but should generally not be called directly
+    /// when entering a span.
+    fn enter(self) -> Entered<'a> {
+        self.subscriber.enter(&self.id);
+        Entered { inner: self }
+    }
+
     /// Indicates that the span with the given ID has an indirect causal
     /// relationship with this span.
     ///
@@ -596,25 +611,25 @@ impl<'a> Inner<'a> {
     }
 }
 
-impl<'a> cmp::PartialEq for Inner<'a> {
+impl<'a> cmp::PartialEq for Enter<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
 
-impl<'a> Hash for Inner<'a> {
+impl<'a> Hash for Enter<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id.hash(state);
     }
 }
 
-impl<'a> Drop for Inner<'a> {
+impl<'a> Drop for Enter<'a> {
     fn drop(&mut self) {
         self.subscriber.drop_span(self.id.clone());
     }
 }
 
-impl<'a> Clone for Inner<'a> {
+impl<'a> Clone for Enter<'a> {
     fn clone(&self) -> Self {
         Self {
             id: self.subscriber.clone_span(&self.id),
@@ -625,7 +640,7 @@ impl<'a> Clone for Inner<'a> {
     }
 }
 
-impl<'a> field::Record for Inner<'a> {
+impl<'a> field::Record for Enter<'a> {
     #[inline]
     fn record_i64<Q: ?Sized>(&mut self, field: &Q, value: i64)
     where
@@ -677,35 +692,13 @@ impl<'a> field::Record for Inner<'a> {
     }
 }
 
-// ===== impl Enter =====
-
-impl Enter {
-    /// Indicates that this handle will not be reused to enter the span again.
-    ///
-    /// After calling `close`, the `Entered` guard returned by `self.enter()`
-    /// will _drop_ this handle when it is exited.
-    fn close(&mut self) {
-        self.closed = true;
-    }
-
-    /// Enters the span, returning a guard that may be used to exit the span and
-    /// re-enter the prior span.
-    ///
-    /// This is used internally to implement `Span::enter`. It may be used for
-    /// writing custom span handles, but should generally not be called directly
-    /// when entering a span.
-    fn enter(self) -> Entered {
-        self.subscriber.enter(&self.id);
-        Entered { inner: self }
-    }
-}
-
 // ===== impl Entered =====
-impl Entered {
+
+impl<'a> Entered<'a> {
     /// Exit the `Entered` guard, returning an `Enter` handle that may be used
     /// to re-enter the span, or `None` if the span closed while performing the
     /// exit.
-    fn exit(self) -> Option<Enter> {
+    fn exit(self) -> Option<Enter<'a>> {
         self.inner.subscriber.exit(&self.inner.id);
         if self.inner.closed {
             // Dropping `inner` will allow it to perform the closure if

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -774,7 +774,7 @@ mod tests {
     fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
         // Every time time this function is called, it will return a _new
         // instance_ of a span with the same metadata, name, and fields.
-        fn make_span() -> Span<'static>{
+        fn make_span() -> Span<'static> {
             span!("foo", bar = 1u64, baz = false)
         }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -270,7 +270,7 @@ impl Span {
                     is_closed: false,
                 };
             }
-            let id = dispatch.new_static(meta);
+            let id = dispatch.new_span(meta);
             let inner = Some(Enter::new(id, dispatch, meta));
             Self {
                 inner,


### PR DESCRIPTION
This branch removes the `Subscriber::new_static` function, so that all
spans are created through the `Subscriber::new_span` function. It also
removes the restriction that all spans must have `'static` metadata.
Spans are now generic over the lifetime of their metadata.

Closes #137 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>