### PR TITLE
Add impls for tokio types to the `tokio-trace-futures` crate

### DIFF
--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -3,9 +3,14 @@ name = "tokio-trace-futures"
 version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
+[features]
+default = ["with-tokio"]
+with-tokio = ["tokio"]
+
 [dependencies]
 futures = "0.1"
 tokio-trace = { path = "../tokio-trace" }
+tokio = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1"

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -5,6 +5,12 @@ use futures::{
 use tokio_trace::Span;
 use {Instrument, Instrumented, WithDispatch};
 
+#[cfg(feature = "with-tokio")]
+use tokio::{
+    executor::{Executor as TokioExecutor, SpawnError},
+    runtime::{Runtime, TaskExecutor, current_thread},
+};
+
 pub trait InstrumentExecutor<'a, F>
 where
     Self: Executor<Instrumented<'a, F>>,
@@ -57,6 +63,153 @@ where
     }
 }
 
+#[cfg(feature = "with-tokio")]
+impl<T, N> TokioExecutor for InstrumentedExecutor<T, N>
+where
+    T: TokioExecutor,
+    N: Fn() -> Span<'static>,
+{
+    fn spawn(
+        &mut self,
+        future: Box<Future<Error = (), Item = ()> + 'static + Send>
+    ) -> Result<(), SpawnError> {
+        // TODO: get rid of double box somehow?
+        let future = Box::new(future.instrument((self.mk_span)()));
+        self.inner.spawn(future)
+    }
+}
+
+#[cfg(feature = "with-tokio")]
+impl<N> InstrumentedExecutor<Runtime, N>
+where
+    N: Fn() -> Span<'static>,
+{
+    /// Spawn an instrumented future onto the Tokio runtime.
+    ///
+    /// This spawns the given future onto the runtime's executor, usually a
+    /// thread pool. The thread pool is then responsible for polling the
+    /// future until it completes.
+    ///
+    /// This method simply wraps a call to `tokio::runtime::Runtime::spawn`,
+    /// instrumenting the spawned future beforehand.
+    pub fn spawn<F>(&mut self, future: F) -> &mut Self
+    where
+        F: Future<Item = (), Error = ()> + Send + 'static,
+    {
+        let future = future.instrument((self.mk_span)());
+        self.inner.spawn(future);
+        self
+    }
+
+    /// Run an instrumented future to completion on the Tokio runtime.
+    ///
+    /// This runs the given future on the runtime, blocking until it is
+    /// complete, and yielding its resolved result. Any tasks or timers which
+    /// the future spawns internally will be executed on the runtime.
+    ///
+    /// This method should not be called from an asynchrounous context.
+    ///
+    /// This method simply wraps a call to `tokio::runtime::Runtime::block_on`,
+    /// instrumenting the spawned future beforehand.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the executor is at capacity, if the provided
+    /// future panics, or if called within an asynchronous execution context.
+    pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
+    where
+        F: Send + 'static + Future<Item = R, Error = E>,
+        R: Send + 'static,
+        E: Send + 'static,
+    {
+        let future = future.instrument((self.mk_span)());
+        self.inner.block_on(future)
+    }
+
+    /// Return an instrumented handle to the runtime's executor.
+    ///
+    /// The returned handle can be used to spawn tasks that run on this runtime.
+    ///
+    /// The instrumented handle functions identically to a
+    /// `tokio::runtime::TaskExecutor`, but instruments the spawned
+    /// futures prior to spawning them.
+    pub fn executor(&self) -> InstrumentedExecutor<TaskExecutor, &N> {
+        InstrumentedExecutor {
+            inner: self.inner.executor(),
+            mk_span: &self.mk_span,
+        }
+    }
+}
+
+#[cfg(feature = "with-tokio")]
+impl<N> InstrumentedExecutor<current_thread::Runtime, N>
+where
+    N: Fn() -> Span<'static>,
+{
+    /// Spawn an instrumented future onto the single-threaded Tokio runtime.
+    ///
+    /// This method simply wraps a call to `current_thread::Runtime::spawn`,
+    /// instrumenting the spawned future beforehand.
+    pub fn spawn<F>(&mut self, future: F) -> &mut Self
+    where
+        F: Future<Item = (), Error = ()> + 'static,
+    {
+        let future = future.instrument((self.mk_span)());
+        self.inner.spawn(future);
+        self
+    }
+
+    /// Instruments and runs the provided future, blocking the current thread
+    /// until the future completes.
+    ///
+    /// This function can be used to synchronously block the current thread
+    /// until the provided `future` has resolved either successfully or with an
+    /// error. The result of the future is then returned from this function
+    /// call.
+    ///
+    /// Note that this function will **also** execute any spawned futures on the
+    /// current thread, but will **not** block until these other spawned futures
+    /// have completed. Once the function returns, any uncompleted futures
+    /// remain pending in the `Runtime` instance. These futures will not run
+    /// until `block_on` or `run` is called again.
+    ///
+    /// The caller is responsible for ensuring that other spawned futures
+    /// complete execution by calling `block_on` or `run`.
+    ///
+    /// This method simply wraps a call to `current_thread::Runtime::block_on`,
+    /// instrumenting the spawned future beforehand.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the executor is at capacity, if the provided
+    /// future panics, or if called within an asynchronous execution context.
+    pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
+    where
+        F: 'static + Future<Item = R, Error = E>,
+        R: 'static,
+        E: 'static,
+    {
+        let future = future.instrument((self.mk_span)());
+        self.inner.block_on(future)
+    }
+
+    /// Get a new instrumented handle to spawn futures on the single-threaded
+    /// Tokio runtime
+    ///
+    /// Different to the runtime itself, the handle can be sent to different
+    /// threads.
+    ///
+    /// The instrumented handle functions identically to a
+    /// `tokio::runtime::current_thread::Handle`, but instruments the spawned
+    /// futures prior to spawning them.
+    pub fn handle(&self) -> InstrumentedExecutor<current_thread::Handle, &N> {
+        InstrumentedExecutor {
+            inner: self.inner.handle(),
+            mk_span: &self.mk_span,
+        }
+    }
+}
+
 impl<T, F> Executor<F> for WithDispatch<T>
 where
     T: Executor<WithDispatch<F>>,
@@ -65,5 +218,144 @@ where
     fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
         let future = self.with_dispatch(future);
         deinstrument_err!(self.inner.execute(future))
+    }
+}
+
+#[cfg(feature = "with-tokio")]
+impl<T> TokioExecutor for WithDispatch<T>
+where
+    T: TokioExecutor,
+{
+    fn spawn(
+        &mut self,
+        future: Box<Future<Error = (), Item = ()> + 'static + Send>
+    ) -> Result<(), SpawnError> {
+        // TODO: get rid of double box?
+        let future = Box::new(self.with_dispatch(future));
+        self.inner.spawn(future)
+    }
+}
+
+#[cfg(feature = "with-tokio")]
+impl WithDispatch<Runtime> {
+    /// Spawn a future onto the Tokio runtime, in the context of this
+    /// `WithDispatch`'s trace dispatcher.
+    ///
+    /// This spawns the given future onto the runtime's executor, usually a
+    /// thread pool. The thread pool is then responsible for polling the
+    /// future until it completes.
+    ///
+    /// This method simply wraps a call to `tokio::runtime::Runtime::spawn`,
+    /// instrumenting the spawned future beforehand.
+    pub fn spawn<F>(&mut self, future: F) -> &mut Self
+    where
+        F: Future<Item = (), Error = ()> + Send + 'static,
+    {
+        let future = self.with_dispatch(future);
+        self.inner.spawn(future);
+        self
+    }
+
+    /// Run a future to completion on the Tokio runtime, in the context of this
+    /// `WithDispatch`'s trace dispatcher.
+    ///
+    /// This runs the given future on the runtime, blocking until it is
+    /// complete, and yielding its resolved result. Any tasks or timers which
+    /// the future spawns internally will be executed on the runtime.
+    ///
+    /// This method should not be called from an asynchrounous context.
+    ///
+    /// This method simply wraps a call to `tokio::runtime::Runtime::block_on`,
+    /// instrumenting the spawned future beforehand.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the executor is at capacity, if the provided
+    /// future panics, or if called within an asynchronous execution context.
+    pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
+    where
+        F: Send + 'static + Future<Item = R, Error = E>,
+        R: Send + 'static,
+        E: Send + 'static,
+    {
+        let future = self.with_dispatch(future);
+        self.inner.block_on(future)
+    }
+
+    /// Return a handle to the runtime's executor, in the context of this
+    /// `WithDispatch`'s trace dispatcher.
+    ///
+    /// The returned handle can be used to spawn tasks that run on this runtime.
+    ///
+    /// The instrumented handle functions identically to a
+    /// `tokio::runtime::TaskExecutor`, but instruments the spawned
+    /// futures prior to spawning them.
+    pub fn executor(&self) -> WithDispatch<TaskExecutor> {
+        self.with_dispatch(self.inner.executor())
+    }
+}
+
+#[cfg(feature = "with-tokio")]
+impl WithDispatch<current_thread::Runtime> {
+
+    /// Spawn a future onto the single-threaded Tokio runtime, in the context
+    /// of this `WithDispatch`'s trace dispatcher.
+    ///
+    /// This method simply wraps a call to `current_thread::Runtime::spawn`,
+    /// instrumenting the spawned future beforehand.
+    pub fn spawn<F>(&mut self, future: F) -> &mut Self
+    where
+        F: Future<Item = (), Error = ()> + 'static,
+    {
+        let future = self.with_dispatch(future);
+        self.inner.spawn(future);
+        self
+    }
+
+    /// Runs the provided future in the context of this `WithDispatch`'s trace
+    /// dispatcher, blocking the current thread until the future completes.
+    ///
+    /// This function can be used to synchronously block the current thread
+    /// until the provided `future` has resolved either successfully or with an
+    /// error. The result of the future is then returned from this function
+    /// call.
+    ///
+    /// Note that this function will **also** execute any spawned futures on the
+    /// current thread, but will **not** block until these other spawned futures
+    /// have completed. Once the function returns, any uncompleted futures
+    /// remain pending in the `Runtime` instance. These futures will not run
+    /// until `block_on` or `run` is called again.
+    ///
+    /// The caller is responsible for ensuring that other spawned futures
+    /// complete execution by calling `block_on` or `run`.
+    ///
+    /// This method simply wraps a call to `current_thread::Runtime::block_on`,
+    /// instrumenting the spawned future beforehand.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the executor is at capacity, if the provided
+    /// future panics, or if called within an asynchronous execution context.
+    pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
+    where
+        F: 'static + Future<Item = R, Error = E>,
+        R: 'static,
+        E: 'static,
+    {
+        let future = self.with_dispatch(future);
+        self.inner.block_on(future)
+    }
+
+    /// Get a new handle to spawn futures on the single-threaded Tokio runtime,
+    /// in the context of this `WithDispatch`'s trace dispatcher.\
+    ///
+    /// Different to the runtime itself, the handle can be sent to different
+    /// threads.
+    ///
+    /// The instrumented handle functions identically to a
+    /// `tokio::runtime::current_thread::Handle`, but the spawned
+    /// futures are run in the context of the trace dispatcher.
+    pub fn handle(&self) -> WithDispatch<current_thread::Handle> {
+        self.with_dispatch(self.inner.handle())
     }
 }

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -8,7 +8,7 @@ use {Instrument, Instrumented, WithDispatch};
 #[cfg(feature = "with-tokio")]
 use tokio::{
     executor::{Executor as TokioExecutor, SpawnError},
-    runtime::{Runtime, TaskExecutor, current_thread},
+    runtime::{current_thread, Runtime, TaskExecutor},
 };
 
 pub trait InstrumentExecutor<'a, F>
@@ -71,7 +71,7 @@ where
 {
     fn spawn(
         &mut self,
-        future: Box<Future<Error = (), Item = ()> + 'static + Send>
+        future: Box<Future<Error = (), Item = ()> + 'static + Send>,
     ) -> Result<(), SpawnError> {
         // TODO: get rid of double box somehow?
         let future = Box::new(future.instrument((self.mk_span)()));
@@ -228,7 +228,7 @@ where
 {
     fn spawn(
         &mut self,
-        future: Box<Future<Error = (), Item = ()> + 'static + Send>
+        future: Box<Future<Error = (), Item = ()> + 'static + Send>,
     ) -> Result<(), SpawnError> {
         // TODO: get rid of double box?
         let future = Box::new(self.with_dispatch(future));
@@ -297,7 +297,6 @@ impl WithDispatch<Runtime> {
 
 #[cfg(feature = "with-tokio")]
 impl WithDispatch<current_thread::Runtime> {
-
     /// Spawn a future onto the single-threaded Tokio runtime, in the context
     /// of this `WithDispatch`'s trace dispatcher.
     ///

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate futures;
-#[cfg_attr(test, macro_use)]
-extern crate tokio_trace;
 #[cfg(feature = "with-tokio")]
 extern crate tokio;
+#[cfg_attr(test, macro_use)]
+extern crate tokio_trace;
 
 use futures::{Async, Future, Poll, Sink, StartSend, Stream};
 use tokio_trace::{dispatcher, Dispatch, Span, Subscriber};

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate futures;
 #[cfg_attr(test, macro_use)]
 extern crate tokio_trace;
+#[cfg(feature = "with-tokio")]
+extern crate tokio;
 
 use futures::{Async, Future, Poll, Sink, StartSend, Stream};
 use tokio_trace::{dispatcher, Dispatch, Span, Subscriber};


### PR DESCRIPTION
Currently, the `tokio-trace-futures` crate has types which wrap values
implementing the `futures::Executor` trait. Although `tokio` provides
executors implementing this trait, it also has its own `Executor` trait,
and provides runtime types with other functions which also spawn or run
futures, such as `block_on`. The `InstrumentedExecutor` and
`WithDispatch` types currently do not implement `tokio`'s `Executor`
trait or other useful functions, so a wrapped tokio `Runtime` or
`Executor` may only be interacted with through its `futures::Executor`
implementation.

This branch adds new impls for `WithDispatch` and
`InstrumentedExecutor` for `tokio`'s `Executor` trait and runtime types.
Commonly-used functions on `tokio`'s `Runtime` and
`current_thread::Runtime` (`block_on`, `spawn`, and `handle`/`executor`)
are also exposed, and these proxy functions also instrument the spawned
or blocked on future. The `handle` and `executor` functions create new
handles which propagate the instrumentation as well.

These features, and the `tokio` dependency, are enabled by a new
`with-tokio` feature flag, which is on by default. Users who wish to use
`tokio-trace-futures` without `tokio` may disable this feature.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>