### PR TITLE
Support Event macro invocations without a message

### DIFF
--- a/tokio-trace/examples/basic.rs
+++ b/tokio-trace/examples/basic.rs
@@ -12,8 +12,9 @@ fn main() {
         .finish();
 
     tokio_trace::dispatcher::with_default(tokio_trace::Dispatch::new(subscriber), || {
-        let foo = 3;
-        trace!({ foo = foo, bar = "bar" }, "hello! I'm gonna shave a yak.");
+        let number_of_yaks = 3;
+        info!(yaks_to_shave = number_of_yaks);
+        info!({ yak = number_of_yaks, excitement = "yay!" }, "hello! I'm gonna shave a yak.");
 
         let mut span = span!("my_great_span", foo = &4, baz = &5);
         span.enter(|| {

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -269,6 +269,34 @@ macro_rules! event {
             event
         }
     });
+    (target: $target:expr, $lvl:expr, { $( $k:ident $( = $val:expr )* ),* } ) => ({
+        {
+            #[allow(unused_imports)]
+            use $crate::{callsite, Id, Subscriber, Event, field::{Value, AsField}};
+            use $crate::callsite::Callsite;
+            let callsite = callsite! { event:
+                $lvl,
+                target:
+                $target, $( $k ),*
+            };
+            let mut event = Event::new(callsite.interest(), callsite.metadata());
+            // Depending on how many fields are generated, this may or may
+            // not actually be used, but it doesn't make sense to repeat it.
+            #[allow(unused_variables, unused_mut)] {
+                if !event.is_disabled() {
+                    let mut keys = callsite.metadata().fields().into_iter();
+                    let msg_key = keys.next()
+                        .expect("event metadata should define a key for the message");
+                    $(
+                        let key = keys.next()
+                            .expect(concat!("metadata should define a key for '", stringify!($k), "'"));
+                        event!(@ record: event, $k, &key, $($val)*);
+                    )*
+                }
+            }
+            event
+        }
+    });
     ( $lvl:expr, { $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $lvl, { $($k $( = $val)* ),* }, $($arg)+)
     );
@@ -288,6 +316,9 @@ macro_rules! trace {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::TRACE, { $($k $( = $val)* ),* }, $($arg)+)
     );
+    ($( $k:ident $( = $val:expr )* ),* ) => (
+        event!(target: module_path!(), $crate::Level::TRACE, { $($k $( = $val)* ),* })
+    );
     ( $($arg:tt)+ ) => (
         drop(event!(target: module_path!(), $crate::Level::TRACE, {}, $($arg)+));
     );
@@ -297,6 +328,9 @@ macro_rules! trace {
 macro_rules! debug {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::DEBUG, { $($k $( = $val)* ),* }, $($arg)+)
+    );
+    ($( $k:ident $( = $val:expr )* ),* ) => (
+        event!(target: module_path!(), $crate::Level::DEBUG, { $($k $( = $val)* ),* })
     );
     ( $($arg:tt)+ ) => (
         drop(event!(target: module_path!(), $crate::Level::DEBUG, {}, $($arg)+));
@@ -308,6 +342,9 @@ macro_rules! info {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::INFO, { $($k $( = $val)* ),* }, $($arg)+)
     );
+    ($( $k:ident $( = $val:expr )* ),* ) => (
+        event!(target: module_path!(), $crate::Level::INFO, { $($k $( = $val)* ),* })
+    );
     ( $($arg:tt)+ ) => (
         drop(event!(target: module_path!(), $crate::Level::INFO, {}, $($arg)+));
     );
@@ -318,6 +355,9 @@ macro_rules! warn {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::WARN, { $($k $( = $val)* ),* }, $($arg)+)
     );
+    ($( $k:ident $( = $val:expr )* ),* ) => (
+        event!(target: module_path!(), $crate::Level::WARN, { $($k $( = $val)* ),* })
+    );
     ( $($arg:tt)+ ) => (
         drop(event!(target: module_path!(), $crate::Level::WARN, {}, $($arg)+));
     );
@@ -327,6 +367,9 @@ macro_rules! warn {
 macro_rules! error {
     ({ $( $k:ident $( = $val:expr )* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::ERROR, { $($k $( = $val)* ),* }, $($arg)+)
+    );
+    ($( $k:ident $( = $val:expr )* ),* ) => (
+        event!(target: module_path!(), $crate::Level::ERROR, { $($k $( = $val)* ),* })
     );
     ( $($arg:tt)+ ) => (
         drop(event!(target: module_path!(), $crate::Level::ERROR, {}, $($arg)+));


### PR DESCRIPTION
This changes resolves #166. This is accomplished in a subpar manner, as I’m duplicating code within the event macro.