### PR TITLE
Remove closures from Span and Event constructors

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -43,10 +43,7 @@ use tokio_trace::{
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let meta = record.as_trace();
     let k = meta.fields().field_named(&"message").unwrap();
-    let mut event = tokio_trace::Event::new(
-        subscriber::Interest::SOMETIMES,
-        &meta,
-    );
+    let mut event = tokio_trace::Event::new(subscriber::Interest::SOMETIMES, &meta);
     if !event.is_disabled() {
         event.message(&k, record.args().clone());
     }

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -43,13 +43,14 @@ use tokio_trace::{
 pub fn format_trace(record: &log::Record) -> io::Result<()> {
     let meta = record.as_trace();
     let k = meta.fields().field_named(&"message").unwrap();
-    drop(tokio_trace::Event::new(
+    let mut event = tokio_trace::Event::new(
         subscriber::Interest::SOMETIMES,
         &meta,
-        |event| {
-            event.message(&k, record.args().clone());
-        },
-    ));
+    );
+    if !event.is_disabled() {
+        event.message(&k, record.args().clone());
+    }
+    drop(event);
     Ok(())
 }
 


### PR DESCRIPTION
Currently, the `Span::new` and `Event::new` constructors take closures
which are executed if the span or event is enabled. These closures are
used by the `span!` and `event!` macros to add fields to the span.

However, while replacing uses of the `log` crate in Linkerd 2's proxy
with `tokio-trace`, I noticed that the use of closures here causes some
borrow checker errors with macro invocations which work under the log
crate. When a format argument passed to a macro invocation is later
borrowed mutably in the same scope, the compiler produces errors like
this one:
```
error[E0502]: cannot borrow `self` as immutable because `self.state.0` is also borrowed as mutable
   --> src/app/profiles.rs:188:25
    |
181 |                 State::Waiting(ref mut f) => match f.poll() {
    |                                --------- mutable borrow occurs here
...
188 |                         warn!("error fetching profile for {}: {:?}", self.dst, e);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----^^^^^^^^^
    |                         |                                            |
    |                         |                                            borrow occurs due to use of `self` in closure
    |                         immutable borrow occurs here
...
203 |             };
    |             - mutable borrow ends here
    |
    = note: this error originates in a macro outside of the current crate (in
    Nightly builds, run with -Z external-macro-backtrace for more info)
```

Due to the use of the closure, `tokio-trace` must create a longer borrow
than the `log` crate, which simply calls a function on the arguments
(`fmt_args`), allowing the borrow to be released immediately.

I realised that the use of closures here was not strictly necessary, and
the same behaviour (not formatting expensive arguments when the span is
disabled) could be implemented just by using the `{Span,
Event}::is_disabled` method. Therefore, I've removed them, resolving the
borrow errors in `linkerd2-proxy`.

Signed-off-by: Eliza Weisman <eliza@Buoyant.io>