### PR TITLE
Reformat with 1.31.0 stable rustfmt

### DIFF
--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -29,7 +29,8 @@ fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
         method = &field::debug(req.method()),
         uri = &field::debug(req.uri()),
         headers = &field::debug(req.headers())
-    ).enter(|| {
+    )
+    .enter(|| {
         info!("received request");
         let mut response = Response::new(Body::empty());
 
@@ -137,13 +138,16 @@ fn main() {
                     http.serve_connection(sock, service_fn(echo))
                         .map_err(|e| {
                             error!({ error = field::display(e) }, "serve error");
-                        }).instrument(span),
+                        })
+                        .instrument(span),
                 );
                 Ok::<_, ::std::io::Error>(http)
-            }).map(|_| ())
+            })
+            .map(|_| ())
             .map_err(|e| {
                 error!({ error = field::display(e) }, "server error");
-            }).instrument(server_span.clone());
+            })
+            .instrument(server_span.clone());
         server_span.enter(|| {
             info!("listening...");
             hyper::rt::run(server);

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -32,7 +32,8 @@ impl<T, F> InstrumentExecutor<F> for T
 where
     T: Executor<Instrumented<F>>,
     F: Future<Item = (), Error = ()>,
-{}
+{
+}
 
 macro_rules! deinstrument_err {
     ($e:expr) => {

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -373,7 +373,8 @@ impl EventLineBuilder {
                     .args(format_args!(
                         "{}{}{}{}",
                         self.message, before_current, current_span, self.log_line
-                    )).build(),
+                    ))
+                    .build(),
             );
         }
     }
@@ -463,7 +464,8 @@ impl Subscriber for TraceLogger {
                                 .args(format_args!(
                                     "enter {}; id={:?}; in={:?}; {}",
                                     meta.name, id, current_id, current_fields
-                                )).build(),
+                                ))
+                                .build(),
                         );
                     } else {
                         logger.log(

--- a/tokio-trace-macros/src/lib.rs
+++ b/tokio-trace-macros/src/lib.rs
@@ -41,5 +41,6 @@ pub fn trace(_args: TokenStream, item: TokenStream) -> TokenStream {
                 #block
             })
         }
-    ).into()
+    )
+    .into()
 }

--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -147,17 +147,21 @@ fn main() {
                             .serve(sock)
                             .map_err(|e| {
                                 error!("error {:?}", e);
-                            }).and_then(|_| {
+                            })
+                            .and_then(|_| {
                                 debug!("response finished");
                                 future::ok(())
-                            }).instrument(conn_span2);
+                            })
+                            .instrument(conn_span2);
                         reactor.spawn(Box::new(serve));
 
                         Ok((h2, reactor))
                     })
-                }).map_err(|e| {
+                })
+                .map_err(|e| {
                     error!("serve error {:?}", e);
-                }).map(|_| {})
+                })
+                .map(|_| {})
                 .instrument(serve_span2);
 
             rt.spawn(serve);

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -113,7 +113,8 @@ where
                 version = &field::debug(request.version()),
                 uri = &field::debug(request.uri()),
                 headers = &field::debug(request.headers())
-            ).enter(move || inner.call(request).instrument(span2))
+            )
+            .enter(move || inner.call(request).instrument(span2))
         })
     }
 }

--- a/tokio-trace/examples/sloggish/sloggish_subscriber.rs
+++ b/tokio-trace/examples/sloggish/sloggish_subscriber.rs
@@ -64,7 +64,8 @@ impl fmt::Display for ColorLevel {
             Level::INFO => Color::Green.paint("INFO"),
             Level::WARN => Color::Yellow.paint("WARN "),
             Level::ERROR => Color::Red.paint("ERROR"),
-        }.fmt(f)
+        }
+        .fmt(f)
     }
 }
 
@@ -249,12 +250,14 @@ impl Subscriber for SloggishSubscriber {
                 level = ColorLevel(event.level),
                 target = &event.target,
                 message = Style::new().bold().paint(event.message),
-            ).unwrap();
+            )
+            .unwrap();
             self.print_kvs(
                 &mut stderr,
                 event.kvs.iter().map(|&(ref k, ref v)| (k, v)),
                 ", ",
-            ).unwrap();
+            )
+            .unwrap();
             write!(&mut stderr, "\n").unwrap();
         }
         // TODO: GC unneeded spans.

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -404,7 +404,8 @@ impl fmt::Debug for Span {
             span.field("id", &inner.id())
         } else {
             span.field("disabled", &true)
-        }.finish()
+        }
+        .finish()
     }
 }
 
@@ -837,7 +838,8 @@ mod tests {
             dispatcher::with_default(Dispatch::new(subscriber::mock().run()), || {
                 foo.enter(|| {});
             })
-        }).join()
+        })
+        .join()
         .unwrap();
     }
 

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -90,7 +90,8 @@ mod tests {
                     true
                 }
                 _ => false,
-            }).run_with_handle();
+            })
+            .run_with_handle();
 
         dispatcher::with_default(Dispatch::new(subscriber), move || {
             // Enter "alice" and then "bob". The dispatcher expects to see "bob" but
@@ -219,7 +220,8 @@ mod tests {
                     }
                     _ => false,
                 }
-            }).run();
+            })
+            .run();
 
         dispatcher::with_default(Dispatch::new(subscriber), move || {
             // Enter "charlie" and then "dave". The dispatcher expects to see "dave" but
@@ -277,7 +279,8 @@ mod tests {
                     true
                 }
                 _ => false,
-            }).run();
+            })
+            .run();
 
         dispatcher::with_default(Dispatch::new(subscriber), || {
             // Call the function once. The filter should be re-evaluated.


### PR DESCRIPTION
Looks like the rustfmt formatting rules on stable changed between Rust
1.30.0 and 1.31.0. This branch reformats everything with the latest 
stable.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>