### PR TITLE
Change log-like event macros to expand to ()

### DIFF
--- a/tokio-trace-tower-http/examples/tower-h2-server.rs
+++ b/tokio-trace-tower-http/examples/tower-h2-server.rs
@@ -145,9 +145,7 @@ fn main() {
 
                         let serve = h2
                             .serve(sock)
-                            .map_err(|e| {
-                                error!("error {:?}", e);
-                            })
+                            .map_err(|e| error!("error {:?}", e))
                             .and_then(|_| {
                                 debug!("response finished");
                                 future::ok(())

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -281,7 +281,7 @@ macro_rules! trace {
         event!(target: module_path!(), $crate::Level::TRACE, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::TRACE, {}, $($arg)+)
+        drop(event!(target: module_path!(), $crate::Level::TRACE, {}, $($arg)+));
     );
 }
 
@@ -291,7 +291,7 @@ macro_rules! debug {
         event!(target: module_path!(), $crate::Level::DEBUG, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::DEBUG, {}, $($arg)+)
+        drop(event!(target: module_path!(), $crate::Level::DEBUG, {}, $($arg)+));
     );
 }
 
@@ -301,7 +301,7 @@ macro_rules! info {
         event!(target: module_path!(), $crate::Level::INFO, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::INFO, {}, $($arg)+)
+        drop(event!(target: module_path!(), $crate::Level::INFO, {}, $($arg)+));
     );
 }
 
@@ -311,7 +311,7 @@ macro_rules! warn {
         event!(target: module_path!(), $crate::Level::WARN, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::WARN, {}, $($arg)+)
+        drop(event!(target: module_path!(), $crate::Level::WARN, {}, $($arg)+));
     );
 }
 
@@ -321,7 +321,7 @@ macro_rules! error {
         event!(target: module_path!(), $crate::Level::ERROR, { $($k $( = $val)* ),* }, $($arg)+)
     );
     ( $($arg:tt)+ ) => (
-        event!(target: module_path!(), $crate::Level::ERROR, {}, $($arg)+)
+        drop(event!(target: module_path!(), $crate::Level::ERROR, {}, $($arg)+));
     );
 }
 


### PR DESCRIPTION
This branch changes the "`log`-like" event macros (`error!`, `warn!`,
`info!`, `debug!`, and `trace!`, when used without fields) to expand to
an expression returning `()`, rather than an `Event`. 

This change makes it easier to use `tokio-trace` as a drop-in
replacement for the `log` crate. Since these macros previously returned
a value, they couldn't be used in cases where, for example, a value was
logged and discarded in order to make a `Future`'s `Item` or `Error`
types `()`, without changing the syntax.

For example, the following code works with `log`, but not `tokio-trace`:

```rust
fn foo() -> impl Future<Item = (), Error = ()> {
    future::lazy(...)
        // ...
        .map_err(|e| error!("error: {:?}", e))
        .map(|_| ())
}
```
Since `tokio-trace`'s macros previously returned an `event` when
used in this manner, it was necessary to change the `map_err` to:

```rust
        .map_err(|e| { error!("error: {:?}", e); })
```
otherwise, a type error occurs. When replacing the use of `log` with
`tokio-trace` in a large codebase, fixing these errors can be tedious.

Since the `log` crate does not define the syntax that `tokio-trace` uses
for setting fields `{ key = value, ... }`, this change is only necessary
for uses of the event macros that are "log-like". The primary reason to
use the event handle returned by the macros is to add values to fields
defined in the macro. In this case, no fields are defined, so it is okay
to drop the event handle immediately.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>